### PR TITLE
Export dialect generator as binary artifact

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,6 +3,7 @@ uuid = "bfde9dd4-8f40-4a1e-be09-1475335e1c92"
 version = "0.1.0"
 
 [deps]
+Artifacts = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
 CEnum = "fa961155-64e5-5f13-b03f-caf6b980ea82"
 LLVM = "929cbde3-209d-540e-8aea-75f648917ca0"
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"

--- a/deps/.gitignore
+++ b/deps/.gitignore
@@ -1,0 +1,1 @@
+Artifacts.toml

--- a/deps/Project.toml
+++ b/deps/Project.toml
@@ -1,5 +1,7 @@
 [deps]
 LLVM_full_jll = "a3ccf953-465e-511d-b87f-60a6490c289d"
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [compat]
 LLVM_full_jll = "15"

--- a/src/MLIR.jl
+++ b/src/MLIR.jl
@@ -3,7 +3,8 @@ module MLIR
 import LLVM
 using Artifacts
 
-const generator = artifact"MLIR/mlir-jl-tblgen"
+tblgen_exe() = artifact"MLIR/mlir-jl-tblgen"
+tblgen_exe(f) = f(tblgen_exe())
 
 module API
     using CEnum

--- a/src/MLIR.jl
+++ b/src/MLIR.jl
@@ -1,6 +1,9 @@
 module MLIR
 
 import LLVM
+using Artifacts
+
+const generator = artifact"MLIR/mlir-jl-tblgen"
 
 module API
     using CEnum


### PR DESCRIPTION
This PR stores the `mlir-jl-tblgen` binary in an artifact and introduces the `tblgen_exe` method for accessing to it.

This is of interest for external dialects. For example, a hypothetical StableHLO.jl package could reuse `mlir-jl-tblgen` to generate the bindings to the `StableHLO` dialect.