### PR TITLE
update Attribute constructor for integers

### DIFF
--- a/src/IR/Attribute.jl
+++ b/src/IR/Attribute.jl
@@ -141,7 +141,7 @@ isinteger(attr::Attribute) = API.mlirAttributeIsAInteger(attr)
 
 Creates an integer attribute of the given type with the given integer value.
 """
-Attribute(i::T) where {T<:Integer} = Attribute(API.mlirIntegerAttrGet(Type(T), Int64(i)))
+Attribute(i::T, t=Type(T)) where {T<:Integer} = Attribute(API.mlirIntegerAttrGet(t, Int64(i)))
 
 """
     Int64(attr)

--- a/src/IR/Attribute.jl
+++ b/src/IR/Attribute.jl
@@ -141,7 +141,7 @@ isinteger(attr::Attribute) = API.mlirAttributeIsAInteger(attr)
 
 Creates an integer attribute of the given type with the given integer value.
 """
-Attribute(i::T, t=Type(T)) where {T<:Integer} = Attribute(API.mlirIntegerAttrGet(t, Int64(i)))
+Attribute(i::T, type=Type(T)) where {T<:Integer} = Attribute(API.mlirIntegerAttrGet(type, Int64(i)))
 
 """
     Int64(attr)


### PR DESCRIPTION
allow to manually specify type for integerattr (e.g. to create indexattribute)