### PR TITLE
Strip newline on `show(::Operation)`

### DIFF
--- a/src/IR/IR.jl
+++ b/src/IR/IR.jl
@@ -649,7 +649,7 @@ function Base.show(io::IO, operation::Operation)
     flags = API.mlirOpPrintingFlagsCreate()
     get(io, :debug, false) && API.mlirOpPrintingFlagsEnableDebugInfo(flags, true, true)
     API.mlirOperationPrintWithFlags(operation, flags, c_print_callback, ref)
-    flags = API.mlirOpPrintingFlagsDestroy(flags)
+    API.mlirOpPrintingFlagsDestroy(flags)
 
     write(io, rstrip(String(take!(buffer))))
 end

--- a/src/IR/IR.jl
+++ b/src/IR/IR.jl
@@ -208,7 +208,7 @@ IndexType() = MLIRType(API.mlirIndexTypeGet(context()))
 Base.convert(::Type{MlirType}, mtype::MLIRType) = mtype.type
 Base.parse(::Type{MLIRType}, s) =
     MLIRType(API.mlirTypeParseGet(context(), s))
-    
+
 function Base.eltype(type::MLIRType)
     if API.mlirTypeIsAShaped(type)
         MLIRType(API.mlirShapedTypeGetElementType(type))
@@ -642,11 +642,16 @@ end
 
 function Base.show(io::IO, operation::Operation)
     c_print_callback = @cfunction(print_callback, Cvoid, (MlirStringRef, Any))
-    ref = Ref(io)
+
+    buffer = IOBuffer()
+    ref = Ref(buffer)
+
     flags = API.mlirOpPrintingFlagsCreate()
     get(io, :debug, false) && API.mlirOpPrintingFlagsEnableDebugInfo(flags, true, true)
     API.mlirOperationPrintWithFlags(operation, flags, c_print_callback, ref)
-    println(io)
+    flags = API.mlirOpPrintingFlagsDestroy(flags)
+
+    write(io, rstrip(String(take!(buffer))))
 end
 
 verify(operation::Operation) = API.mlirOperationVerify(operation)


### PR DESCRIPTION
`Base.show` on `Operation` prints too many newlines. This PR fixes that by printing to a `IOBuffer` first and stripping the newlines before printing to the original `IO`.

It also adds the call to `mlirOpPrintingFlagsDestroy` destructor.

### Before
```julia
julia> MLIR.IR.create_operation("asdfs.asdfsa", MLIR.IR.Location(); results=[MLIR.IR.MLIRType(Bool)])
%0 = "asdfs.asdfsa"() : () -> i1



julia>
```

### After
```julia
julia> MLIR.IR.create_operation("asdfs.asdfsa", MLIR.IR.Location(); results=[MLIR.IR.MLIRType(Bool)])
%0 = "asdfs.asdfsa"() : () -> i1

julia>
```