### PR TITLE
Compile `mlir-jl-tblgen` with Clang from `LLVM_full_jll`

### DIFF
--- a/deps/build_local.jl
+++ b/deps/build_local.jl
@@ -45,11 +45,13 @@ else
 end
 LLVM_DIR = joinpath(LLVM.artifact_dir, "lib", "cmake", "llvm")
 MLIR_DIR = joinpath(LLVM.artifact_dir, "lib", "cmake", "mlir")
+CLANG_PATH = joinpath(LLVM.artifact_dir, "tools", "clang")
+CLANGXX_PATH = joinpath(LLVM.artifact_dir, "tools", "clang++")
 
 # build and install
-@info "Building" source_dir scratch_dir build_dir LLVM_DIR MLIR_DIR
+@info "Building" source_dir scratch_dir build_dir LLVM_DIR MLIR_DIR CLANG_PATH CLANGXX_PATH
 cmake() do cmake_path
-    config_opts = `-DLLVM_ROOT=$(LLVM_DIR) -DMLIR_ROOT=$(MLIR_DIR) -DCMAKE_INSTALL_PREFIX=$(scratch_dir)`
+    config_opts = `-DLLVM_ROOT=$(LLVM_DIR) -DMLIR_ROOT=$(MLIR_DIR) -DCMAKE_INSTALL_PREFIX=$(scratch_dir) -DCMAKE_C_COMPILER=$(CLANG_PATH) -DCMAKE_CXX_COMPILER=$(CLANGXX_PATH)`
     if Sys.iswindows()
         # prevent picking up MSVC
         config_opts = `$config_opts -G "MSYS Makefiles"`


### PR DESCRIPTION
I'm getting the following error in macOS:

```
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/c++ -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -I/Users/mofeing/.julia/artifacts/43c5f915b23163ac6d25e7754f68cfc1ff50d375/include -Wall -fPIC -fno-rtti -fPIC -fvisibility-inlines-hidden -Werror=date-time -Werror=unguarded-availability-new -Wall -Wextra -Wno-unused-parameter -Wwrite-strings -Wcast-qual -Wmissing-field-initializers -Wimplicit-fallthrough -Wcovered-switch-default -Wno-noexcept-type -Wnon-virtual-dtor -Wdelete-non-virtual-dtor -Wsuggest-override -Wstring-conversion -std=gnu++17 -arch x86_64 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.2.sdk -mmacosx-version-min=14.1   -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -MD -MT CMakeFiles/mlir-jl-tblgen.dir/jl-generators.cc.o -MF CMakeFiles/mlir-jl-tblgen.dir/jl-generators.cc.o.d -o CMakeFiles/mlir-jl-tblgen.dir/jl-generators.cc.o -c /Users/mofeing/Developer/MLIR.jl/deps/tblgen/jl-generators.cc

...

/Users/mofeing/Developer/MLIR.jl/deps/tblgen/jl-generators.cc:39:10: fatal error: 'mlir/TableGen/Class.h' file not found
#include "mlir/TableGen/Class.h"
         ^~~~~~~~~~~~~~~~~~~~~~~
2 warnings and 1 error generated.
make[2]: *** [CMakeFiles/mlir-jl-tblgen.dir/jl-generators.cc.o] Error 1
make[1]: *** [CMakeFiles/mlir-jl-tblgen.dir/all] Error 2
make: *** [all] Error 2
```

The reason is that it's using Apple Clang for compilation but Apple LLVM doesn't have MLIR.

This PR forces to compile with Clang from `LLVM_full_jll`.