### PR TITLE
Test against Julia 1.10 on CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -18,6 +18,7 @@ jobs:
       matrix:
         version:
           - '1.9'
+          - '1.10'
           - 'nightly'
         os:
           - ubuntu-latest


### PR DESCRIPTION
Since Julia 1.10 was released weeks ago, we should be testing against it.

Additionally, in #27 we discussed that since MLIR.jl is very experimental yet, maybe we could update the minimum Julia version to v1.10 to avoid some problems in the dialect binding generator.