### PR TITLE
Should there be a higher level API?

### DIFF
--- a/src/Dialects.jl
+++ b/src/Dialects.jl
@@ -9,13 +9,13 @@ for (f, t) in Iterators.product(
     (:i, :f),
 )
     fname = Symbol(f, t)
-    @eval function $fname(context, operands, type=IR.get_type(first(operands)); loc=Location(context))
+    @eval function $fname(operands, type=IR.get_type(first(operands)); loc=Location())
         IR.create_operation($(string("arith.", fname)), loc; operands, results=[type])
     end
 end
 
 for fname in (:xori, :andi, :ori)
-    @eval function $fname(context, operands, type=IR.get_type(first(operands)); loc=Location(context))
+    @eval function $fname(operands, type=IR.get_type(first(operands)); loc=Location())
         IR.create_operation($(string("arith.", fname)), loc; operands, results=[type])
     end
 end
@@ -25,37 +25,37 @@ for (f, t) in Iterators.product(
     (:si, :ui, :f),
 )
     fname = Symbol(f, t)
-    @eval function $fname(context, operands, type=IR.get_type(first(operands)); loc=Location(context))
+    @eval function $fname(operands, type=IR.get_type(first(operands)); loc=Location())
         IR.create_operation($(string("arith.", fname)), loc; operands, results=[type])
     end
 end
 
 # https://mlir.llvm.org/docs/Dialects/ArithOps/#arithindex_cast-mlirarithindexcastop
 for f in (:index_cast, :index_castui)
-    @eval function $f(context, operand; loc=Location(context))
+    @eval function $f(operand; loc=Location())
         IR.create_operation(
             $(string("arith.", f)),
             loc;
             operands=[operand],
-            results=[IR.IndexType(context)],
+            results=[IR.IndexType()],
         )
     end
 end
 
 # https://mlir.llvm.org/docs/Dialects/ArithOps/#arithextf-mlirarithextfop
-function extf(context, operand, type; loc=Location(context))
+function extf(operand, type; loc=Location())
     IR.create_operation("arith.exf", loc; operands=[operand], results=[type])
 end
 
 # https://mlir.llvm.org/docs/Dialects/ArithOps/#arithconstant-mlirarithconstantop
-function constant(context, value, type=MLIRType(context, typeof(value)); loc=Location(context))
+function constant(value, type=MLIRType(typeof(value)); loc=Location())
     IR.create_operation(
       "arith.constant",
       loc;
       results=[type],
       attributes=[
-          IR.NamedAttribute(context, "value",
-              Attribute(context, value, type)),
+          IR.NamedAttribute("value",
+              Attribute(value, type)),
       ],
     )
 end
@@ -73,15 +73,15 @@ module Predicates
     const uge = 9
 end
 
-function cmpi(context, predicate, operands; loc=Location(context))
+function cmpi(predicate, operands; loc=Location())
     IR.create_operation(
         "arith.cmpi",
         loc;
         operands,
-        results=[MLIRType(context, Bool)],
+        results=[MLIRType(Bool)],
         attributes=[
-            IR.NamedAttribute(context, "predicate",
-                Attribute(context, predicate))
+            IR.NamedAttribute("predicate",
+                Attribute(predicate))
         ],
     )
 end
@@ -93,20 +93,20 @@ module std
 
 using ...IR
 
-function return_(context, operands; loc=Location(context))
+function return_(operands; loc=Location())
     IR.create_operation("std.return", loc; operands, result_inference=false)
 end
 
