### PR TITLE
Clean dialect bindings before build step

### DIFF
--- a/deps/.gitignore
+++ b/deps/.gitignore
@@ -1,0 +1,2 @@
+build.log
+mlir-jl-tblgen

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -37,6 +37,10 @@ println("- extra flags = $extra")
 
 run(`$(clang()) $files $CXXFLAGS $LDFLAGS $extra $libs $output`)
 
+# cleaning up
+println("Cleaning up...")
+rm.(filter(contains(r".jl$"), readdir(joinpath(@__DIR__, "..", "src", "dialects"); join=true)))
+
 # generate bindings
 println("Generating bindings...")
 

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -39,7 +39,7 @@ run(`$(clang()) $files $CXXFLAGS $LDFLAGS $extra $libs $output`)
 
 # cleaning up
 println("Cleaning up...")
-rm.(filter(contains(r".jl$"), readdir(joinpath(@__DIR__, "..", "src", "dialects"); join=true)))
+rm.(filter(endswith(".jl"), readdir(joinpath(@__DIR__, "..", "src", "dialects"); join=true)))
 
 # generate bindings
 println("Generating bindings...")


### PR DESCRIPTION
During development, if you switch `LLVM_full_jll` version (by for example, switching Julia version), then some erroneous dialect bindings might live on.

This PR forces deleting any dialect binding before generating them during build.