### PR TITLE
MLIRValueTrait to support user defined Value types

### DIFF
--- a/src/IR/Value.jl
+++ b/src/IR/Value.jl
@@ -11,6 +11,17 @@ Base.convert(::Core.Type{API.MlirValue}, value::Value) = value.value
 Base.size(value::Value) = Base.size(Type(value))
 Base.ndims(value::Value) = Base.ndims(Type(value))
 
+
+abstract type MLIRValueTrait end
+struct Convertible <: MLIRValueTrait end
+struct NonConvertible <: MLIRValueTrait end
+
+MLIRValueTrait(T) = NonConvertible()
+get_value(x::Value) = x
+get_value(x::T) where T = get_value(MLIRValueTrait(T), x)
+get_value(::Convertible, x) = x.value
+get_value(::NonConvertible, x::T) where T = error("Type $T does not have the Convertible MLIRValueTrait")
+
 """
     ==(value1, value2)
 


### PR DESCRIPTION
What this enables:
```jl
# Setup #
using MLIR
using MLIR: IR, API
using MLIR.IR: Value, Operation, Block, push_argument!, Context, MLIRValueTrait, Convertible
using MLIR.Dialects: arith
ctx = Context()

# Define a Julia type and mapping to MLIR #
struct MLIRInteger{N} <: Integer
    value::Value
    MLIRInteger{N}(i::Value) where {N} = new(i)
end
const i64 = MLIRInteger{64}
IR.Type(::Type{MLIRInteger{N}}) where {N} = API.mlirIntegerTypeGet(ctx, N)
MLIRValueTrait(::Type{<:MLIRInteger}) = Convertible()

# Specialize or write function #
function Base.:+(a::T, b::T)::T where {T<:MLIRInteger}
    T(IR.result(arith.addi(a, b)))
end

# Execute # 
block = Block()
a = i64(push_argument!(block, IR.Type(i64)))
b = i64(push_argument!(block, IR.Type(i64)))

a+b
```
Of course, using this approach you lose direct access to a handle to the generated operation (`arith.addi`) so it is of dubious value as of now.
In Jojo.jl this system is used in combination with CassetteOverlay to make sure that all created operations are collected. This system is still a bit finicky and I'm still working on it so I wouldn't try upstream this yet.

While collecting things to push here, it's clear some cleaning up is still required.
* `get_value` is a bad name. It could be changed to `Value`, or instead, use Julia conversion `convert(::Value, ...)` which would probably be nicer to allow automatic conversion when e.g. pushing to `Value[]`
* `MLIRValueTrait` => `ValueTrait`?

I'm not even sure if it's necessary to have this trait system. For now, the conversion to `IR.Value` is so simple that you might as well just specialize `get_value` instead of letting it happen through the trait. On the other hand, this might help in the future as people want to add extra functionality to Value-like types.