-function br(context, dest, operands; loc=Location(context))
+function br(dest, operands; loc=Location())
     IR.create_operation("std.br", loc; operands, successors=[dest], result_inference=false)
 end
 
 function cond_br(
-    context, cond,
+    cond,
     true_dest, false_dest,
     true_dest_operands,
     false_dest_operands;
-    loc=Location(context),
+    loc=Location(),
 )
     IR.create_operation(
         "std.cond_br",
@@ -114,8 +114,8 @@ function cond_br(
         successors=[true_dest, false_dest],
         operands=[cond, true_dest_operands..., false_dest_operands...],
         attributes=[
-            IR.NamedAttribute(context, "operand_segment_sizes",
-                IR.Attribute(context, Int32[1, length(true_dest_operands), length(false_dest_operands)]))
+            IR.NamedAttribute("operand_segment_sizes",
+                IR.Attribute(Int32[1, length(true_dest_operands), length(false_dest_operands)]))
         ],
         result_inference=false,
     )
@@ -128,7 +128,7 @@ module func
 
 using ...IR
 
-function return_(context, operands; loc=Location(context))
+function return_(operands; loc=Location())
     IR.create_operation("func.return", loc; operands, result_inference=false)
 end
 
@@ -138,24 +138,24 @@ module cf
 
 using ...IR
 
-function br(context, dest, operands; loc=Location(context))
+function br(dest, operands; loc=Location())
     IR.create_operation("cf.br", loc; operands, successors=[dest], result_inference=false)
 end
 
 function cond_br(
-    context, cond,
+    cond,
     true_dest, false_dest,
     true_dest_operands,
     false_dest_operands;
-    loc=Location(context),
+    loc=Location(),
 )
     IR.create_operation(
         "cf.cond_br", loc; 
         operands=[cond, true_dest_operands..., false_dest_operands...],
         successors=[true_dest, false_dest],
         attributes=[
-            IR.NamedAttribute(context, "operand_segment_sizes",
-                IR.Attribute(context, Int32[1, length(true_dest_operands), length(false_dest_operands)]))
+            IR.NamedAttribute("operand_segment_sizes",
+                IR.Attribute(Int32[1, length(true_dest_operands), length(false_dest_operands)]))
         ],
         result_inference=false,
     )

--- a/src/IR/IR.jl
+++ b/src/IR/IR.jl
@@ -1,7 +1,3 @@
-module IR
-
-import ..API: API
-
 export
     Operation,
     OperationState,
@@ -90,38 +86,53 @@ end
 
 ### Context
 
-mutable struct Context
+struct Context
     context::MlirContext
 end
+
 function Context()
     context = API.mlirContextCreate()
     @assert !mlirIsNull(context) "cannot create Context with null MlirContext"
-    finalizer(Context(context)) do context
-        API.mlirContextDestroy(context.context)
+    context = Context(context)
+    activate(context)
+    context
+end
+
+function dispose(ctx::Context)
+    deactivate(ctx)
+    API.mlirContextDestroy(context.context)
+end
+
+function Context(f::Core.Function)
+    ctx = Context()
+    try
+        f(ctx)
+    finally
+        dispose(ctx)
     end
 end
 
 Base.convert(::Type{MlirContext}, c::Context) = c.context
 
-num_loaded_dialects(context) = API.mlirContextGetNumLoadedDialects(context)
-function get_or_load_dialect!(context, handle::DialectHandle)
-    mlir_dialect = API.mlirDialectHandleLoadDialect(handle, context)
+num_loaded_dialects() = API.mlirContextGetNumLoadedDialects(context())
+function get_or_load_dialect!(handle::DialectHandle)
+    mlir_dialect = API.mlirDialectHandleLoadDialect(handle, context())
     if mlirIsNull(mlir_dialect)
         error("could not load dialect from handle $handle")
     else
         Dialect(mlir_dialect)
     end
 end
-function get_or_load_dialect!(context, dialect::String)
-    get_or_load_dialect!(context, DialectHandle(Symbol(dialect)))
+function get_or_load_dialect!(dialect::String)
+    get_or_load_dialect!(DialectHandle(Symbol(dialect)))
 end
 
-function enable_multithreading!(context, enable=true)
-    API.mlirContextEnableMultithreading(context, enable)
-    context
+function enable_multithreading!(enable=true)
+    API.mlirContextEnableMultithreading(context(), enable)
+    context()
 end
 
-is_registered_operation(context, opname) = API.mlirContextIsRegisteredOperation(context, opname)
+is_registered_operation(opname) = API.mlirContextIsRegisteredOperation(context(), opname)
 
 ### Location
 
@@ -134,9 +145,9 @@ struct Location
     end
 end
 
-Location(context::Context) = Location(API.mlirLocationUnknownGet(context))
-Location(context::Context, filename, line, column) =
-    Location(API.mlirLocationFileLineColGet(context, filename, line, column))
+Location() = Location(API.mlirLocationUnknownGet(context()))
+Location(filename, line, column) =
+    Location(API.mlirLocationFileLineColGet(context(), filename, line, column))
 
 Base.convert(::Type{MlirLocation}, location::Location) = location.location
 
@@ -160,39 +171,39 @@ struct MLIRType
 end
 
 MLIRType(t::MLIRType) = t
-MLIRType(context::Context, T::Type{<:Signed}) =
-    MLIRType(API.mlirIntegerTypeGet(context, sizeof(T) * 8))
-MLIRType(context::Context, T::Type{<:Unsigned}) =
-    MLIRType(API.mlirIntegerTypeGet(context, sizeof(T) * 8))
-MLIRType(context::Context, ::Type{Bool}) =
-    MLIRType(API.mlirIntegerTypeGet(context, 1))
-MLIRType(context::Context, ::Type{Float32}) =
-    MLIRType(API.mlirF32TypeGet(context))
-MLIRType(context::Context, ::Type{Float64}) =
-    MLIRType(API.mlirF64TypeGet(context))
-MLIRType(context::Context, ft::Pair) =
-    MLIRType(API.mlirFunctionTypeGet(context,
+MLIRType(T::Type{<:Signed}) =
+    MLIRType(API.mlirIntegerTypeGet(context(), sizeof(T) * 8))
+MLIRType(T::Type{<:Unsigned}) =
+    MLIRType(API.mlirIntegerTypeGet(context(), sizeof(T) * 8))
+MLIRType(::Type{Bool}) =
+    MLIRType(API.mlirIntegerTypeGet(context(), 1))
+MLIRType(::Type{Float32}) =
+    MLIRType(API.mlirF32TypeGet(context()))
+MLIRType(::Type{Float64}) =
+    MLIRType(API.mlirF64TypeGet(context()))
+MLIRType(ft::Pair) =
+    MLIRType(API.mlirFunctionTypeGet(context(),
         length(ft.first), [MLIRType(t) for t in ft.first],
         length(ft.second), [MLIRType(t) for t in ft.second]))
-MLIRType(context, a::AbstractArray{T}) where {T} = MLIRType(context, MLIRType(context, T), size(a))
-MLIRType(context, ::Type{<:AbstractArray{T,N}}, dims) where {T,N} =
+MLIRType(a::AbstractArray{T}) where {T} = MLIRType(MLIRType(T), size(a))
+MLIRType(::Type{<:AbstractArray{T,N}}, dims) where {T,N} =
     MLIRType(API.mlirRankedTensorTypeGetChecked(
-        Location(context),
+        Location(),
         N, collect(dims),
-        MLIRType(context, T),
+        MLIRType(T),
         Attribute(),
     ))
-MLIRType(context, element_type::MLIRType, dims) =
+MLIRType(element_type::MLIRType, dims) =
     MLIRType(API.mlirRankedTensorTypeGetChecked(
-        Location(context),
+        Location(),
         length(dims), collect(dims),
         element_type,
         Attribute(),
     ))
-MLIRType(context, ::T) where {T<:Real} = MLIRType(context, T)
+MLIRType(::T) where {T<:Real} = MLIRType(T)
 MLIRType(_, type::MLIRType) = type
 
-IndexType(context) = MLIRType(API.mlirIndexTypeGet(context))
+IndexType() = MLIRType(API.mlirIndexTypeGet(context()))
 
 Base.convert(::Type{MlirType}, mtype::MLIRType) = mtype.type
 Base.parse(::Type{MLIRType}, context, s) =
@@ -246,10 +257,10 @@ function Base.show(io::IO, type::MLIRType)
 end
 
 function inttype(size, issigned)
-   size == 1 && issigned && return Bool
-   ints = (Int8, Int16, Int32, Int64, Int128)
-   IT = ints[Int(log2(size)) - 2]
-   issigned ? IT : unsigned(IT)
+    size == 1 && issigned && return Bool
+    ints = (Int8, Int16, Int32, Int64, Int128)
+    IT = ints[Int(log2(size))-2]
+    issigned ? IT : unsigned(IT)
 end
 
 function julia_type(type::MLIRType)
@@ -318,83 +329,83 @@ struct Attribute
 end
 
 Attribute() = Attribute(API.mlirAttributeGetNull())
-Attribute(context, s::AbstractString) = Attribute(API.mlirStringAttrGet(context, s))
+Attribute(s::AbstractString) = Attribute(API.mlirStringAttrGet(context(), s))
 Attribute(type::MLIRType) = Attribute(API.mlirTypeAttrGet(type))
-Attribute(context, f::F, type=MLIRType(context, F)) where {F<:AbstractFloat} = Attribute(
-    API.mlirFloatAttrDoubleGet(context, type, Float64(f))
+Attribute(f::F, type=MLIRType(F)) where {F<:AbstractFloat} = Attribute(
+    API.mlirFloatAttrDoubleGet(context(), type, Float64(f))
 )
-Attribute(context, i::T) where {T<:Integer} = Attribute(
-    API.mlirIntegerAttrGet(MLIRType(context, T), Int64(i))
+Attribute(i::T) where {T<:Integer} = Attribute(
+    API.mlirIntegerAttrGet(MLIRType(T), Int64(i))
 )
-function Attribute(context, values::T) where {T<:AbstractArray{Int32}}
-    type = MLIRType(context, T, size(values))
+function Attribute(values::T) where {T<:AbstractArray{Int32}}
+    type = MLIRType(T, size(values))
     Attribute(
         API.mlirDenseElementsAttrInt32Get(type, length(values), values)
     )
 end
-function Attribute(context, values::T) where {T<:AbstractArray{Int64}}
-    type = MLIRType(context, T, size(values))
+function Attribute(values::T) where {T<:AbstractArray{Int64}}
+    type = MLIRType(T, size(values))
     Attribute(
         API.mlirDenseElementsAttrInt64Get(type, length(values), values)
     )
 end
-function Attribute(context, values::T) where {T<:AbstractArray{Float64}}
-    type = MLIRType(context, T, size(values))
+function Attribute(values::T) where {T<:AbstractArray{Float64}}
+    type = MLIRType(T, size(values))
     Attribute(
         API.mlirDenseElementsAttrDoubleGet(type, length(values), values)
     )
 end
-function Attribute(context, values::T) where {T<:AbstractArray{Float32}}
-    type = MLIRType(context, T, size(values))
+function Attribute(values::T) where {T<:AbstractArray{Float32}}
+    type = MLIRType(T, size(values))
     Attribute(
         API.mlirDenseElementsAttrFloatGet(type, length(values), values)
     )
 end
-function Attribute(context, values::AbstractArray{Int32}, type)
+function Attribute(values::AbstractArray{Int32}, type)
     Attribute(
         API.mlirDenseElementsAttrInt32Get(type, length(values), values)
     )
 end
-function Attribute(context, values::AbstractArray{Int}, type)
+function Attribute(values::AbstractArray{Int}, type)
     Attribute(
         API.mlirDenseElementsAttrInt64Get(type, length(values), values)
     )
 end
-function Attribute(context, values::AbstractArray{Float32}, type)
+function Attribute(values::AbstractArray{Float32}, type)
     Attribute(
         API.mlirDenseElementsAttrFloatGet(type, length(values), values)
     )
 end
-function ArrayAttribute(context, values::AbstractVector{Int})
-    elements = Attribute.((context,), values)
+function ArrayAttribute(values::AbstractVector{Int})
+    elements = Attribute.((context(),), values)
     Attribute(
-        API.mlirArrayAttrGet(context, length(elements), elements)
+        API.mlirArrayAttrGet(context(), length(elements), elements)
     )
 end
-function ArrayAttribute(context, attributes::Vector{Attribute})
+function ArrayAttribute(attributes::Vector{Attribute})
     Attribute(
-        API.mlirArrayAttrGet(context, length(attributes), attributes),
+        API.mlirArrayAttrGet(context(), length(attributes), attributes),
     )
 end
-function DenseArrayAttribute(context, values::AbstractVector{Int})
+function DenseArrayAttribute(values::AbstractVector{Int})
     Attribute(
-        API.mlirDenseI64ArrayGet(context, length(values), collect(values))
+        API.mlirDenseI64ArrayGet(context(), length(values), collect(values))
     )
 end
-function Attribute(context, value::Int, type::MLIRType)
+function Attribute(value::Int, type::MLIRType)
     Attribute(
         API.mlirIntegerAttrGet(type, value)
     )
 end
-function Attribute(context, value::Bool, ::MLIRType=nothing)
+function Attribute(value::Bool, ::MLIRType=nothing)
     Attribute(
-        API.mlirBoolAttrGet(context, value)
+        API.mlirBoolAttrGet(context(), value)
     )
 end
 
 Base.convert(::Type{MlirAttribute}, attribute::Attribute) = attribute.attribute
-Base.parse(::Type{Attribute}, context, s) =
-    Attribute(API.mlirAttributeParseGet(context, s))
+Base.parse(::Type{Attribute}, s) =
+    Attribute(API.mlirAttributeParseGet(context(), s))
 
 function get_type(attribute::Attribute)
     MLIRType(API.mlirAttributeGetType(attribute))
@@ -426,10 +437,10 @@ struct NamedAttribute
     named_attribute::MlirNamedAttribute
 end
 
-function NamedAttribute(context, name, attribute)
+function NamedAttribute(name, attribute)
     @assert !mlirIsNull(attribute.attribute)
     NamedAttribute(API.mlirNamedAttributeGet(
-        API.mlirIdentifierGet(context, name),
+        API.mlirIdentifierGet(context(), name),
         attribute
     ))
 end
@@ -510,7 +521,7 @@ function create_operation(
     owned_regions=nothing,
     successors=nothing,
     attributes=nothing,
-    result_inference=isnothing(results),
+    result_inference=isnothing(results)
 )
     GC.@preserve name loc begin
         state = Ref(API.mlirOperationStateGet(name, loc))
@@ -534,9 +545,9 @@ function create_operation(
             GC.@preserve successors begin
                 mlir_blocks = Base.unsafe_convert.(MlirBlock, successors)
                 API.mlirOperationStateAddSuccessors(
-                  state,
-                  length(mlir_blocks),
-                  mlir_blocks,
+                    state,
+                    length(mlir_blocks),
+                    mlir_blocks,
                 )
             end
         end
@@ -761,22 +772,21 @@ Base.unsafe_convert(::Type{MlirRegion}, region::Region) = region.region
 
 mutable struct MModule
     module_::MlirModule
-    context::Context
 
-    MModule(module_, context) = begin
+    MModule(module_) = begin
         @assert !mlirIsNull(module_) "cannot create MModule with null MlirModule"
-        finalizer(API.mlirModuleDestroy, new(module_, context))
+        finalizer(API.mlirModuleDestroy, new(module_))
     end
 end
 
-MModule(context::Context, loc=Location(context)) =
-    MModule(API.mlirModuleCreateEmpty(loc), context)
+MModule(loc::Location=Location()) =
+    MModule(API.mlirModuleCreateEmpty(loc))
 get_operation(module_) = Operation(API.mlirModuleGetOperation(module_), false)
 get_body(module_) = Block(API.mlirModuleGetBody(module_), false)
 get_first_child_op(mod::MModule) = get_first_child_op(get_operation(mod))
 
 Base.convert(::Type{MlirModule}, module_::MModule) = module_.module_
-Base.parse(::Type{MModule}, context, module_) = MModule(API.mlirModuleCreateParse(context, module_), context)
+Base.parse(::Type{MModule}, module_) = MModule(API.mlirModuleCreateParse(context(), module_), context())
 
 macro mlir_str(code)
     quote
@@ -801,30 +811,29 @@ Base.convert(::Type{API.MlirTypeID}, typeid::TypeID) = typeid.typeid
 
 @static if isdefined(API, :MlirTypeIDAllocator)
 
-### TypeIDAllocator
+    ### TypeIDAllocator
 
-mutable struct TypeIDAllocator
-    allocator::API.MlirTypeIDAllocator
+    mutable struct TypeIDAllocator
+        allocator::API.MlirTypeIDAllocator
 
-    function TypeIDAllocator()
-        ptr = API.mlirTypeIDAllocatorCreate()
-        @assert ptr != C_NULL "cannot create TypeIDAllocator"
-        finalizer(API.mlirTypeIDAllocatorDestroy, new(ptr))
+        function TypeIDAllocator()
+            ptr = API.mlirTypeIDAllocatorCreate()
+            @assert ptr != C_NULL "cannot create TypeIDAllocator"
+            finalizer(API.mlirTypeIDAllocatorDestroy, new(ptr))
+        end
     end
-end
 
-Base.cconvert(::Type{API.MlirTypeIDAllocator}, allocator::TypeIDAllocator) = allocator
-Base.unsafe_convert(::Type{API.MlirTypeIDAllocator}, allocator) = allocator.allocator
+    Base.cconvert(::Type{API.MlirTypeIDAllocator}, allocator::TypeIDAllocator) = allocator
+    Base.unsafe_convert(::Type{API.MlirTypeIDAllocator}, allocator) = allocator.allocator
 
-TypeID(allocator::TypeIDAllocator) = TypeID(API.mlirTypeIDCreate(allocator))
+    TypeID(allocator::TypeIDAllocator) = TypeID(API.mlirTypeIDCreate(allocator))
 
 else
 
-struct TypeIDAllocator end
+    struct TypeIDAllocator end
 
 end
 
 include("./Support.jl")
 include("./Pass.jl")
 
-end # module IR

--- a/src/IR/state.jl
+++ b/src/IR/state.jl
@@ -1,0 +1,43 @@
+# Global state
+
+# to simplify the API, we maintain a stack of contexts in task local storage
+# and pass them implicitly to MLIR API's that require them.
+
+export context, activate, deactivate, context!
+
+using ..IR
+
+_has_context() = haskey(task_local_storage(), :MLIRContext) &&
+                 !isempty(task_local_storage(:MLIRContext))
+
+function context(; throw_error::Core.Bool=true)
+    if !_has_context()
+        throw_error && error("No MLIR context is active")
+        return nothing
+    end
+    last(task_local_storage(:MLIRContext))
+end
+
+function activate(ctx::Context)
+    stack = get!(task_local_storage(), :MLIRContext) do
+        Context[]
+    end
+    push!(stack, ctx)
+    return
+end
+
+function deactivate(ctx::Context)
+    context() == ctx || error("Deactivating wrong context")
+    pop!(task_local_storage(:MLIRContext))
+end
+
+function context!(f, ctx::Context)
+    activate(ctx)
+    try
+        f()
+    finally
+        deactivate(ctx)
+    end
+end
+
+

--- a/src/MLIR.jl
+++ b/src/MLIR.jl
@@ -42,6 +42,7 @@ module IR
     include("./IR/state.jl")
 end # module IR
 
+include("./highlevel.jl")
 include("./Dialects.jl")
 
 

--- a/src/MLIR.jl
+++ b/src/MLIR.jl
@@ -35,7 +35,14 @@ function Base.unsafe_convert(::Type{API.MlirStringRef}, s::Union{Symbol, String,
     return API.MlirStringRef(p, length(s))
 end
 
-include("./IR/IR.jl")
+module IR
+    import ..API: API
+
+    include("./IR/IR.jl")
+    include("./IR/state.jl")
+end # module IR
+
 include("./Dialects.jl")
+
 
 end # module MLIR

--- a/src/highlevel.jl
+++ b/src/highlevel.jl
@@ -1,0 +1,144 @@
+module Builder
+
+export @Block, @Region
+
+using ...IR
+
+ctx = IR.Context()
+loc = IR.Location()
+
+struct BlockBuilder
+    block::IR.Block
+    expr::Expr
+end
+_has_blockbuilder() = haskey(task_local_storage(), :BlockBuilder) &&
+                      !isempty(task_local_storage(:BlockBuilder))
+
+function blockbuilder()
+    if !_has_blockbuilder()
+        error("No BlockBuilder is active")
+        return nothing
+    end
+    last(task_local_storage(:BlockBuilder))
+end
+function activate(b::BlockBuilder)
+    stack = get!(task_local_storage(), :BlockBuilder) do
+        BlockBuilder[]
+    end
+    push!(stack, b)
+end
+function deactivate(b::BlockBuilder)
+    blockbuilder() == b || error("Deactivating wrong RegionBuilder")
+    pop!(task_local_storage(:BlockBuilder))
+end
+
+struct RegionBuilder
+    region::IR.Region
+    blockbuilders::Vector{BlockBuilder}
+end
+_has_regionbuilder() = haskey(task_local_storage(), :RegionBuilder) &&
+                       !isempty(task_local_storage(:RegionBuilder))
+function regionbuilder()
+    if !_has_regionbuilder()
+        error("No RegionBuilder is active")
+        return nothing
+    end
+    last(task_local_storage(:RegionBuilder))
+end
+function activate(r::RegionBuilder)
+    stack = get!(task_local_storage(), :RegionBuilder) do
+        RegionBuilder[]
+    end
+    push!(stack, r)
+end
+function deactivate(r::RegionBuilder)
+    regionbuilder() == r || error("Deactivating wrong RegionBuilder")
+    pop!(task_local_storage(:RegionBuilder))
+end
+
+function Region(expr)
+    exprs = Expr[]
+
+    #= Create region =#
+    region = IR.Region()
+    #= Push region on the stack =#
+    regionbuilder = RegionBuilder(region, BlockBuilder[])
+    activate(regionbuilder)
+    #=
+    `expr` calls to @block.
+    These calls will create the block variables that
+    are referenced in control flow operations.
+    Blocks are added to the region at the top of the
+    stack and a queue of blocks is kept. The
+    expressions to generate the operations in each
+    block can't be executed yet since they can't
+    reference the blocks before their creation.
+    =#
+    push!(exprs, expr)
+    #=
+    Once the blocks are created, the operation
+    code can be run. This happens in order. All the
+    operations are pushed to the block at the front
+    of the queue
+    =#
+    push!(exprs, quote
+        for blockbuilder in $regionbuilder.blockbuilders
+            $activate(blockbuilder)
+            eval(blockbuilder.expr)
+            $deactivate(blockbuilder)
+        end
+    end)
+
+    push!(exprs, quote
+        $deactivate($regionbuilder)
+        $region
+    end)
+
+    return Expr(:block, exprs...)
+end
+macro Region(expr)
+    quote
+        $(esc(Region(expr)))
+    end
+end
+
+function Block(expr)
+    block = IR.Block()
+    blockbuilder = BlockBuilder(block, expr)
+
+    if (_has_regionbuilder())
+        #= Add block to current region =#
+        push!(regionbuilder().region, block)
+        #=
+        Add blockbuilder to the queue to come back later to
+        generate its operations.
+        =#
+        push!(regionbuilder().blockbuilders, blockbuilder)
+
+        #=
+        Only return the block, don't create the
+        operations yet.
+        =#
+        return quote
+            $block
+        end
+    else
+        #=
+        If there's no regionbuilder, the operations
+        defined in `expr` can immediately get executed
+        =#
+        return quote
+            $activate($blockbuilder)
+            $expr
+            $deactivate($blockbuilder)
+            $block
+        end
+    end
+end
+macro Block(expr)
+    quote
+        $(esc(Block(expr)))
+    end
+end
+
+end # Builder


### PR DESCRIPTION
Inspired by [Beaver](https://github.com/beaver-lodge/beaver) I've been thinking about the possiblity of a higher level API to write MLIR IR. At the lowest level, adding operations to a block could be achieved by using a similar mechanism as the context in thread local storage:

```jl
@Block begin # pushes a block to a block-stack in thread-local storage
  c = arith.constant(123) # each operation function returns its result value, internally it pushes the operation itself to the block in the thread-local storage.
  d = c
  for _ in 1:10
    d = rand() > 0.5 ? :  arith.addi(c, d) : arith.muli(c, d)
  end
end
```

using `esc` in the macro would make sure that the created values are available outside the `@Block` expression, enabling other blocks to reference those values as well.

Things fall apart when introducing control flow. `cf.br` needs to be able to reference blocks that are yet to be created. I tried writing `@Region` and `@Block` which I believe is a dumbed-down version of how things work in Beaver  (I don't really understand Elixir, [code](https://github.com/beaver-lodge/beaver/blob/865b5d212e79431e04682558b2fedc117b2c4e37/lib/beaver.ex#L128C1-L224C6)). This is the code in this PR but it isn't meant for merging, rather for showing what I tried and didn't work very well.

```jl
using MLIR: IR
using MLIR.Dialects: Func, Arith, CF
using MLIR.Builder

ctx = IR.Context()

myregion = @Region begin
    b1 = @Block begin
        Arith.constant(2)
        println("b1")
        CF.br(b2)
    end
    b2 = @Block begin
        println("b2")
    end
end

```
Here, `@Block` pushes the code it encompasses on a stack and first creates all blocks. Only at the end is the actual code from within each block run. I got this working using `eval` which isn't good all variables are then visible in module scope.
Also, even if this approach worked, I believe it's not entirely correct because blocks that are *dominated* by a block can access its values, this doesn't necessarily mean that those values are defined in order in code. e.g. if bb3 dominates bb2, bb2 can access it's values.
Lastly, block arguments aren't accounted for here but I imagine these could be added to the macro (`@Block arg::argtype begin `)

At this point I think it might not be worth it to try writing an all-encompassing high-level API that is quickly becoming riddled by magic (which I've already been warned of by @maleadt, who mentors my master thesis). But maybe there is some middleground such as operation functions returning their value or perhaps even using the automatic pushing to the block on the thread-local stack?
Any feedback would be greatly appreciated!

Jules
