### PR TITLE
Replace `LLVM.version()` with `Base.libllvm_version`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,12 +4,10 @@ version = "0.1.0"
 
 [deps]
 CEnum = "fa961155-64e5-5f13-b03f-caf6b980ea82"
-LLVM = "929cbde3-209d-540e-8aea-75f648917ca0"
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 MLIR_jll = "a70bccb4-a5c0-5e2e-a329-e731972457e8"
 
 [compat]
 CEnum = "0.4"
-LLVM = "5"
 MLIR_jll = "14,15,16"
 julia = "1.9"

--- a/src/Dialects.jl
+++ b/src/Dialects.jl
@@ -1,6 +1,5 @@
 module Dialects
 
-import LLVM
 import ..IR: Attribute, NamedAttribute, context
 import ..API
 
@@ -14,7 +13,7 @@ end
 operandsegmentsizes(segments) = namedattribute("operand_segment_sizes", Attribute(Int32.(segments)))
 
 let
-    ver = string(LLVM.version().major)
+    ver = string(Base.libllvm_version.major)
     dir = joinpath(@__DIR__, "Dialects", ver)
     if !isdir(dir)
         error("""The MLIR dialect bindings for v$ver do not exist.

--- a/src/IR/Attribute.jl
+++ b/src/IR/Attribute.jl
@@ -621,7 +621,7 @@ function Base.length(attr::Attribute)
         API.mlirDictionaryAttrGetNumElements(attr)
     elseif iselements(attr)
         API.mlirElementsAttrGetNumElements(attr)
-    elseif LLVM.version() >= v"16"
+    elseif Base.libllvm_version >= v"16"
         _isdensearray = any(T -> isdensearray(attr, T), [Bool, Int8, Int16, Int32, Int64, Float32, Float64])
         if _isdensearray
             API.mlirDenseBoolArrayGetNumElements(attr)
@@ -667,7 +667,7 @@ function Base.getindex(attr::Attribute, i)
         else
             throw("unsupported element type $(elem_type)")
         end
-    elseif LLVM.version() >= v"16"
+    elseif Base.libllvm_version >= v"16"
         if isdensearray(attr, Bool)
             API.mlirDenseBoolArrayGetElement(attr, i)
         elseif isdensearray(attr, Int8)

--- a/src/IR/IR.jl
+++ b/src/IR/IR.jl
@@ -1,7 +1,6 @@
 module IR
 
 using ..API
-using LLVM: LLVM
 
 # do not export `Type`, as it is already defined in Core
 # also, use `Core.Type` inside this module to avoid clash with MLIR `Type`
@@ -31,7 +30,7 @@ macro llvmversioned(pred, expr)
     @assert Meta.isexpr(version, :macrocall) && version.args[1] == Symbol("@v_str") "Expected a VersionNumber"
     version = eval(version)
 
-    if predname == :min && LLVM.version() >= version || predname == :max && VersionNumber(LLVM.version().major) <= version
+    if predname == :min && Base.libllvm_version >= version || predname == :max && VersionNumber(Base.libllvm_version.major) <= version
         esc(expr)
     else
         esc(:(nothing))

--- a/src/IR/Operation.jl
+++ b/src/IR/Operation.jl
@@ -220,7 +220,7 @@ function Base.show(io::IO, operation::Operation)
 
     flags = API.mlirOpPrintingFlagsCreate()
 
-    if LLVM.version() >= v"16"
+    if Base.libllvm_version >= v"16"
         API.mlirOpPrintingFlagsEnableDebugInfo(flags, get(io, :debug, false), true)
     else
         get(io, :debug, false) && API.mlirOpPrintingFlagsEnableDebugInfo(flags, true)

--- a/src/IR/Pass.jl
+++ b/src/IR/Pass.jl
@@ -145,7 +145,7 @@ end
 Parse a textual MLIR pass pipeline and add it to the provided `OpPassManager`.
 """
 function Base.parse(opm::OpPassManager, pipeline::String)
-    result = if LLVM.version() >= v"16"
+    result = if Base.libllvm_version >= v"16"
         io = IOBuffer()
         c_print_callback = @cfunction(print_callback, Cvoid, (API.MlirStringRef, Any))
         API.mlirParsePassPipeline(opm, pipeline, c_print_callback, Ref(io))

--- a/src/MLIR.jl
+++ b/src/MLIR.jl
@@ -1,15 +1,12 @@
 module MLIR
 
-import LLVM
-
 module API
 using CEnum
 
 # MLIR C API
-import ..LLVM
 using MLIR_jll
 let
-    ver = string(LLVM.version().major)
+    ver = string(Base.libllvm_version.major)
     dir = joinpath(@__DIR__, "API", ver)
     if !isdir(dir)
         error("""The MLIR API bindings for v$ver do not exist.


### PR DESCRIPTION
Currently, we only use LLVM.jl for conditionally loading code based on the LLVM version the current Julia session is using. `LLVM.version()` is actually just returning `Base.libllvm_version` so we can remove the `LLVM` dependency.

https://github.com/maleadt/LLVM.jl/blob/6bf0d9775d2bea129ba3edba895ce9f963710271/src/version.jl#L5

https://github.com/maleadt/LLVM.jl/blob/6bf0d9775d2bea129ba3edba895ce9f963710271/src/LLVM.jl#L19
