### PR TITLE
Replace `Base.libllvm_version` with `libmlir_version` preference

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,8 +6,10 @@ version = "0.1.0"
 CEnum = "fa961155-64e5-5f13-b03f-caf6b980ea82"
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 MLIR_jll = "a70bccb4-a5c0-5e2e-a329-e731972457e8"
+Preferences = "21216c6a-2e73-6563-6e65-726566657250"
 
 [compat]
 CEnum = "0.4"
 MLIR_jll = "14,15,16"
+Preferences = "1"
 julia = "1.9"

--- a/src/Dialects.jl
+++ b/src/Dialects.jl
@@ -13,7 +13,7 @@ end
 operandsegmentsizes(segments) = namedattribute("operand_segment_sizes", Attribute(Int32.(segments)))
 
 let
-    ver = string(Base.libllvm_version.major)
+    ver = string(libmlir_version.major)
     dir = joinpath(@__DIR__, "Dialects", ver)
     if !isdir(dir)
         error("""The MLIR dialect bindings for v$ver do not exist.

--- a/src/IR/Attribute.jl
+++ b/src/IR/Attribute.jl
@@ -621,7 +621,7 @@ function Base.length(attr::Attribute)
         API.mlirDictionaryAttrGetNumElements(attr)
     elseif iselements(attr)
         API.mlirElementsAttrGetNumElements(attr)
-    elseif Base.libllvm_version >= v"16"
+    elseif libmlir_version >= v"16"
         _isdensearray = any(T -> isdensearray(attr, T), [Bool, Int8, Int16, Int32, Int64, Float32, Float64])
         if _isdensearray
             API.mlirDenseBoolArrayGetNumElements(attr)
@@ -667,7 +667,7 @@ function Base.getindex(attr::Attribute, i)
         else
             throw("unsupported element type $(elem_type)")
         end
-    elseif Base.libllvm_version >= v"16"
+    elseif libmlir_version >= v"16"
         if isdensearray(attr, Bool)
             API.mlirDenseBoolArrayGetElement(attr, i)
         elseif isdensearray(attr, Int8)

--- a/src/IR/IR.jl
+++ b/src/IR/IR.jl
@@ -30,7 +30,7 @@ macro llvmversioned(pred, expr)
     @assert Meta.isexpr(version, :macrocall) && version.args[1] == Symbol("@v_str") "Expected a VersionNumber"
     version = eval(version)
 
-    if predname == :min && Base.libllvm_version >= version || predname == :max && VersionNumber(Base.libllvm_version.major) <= version
+    if predname == :min && libmlir_version >= version || predname == :max && VersionNumber(libmlir_version.major) <= version
         esc(expr)
     else
         esc(:(nothing))

--- a/src/IR/Operation.jl
+++ b/src/IR/Operation.jl
@@ -220,7 +220,7 @@ function Base.show(io::IO, operation::Operation)
 
     flags = API.mlirOpPrintingFlagsCreate()
 
-    if Base.libllvm_version >= v"16"
+    if libmlir_version >= v"16"
         API.mlirOpPrintingFlagsEnableDebugInfo(flags, get(io, :debug, false), true)
     else
         get(io, :debug, false) && API.mlirOpPrintingFlagsEnableDebugInfo(flags, true)

--- a/src/IR/Pass.jl
+++ b/src/IR/Pass.jl
@@ -145,7 +145,7 @@ end
 Parse a textual MLIR pass pipeline and add it to the provided `OpPassManager`.
 """
 function Base.parse(opm::OpPassManager, pipeline::String)
-    result = if Base.libllvm_version >= v"16"
+    result = if libmlir_version >= v"16"
         io = IOBuffer()
         c_print_callback = @cfunction(print_callback, Cvoid, (API.MlirStringRef, Any))
         API.mlirParsePassPipeline(opm, pipeline, c_print_callback, Ref(io))

--- a/src/MLIR.jl
+++ b/src/MLIR.jl
@@ -1,12 +1,16 @@
 module MLIR
 
+using Preferences
+
+libmlir_version = VersionNumber(@load_preference(:libmlir_version, Base.libllvm_version_string))
+
 module API
 using CEnum
 
 # MLIR C API
 using MLIR_jll
 let
-    ver = string(Base.libllvm_version.major)
+    ver = string(libmlir_version.major)
     dir = joinpath(@__DIR__, "API", ver)
     if !isdir(dir)
         error("""The MLIR API bindings for v$ver do not exist.

--- a/src/MLIR.jl
+++ b/src/MLIR.jl
@@ -2,7 +2,7 @@ module MLIR
 
 using Preferences
 
-libmlir_version = VersionNumber(@load_preference(:libmlir_version, Base.libllvm_version_string))
+libmlir_version = VersionNumber(@load_preference("libmlir_version", Base.libllvm_version_string))
 
 module API
 using CEnum


### PR DESCRIPTION
I didn't put this into #69 because this might require more discussion.

This PR lets the user select the MLIR version they want on compile-time.

**Wait, why do this?**

Well, several projects experimenting with MLIR.jl, like [Coil.jl](https://github.com/pangoraw/Coil.jl) and [Reactant.jl](https://github.com/EnzymeAD/Reactant.jl), need to import the whole MLIR.jl code just because they use another libMLIR (included in XLA or IREE). They just need a way to overwrite `MLIR_jll.mlir_c`.

Since we conditionally load code based on Julia's LLVM version (mainly for `MLIR.API` and `MLIR.Dialects`), the loaded code won't match the version of the custom MLIR loaded version.

This PR solves it by letting the user explicitly set the correct MLIR version using `Preferences`.

Upstreaming a patch for adding a `mlir_version` function in libMLIR-C would remove the need for this, since the users would just overwrite `mlir_c` in `MLIR_jll` and we could ask the version to it. Meanwhile, and for supporting older versions, this patch will do the trick.