### PR TITLE
handle multiple optional operands

### DIFF
--- a/deps/tblgen/jl-generators.cc
+++ b/deps/tblgen/jl-generators.cc
@@ -304,7 +304,7 @@ end
 
     if (op.getTrait("::mlir::OpTrait::AttrSizedOperandSegments"))
     {
-      std::vector<std::string> opseglist;
+      std::string operandsegmentsizes = "";
       for (int i = 0; i < op.getNumOperands(); i++)
       {
         const auto &named_operand = op.getOperand(i);
@@ -314,15 +314,14 @@ end
           operandname = "operand_" + std::to_string(i);
         }
         if (named_operand.isOptional())
-          opseglist.push_back("isnothing(" + operandname + ") ? 0 : 1");
+        {
+          operandsegmentsizes += "isnothing(" + operandname + ") ? 0 : 1, ";
+        }
         else
-          opseglist.push_back(named_operand.isVariadic() ? "length(" + operandname + "), " : "1, ");
+        {
+          operandsegmentsizes += named_operand.isVariadic() ? "length(" + operandname + "), " : "1, ";
+        }
       }
-      std::string operandsegmentsizes = std::accumulate(std::begin(opseglist), std::end(opseglist), std::string(),
-                                [](std::string &ss, std::string &s)
-                                {
-                                    return ss.empty() ? s : ss + "," + s;
-                                });
       optionals += llvm::formatv(R"(push!(attributes, operandsegmentsizes([{0}]))
     )",
                                  operandsegmentsizes);

--- a/src/Dialects/16/AMDGPU.jl
+++ b/src/Dialects/16/AMDGPU.jl
@@ -1,8 +1,8 @@
 module amdgpu
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `lds_barrier`
@@ -25,16 +25,12 @@ function lds_barrier(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "amdgpu.lds_barrier",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "amdgpu.lds_barrier", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -67,52 +63,25 @@ order (that is, v[0] will go to arg[7:0], v[1] to arg[15:8] and so on).
 The negateA, negateB, and negateC flags are only supported for double-precision
 operations on gfx940+.
 """
-function mfma(
-    sourceA::Value,
-    sourceB::Value,
-    destC::Value;
-    destD::IR.Type,
-    m,
-    n,
-    k,
-    blocks,
-    cbsz=nothing,
-    abid=nothing,
-    blgp=nothing,
-    reducePrecision=nothing,
-    negateA=nothing,
-    negateB=nothing,
-    negateC=nothing,
-    location=Location(),
-)
-    results = IR.Type[destD,]
-    operands = Value[sourceA, sourceB, destC]
+function mfma(sourceA::Value, sourceB::Value, destC::Value; destD::IR.Type, m, n, k, blocks, cbsz=nothing, abid=nothing, blgp=nothing, reducePrecision=nothing, negateA=nothing, negateB=nothing, negateC=nothing, location=Location())
+    results = IR.Type[destD, ]
+    operands = Value[sourceA, sourceB, destC, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("m", m),
-        namedattribute("n", n),
-        namedattribute("k", k),
-        namedattribute("blocks", blocks),
-    ]
+    attributes = NamedAttribute[namedattribute("m", m), namedattribute("n", n), namedattribute("k", k), namedattribute("blocks", blocks), ]
     !isnothing(cbsz) && push!(attributes, namedattribute("cbsz", cbsz))
     !isnothing(abid) && push!(attributes, namedattribute("abid", abid))
     !isnothing(blgp) && push!(attributes, namedattribute("blgp", blgp))
-    !isnothing(reducePrecision) &&
-        push!(attributes, namedattribute("reducePrecision", reducePrecision))
+    !isnothing(reducePrecision) && push!(attributes, namedattribute("reducePrecision", reducePrecision))
     !isnothing(negateA) && push!(attributes, namedattribute("negateA", negateA))
     !isnothing(negateB) && push!(attributes, namedattribute("negateB", negateB))
     !isnothing(negateC) && push!(attributes, namedattribute("negateC", negateC))
-
-    return IR.create_operation(
-        "amdgpu.mfma",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "amdgpu.mfma", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -136,37 +105,22 @@ Out of bounds atomic operations are ignored in hardware.
 See `amdgpu.raw_buffer_load` for a description of how the underlying
 instruction is constructed.
 """
-function raw_buffer_atomic_fadd(
-    value::Value,
-    memref::Value,
-    indices::Vector{Value},
-    sgprOffset=nothing::Union{Nothing,Value};
-    boundsCheck=nothing,
-    indexOffset=nothing,
-    location=Location(),
-)
+function raw_buffer_atomic_fadd(value::Value, memref::Value, indices::Vector{Value}, sgprOffset=nothing::Union{Nothing, Value}; boundsCheck=nothing, indexOffset=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[value, memref, indices...]
+    operands = Value[value, memref, indices..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(sgprOffset) && push!(operands, sgprOffset)
-    push!(
-        attributes,
-        operandsegmentsizes([1, 1, length(indices), (sgprOffset == nothing) ? 0 : 1]),
-    )
+    push!(attributes, operandsegmentsizes([1, 1, length(indices), isnothing(sgprOffset) ? 0 : 1, ]))
     !isnothing(boundsCheck) && push!(attributes, namedattribute("boundsCheck", boundsCheck))
     !isnothing(indexOffset) && push!(attributes, namedattribute("indexOffset", indexOffset))
-
-    return IR.create_operation(
-        "amdgpu.raw_buffer_atomic_fadd",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "amdgpu.raw_buffer_atomic_fadd", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -202,37 +156,22 @@ are translated to intrinsic arguments as follows:
   to 2 to disable bounds checks, otherwise it is 3
 - The cache coherency bits are off
 """
-function raw_buffer_load(
-    memref::Value,
-    indices::Vector{Value},
-    sgprOffset=nothing::Union{Nothing,Value};
-    value::IR.Type,
-    boundsCheck=nothing,
-    indexOffset=nothing,
-    location=Location(),
-)
-    results = IR.Type[value,]
-    operands = Value[memref, indices...]
+function raw_buffer_load(memref::Value, indices::Vector{Value}, sgprOffset=nothing::Union{Nothing, Value}; value::IR.Type, boundsCheck=nothing, indexOffset=nothing, location=Location())
+    results = IR.Type[value, ]
+    operands = Value[memref, indices..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(sgprOffset) && push!(operands, sgprOffset)
-    push!(
-        attributes,
-        operandsegmentsizes([1, length(indices), (sgprOffset == nothing) ? 0 : 1]),
-    )
+    push!(attributes, operandsegmentsizes([1, length(indices), isnothing(sgprOffset) ? 0 : 1, ]))
     !isnothing(boundsCheck) && push!(attributes, namedattribute("boundsCheck", boundsCheck))
     !isnothing(indexOffset) && push!(attributes, namedattribute("indexOffset", indexOffset))
-
-    return IR.create_operation(
-        "amdgpu.raw_buffer_load",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "amdgpu.raw_buffer_load", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -256,37 +195,22 @@ components is partically completed is chipset-dependent.
 See `amdgpu.raw_buffer_load` for a description of how the underlying
 instruction is constructed.
 """
-function raw_buffer_store(
-    value::Value,
-    memref::Value,
-    indices::Vector{Value},
-    sgprOffset=nothing::Union{Nothing,Value};
-    boundsCheck=nothing,
-    indexOffset=nothing,
-    location=Location(),
-)
+function raw_buffer_store(value::Value, memref::Value, indices::Vector{Value}, sgprOffset=nothing::Union{Nothing, Value}; boundsCheck=nothing, indexOffset=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[value, memref, indices...]
+    operands = Value[value, memref, indices..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(sgprOffset) && push!(operands, sgprOffset)
-    push!(
-        attributes,
-        operandsegmentsizes([1, 1, length(indices), (sgprOffset == nothing) ? 0 : 1]),
-    )
+    push!(attributes, operandsegmentsizes([1, 1, length(indices), isnothing(sgprOffset) ? 0 : 1, ]))
     !isnothing(boundsCheck) && push!(attributes, namedattribute("boundsCheck", boundsCheck))
     !isnothing(indexOffset) && push!(attributes, namedattribute("indexOffset", indexOffset))
-
-    return IR.create_operation(
-        "amdgpu.raw_buffer_store",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "amdgpu.raw_buffer_store", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/16/AMX.jl
+++ b/src/Dialects/16/AMX.jl
@@ -1,38 +1,25 @@
 module amx
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `tdpbf16ps`
 
 """
-function tdpbf16ps(
-    operand_0::Value,
-    operand_1::Value,
-    operand_2::Value,
-    operand_3::Value,
-    operand_4::Value,
-    operand_5::Value;
-    res::IR.Type,
-    location=Location(),
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4, operand_5]
+function tdpbf16ps(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value, operand_4::Value, operand_5::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4, operand_5, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "amx.tdpbf16ps",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "amx.tdpbf16ps", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -40,31 +27,18 @@ end
 `tdpbssd`
 
 """
-function tdpbssd(
-    operand_0::Value,
-    operand_1::Value,
-    operand_2::Value,
-    operand_3::Value,
-    operand_4::Value,
-    operand_5::Value;
-    res::IR.Type,
-    location=Location(),
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4, operand_5]
+function tdpbssd(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value, operand_4::Value, operand_5::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4, operand_5, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "amx.tdpbssd",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "amx.tdpbssd", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -72,31 +46,18 @@ end
 `tdpbsud`
 
 """
-function tdpbsud(
-    operand_0::Value,
-    operand_1::Value,
-    operand_2::Value,
-    operand_3::Value,
-    operand_4::Value,
-    operand_5::Value;
-    res::IR.Type,
-    location=Location(),
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4, operand_5]
+function tdpbsud(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value, operand_4::Value, operand_5::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4, operand_5, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "amx.tdpbsud",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "amx.tdpbsud", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -104,31 +65,18 @@ end
 `tdpbusd`
 
 """
-function tdpbusd(
-    operand_0::Value,
-    operand_1::Value,
-    operand_2::Value,
-    operand_3::Value,
-    operand_4::Value,
-    operand_5::Value;
-    res::IR.Type,
-    location=Location(),
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4, operand_5]
+function tdpbusd(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value, operand_4::Value, operand_5::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4, operand_5, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "amx.tdpbusd",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "amx.tdpbusd", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -136,31 +84,18 @@ end
 `tdpbuud`
 
 """
-function tdpbuud(
-    operand_0::Value,
-    operand_1::Value,
-    operand_2::Value,
-    operand_3::Value,
-    operand_4::Value,
-    operand_5::Value;
-    res::IR.Type,
-    location=Location(),
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4, operand_5]
+function tdpbuud(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value, operand_4::Value, operand_5::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4, operand_5, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "amx.tdpbuud",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "amx.tdpbuud", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -168,29 +103,18 @@ end
 `tileloadd64`
 
 """
-function tileloadd64(
-    operand_0::Value,
-    operand_1::Value,
-    operand_2::Value,
-    operand_3::Value;
-    res::IR.Type,
-    location=Location(),
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1, operand_2, operand_3]
+function tileloadd64(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, operand_2, operand_3, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "amx.tileloadd64",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "amx.tileloadd64", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -198,29 +122,18 @@ end
 `tilestored64`
 
 """
-function tilestored64(
-    operand_0::Value,
-    operand_1::Value,
-    operand_2::Value,
-    operand_3::Value,
-    operand_4::Value;
-    location=Location(),
-)
+function tilestored64(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value, operand_4::Value; location=Location())
     results = IR.Type[]
-    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4]
+    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "amx.tilestored64",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "amx.tilestored64", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -229,21 +142,17 @@ end
 
 """
 function tilezero(operand_0::Value, operand_1::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1]
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "amx.tilezero",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "amx.tilezero", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -262,21 +171,17 @@ corresponding tile configuration.
 ```
 """
 function tile_load(base::Value, indices::Vector{Value}; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[base, indices...]
+    results = IR.Type[res, ]
+    operands = Value[base, indices..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "amx.tile_load",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "amx.tile_load", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -296,21 +201,17 @@ pairs of \"bf16\"). The operation is eventually lowered into the
 ```
 """
 function tile_mulf(lhs::Value, rhs::Value, acc::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[lhs, rhs, acc]
+    results = IR.Type[res, ]
+    operands = Value[lhs, rhs, acc, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "amx.tile_mulf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "amx.tile_mulf", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -332,32 +233,20 @@ instructions with the corresponding tile configuration.
     : vector<16x64xi8>, vector<16x64xi8>, vector<16x16xi32>
 ```
 """
-function tile_muli(
-    lhs::Value,
-    rhs::Value,
-    acc::Value;
-    res::IR.Type,
-    isZextLhs=nothing,
-    isZextRhs=nothing,
-    location=Location(),
-)
-    results = IR.Type[res,]
-    operands = Value[lhs, rhs, acc]
+function tile_muli(lhs::Value, rhs::Value, acc::Value; res::IR.Type, isZextLhs=nothing, isZextRhs=nothing, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[lhs, rhs, acc, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(isZextLhs) && push!(attributes, namedattribute("isZextLhs", isZextLhs))
     !isnothing(isZextRhs) && push!(attributes, namedattribute("isZextRhs", isZextRhs))
-
-    return IR.create_operation(
-        "amx.tile_muli",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "amx.tile_muli", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -377,20 +266,16 @@ corresponding tile configuration.
 """
 function tile_store(base::Value, indices::Vector{Value}, val::Value; location=Location())
     results = IR.Type[]
-    operands = Value[base, indices..., val]
+    operands = Value[base, indices..., val, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "amx.tile_store",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "amx.tile_store", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -408,21 +293,17 @@ vector type of the result. This is eventually lowered into the
 ```
 """
 function tile_zero(; res::IR.Type, location=Location())
-    results = IR.Type[res,]
+    results = IR.Type[res, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "amx.tile_zero",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "amx.tile_zero", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/16/Affine.jl
+++ b/src/Dialects/16/Affine.jl
@@ -1,8 +1,8 @@
 module affine
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `apply`
@@ -27,21 +27,17 @@ have ‘index’ type.
 ```
 """
 function apply(mapOperands::Vector{Value}; result_0::IR.Type, map, location=Location())
-    results = IR.Type[result_0,]
-    operands = Value[mapOperands...,]
+    results = IR.Type[result_0, ]
+    operands = Value[mapOperands..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("map", map),]
-
-    return IR.create_operation(
-        "affine.apply",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("map", map), ]
+    
+    IR.create_operation(
+        "affine.apply", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -68,27 +64,18 @@ In the above example, `%indices:3` conceptually holds the following:
 %indices_2 = affine.apply #map2()[%linear_index]
 ```
 """
-function delinearize_index(
-    linear_index::Value,
-    basis::Vector{Value};
-    multi_index::Vector{IR.Type},
-    location=Location(),
-)
-    results = IR.Type[multi_index...,]
-    operands = Value[linear_index, basis...]
+function delinearize_index(linear_index::Value, basis::Vector{Value}; multi_index::Vector{IR.Type}, location=Location())
+    results = IR.Type[multi_index..., ]
+    operands = Value[linear_index, basis..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "affine.delinearize_index",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "affine.delinearize_index", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -199,24 +186,18 @@ If the `affine.for` defines any values, a yield terminator must be
 explicitly present. The number and types of the \"affine.for\" results must
 match the initial values in the `iter_args` binding and the yield operands.
 """
-function for_(
-    operand_0::Vector{Value}; results::Vector{IR.Type}, region::Region, location=Location()
-)
-    results = IR.Type[results...,]
-    operands = Value[operand_0...,]
-    owned_regions = Region[region,]
+function for_(operand_0::Vector{Value}; results_::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[results_..., ]
+    operands = Value[operand_0..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "affine.for",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "affine.for", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -290,28 +271,18 @@ func.func @pad_edges(%I : memref<10x10xf32>) -> (memref<12x12xf32) {
 }
 ```
 """
-function if_(
-    operand_0::Vector{Value};
-    results::Vector{IR.Type},
-    thenRegion::Region,
-    elseRegion::Region,
-    location=Location(),
-)
-    results = IR.Type[results...,]
-    operands = Value[operand_0...,]
-    owned_regions = Region[thenRegion, elseRegion]
+function if_(operand_0::Vector{Value}; results_::Vector{IR.Type}, thenRegion::Region, elseRegion::Region, location=Location())
+    results = IR.Type[results_..., ]
+    operands = Value[operand_0..., ]
+    owned_regions = Region[thenRegion, elseRegion, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "affine.if",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "affine.if", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -338,21 +309,17 @@ Example 2: Uses \'symbol\' keyword for symbols \'%n\' and \'%m\'.
 ```
 """
 function load(memref::Value, indices::Vector{Value}; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[memref, indices...]
+    results = IR.Type[result, ]
+    operands = Value[memref, indices..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "affine.load",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "affine.load", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -368,22 +335,18 @@ affine map.
 %0 = affine.max (d0) -> (1000, d0 + 512) (%i0) : index
 ```
 """
-function max(operands::Vector{Value}; result_0::IR.Type, map, location=Location())
-    results = IR.Type[result_0,]
-    operands = Value[operands...,]
+function max(operands_::Vector{Value}; result_0::IR.Type, map, location=Location())
+    results = IR.Type[result_0, ]
+    operands = Value[operands_..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("map", map),]
-
-    return IR.create_operation(
-        "affine.max",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("map", map), ]
+    
+    IR.create_operation(
+        "affine.max", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -409,22 +372,18 @@ input operands and result must all have \'index\' type.
 %0 = affine.min affine_map<(d0)[s0] -> (1000, d0 + 512, s0)> (%arg0)[%arg1]
 ```
 """
-function min(operands::Vector{Value}; result_0::IR.Type, map, location=Location())
-    results = IR.Type[result_0,]
-    operands = Value[operands...,]
+function min(operands_::Vector{Value}; result_0::IR.Type, map, location=Location())
+    results = IR.Type[result_0, ]
+    operands = Value[operands_..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("map", map),]
-
-    return IR.create_operation(
-        "affine.min",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("map", map), ]
+    
+    IR.create_operation(
+        "affine.min", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -493,40 +452,18 @@ affine.parallel (%ii, %jj) = (0, 0) to (%N, %M) step (32, 32) {
 }
 ```
 """
-function parallel(
-    mapOperands::Vector{Value};
-    results::Vector{IR.Type},
-    reductions,
-    lowerBoundsMap,
-    lowerBoundsGroups,
-    upperBoundsMap,
-    upperBoundsGroups,
-    steps,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[results...,]
-    operands = Value[mapOperands...,]
-    owned_regions = Region[region,]
+function parallel(mapOperands::Vector{Value}; results_::Vector{IR.Type}, reductions, lowerBoundsMap, lowerBoundsGroups, upperBoundsMap, upperBoundsGroups, steps, region::Region, location=Location())
+    results = IR.Type[results_..., ]
+    operands = Value[mapOperands..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("reductions", reductions),
-        namedattribute("lowerBoundsMap", lowerBoundsMap),
-        namedattribute("lowerBoundsGroups", lowerBoundsGroups),
-        namedattribute("upperBoundsMap", upperBoundsMap),
-        namedattribute("upperBoundsGroups", upperBoundsGroups),
-        namedattribute("steps", steps),
-    ]
-
-    return IR.create_operation(
-        "affine.parallel",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("reductions", reductions), namedattribute("lowerBoundsMap", lowerBoundsMap), namedattribute("lowerBoundsGroups", lowerBoundsGroups), namedattribute("upperBoundsMap", upperBoundsMap), namedattribute("upperBoundsGroups", upperBoundsGroups), namedattribute("steps", steps), ]
+    
+    IR.create_operation(
+        "affine.parallel", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -548,33 +485,18 @@ local keep in cache). The cache type specifier is either \'data\' or \'instr\'
 and specifies whether the prefetch is performed on data cache or on
 instruction cache.
 """
-function prefetch(
-    memref::Value,
-    indices::Vector{Value};
-    isWrite,
-    localityHint,
-    isDataCache,
-    location=Location(),
-)
+function prefetch(memref::Value, indices::Vector{Value}; isWrite, localityHint, isDataCache, location=Location())
     results = IR.Type[]
-    operands = Value[memref, indices...]
+    operands = Value[memref, indices..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("isWrite", isWrite),
-        namedattribute("localityHint", localityHint),
-        namedattribute("isDataCache", isDataCache),
-    ]
-
-    return IR.create_operation(
-        "affine.prefetch",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("isWrite", isWrite), namedattribute("localityHint", localityHint), namedattribute("isDataCache", isDataCache), ]
+    
+    IR.create_operation(
+        "affine.prefetch", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -602,20 +524,16 @@ affine.store %v0, %0[%i0 + symbol(%n), %i1 + symbol(%m)] : memref<100x100xf32>
 """
 function store(value::Value, memref::Value, indices::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[value, memref, indices...]
+    operands = Value[value, memref, indices..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "affine.store",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "affine.store", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -658,24 +576,18 @@ TODOs:
 * Consider adding a permutation map to permute the slice that is read from memory
 (see [vector.transfer_read](../Vector/#vectortransfer_read-vectortransferreadop)).
 """
-function vector_load(
-    memref::Value, indices::Vector{Value}; result::IR.Type, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[memref, indices...]
+function vector_load(memref::Value, indices::Vector{Value}; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[memref, indices..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "affine.vector_load",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "affine.vector_load", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -720,24 +632,18 @@ TODOs:
 * Consider adding a permutation map to permute the slice that is written to memory
 (see [vector.transfer_write](../Vector/#vectortransfer_write-vectortransferwriteop)).
 """
-function vector_store(
-    value::Value, memref::Value, indices::Vector{Value}; location=Location()
-)
+function vector_store(value::Value, memref::Value, indices::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[value, memref, indices...]
+    operands = Value[value, memref, indices..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "affine.vector_store",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "affine.vector_store", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -755,22 +661,18 @@ Otherwise, it has to be present in the syntax to indicate which values are
 yielded.
 ```
 """
-function yield(operands::Vector{Value}; location=Location())
+function yield(operands_::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[operands...,]
+    operands = Value[operands_..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "affine.yield",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "affine.yield", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/16/Arith.jl
+++ b/src/Dialects/16/Arith.jl
@@ -1,8 +1,8 @@
 module arith
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `addf`
@@ -28,30 +28,20 @@ floating point tensor.
 TODO: In the distant future, this will accept optional attributes for fast
 math, contraction, rounding mode, and other controls.
 """
-function addf(
-    lhs::Value,
-    rhs::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function addf(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "arith.addf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.addf", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -76,25 +66,19 @@ has no standard attributes.
 %x = arith.addi %y, %z : tensor<4x?xi8>
 ```
 """
-function addi(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function addi(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.addi",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.addi", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -119,24 +103,18 @@ indicates no overflow.
 %x:2 = arith.addui_extended %y, %z : tensor<4x?xi8>, tensor<4x?xi1>
 ```
 """
-function addui_extended(
-    lhs::Value, rhs::Value; sum::IR.Type, overflow::IR.Type, location=Location()
-)
-    results = IR.Type[sum, overflow]
-    operands = Value[lhs, rhs]
+function addui_extended(lhs::Value, rhs::Value; sum::IR.Type, overflow::IR.Type, location=Location())
+    results = IR.Type[sum, overflow, ]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arith.addui_extended",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.addui_extended", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -161,25 +139,19 @@ has no standard attributes.
 %x = arith.andi %y, %z : tensor<4x?xi8>
 ```
 """
-function andi(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function andi(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.andi",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.andi", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -202,21 +174,17 @@ integer is little-endian) a proper lowering would add operations to swap the
 order of words in addition to the bitcast.
 """
 function bitcast(in::Value; out::IR.Type, location=Location())
-    results = IR.Type[out,]
-    operands = Value[in,]
+    results = IR.Type[out, ]
+    operands = Value[in, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arith.bitcast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.bitcast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -235,25 +203,19 @@ value divided by -1) is TBD; do NOT assume any specific behavior.
 %a = arith.ceildivsi %b, %c : i64
 ```
 """
-function ceildivsi(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function ceildivsi(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.ceildivsi",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.ceildivsi", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -274,25 +236,19 @@ behavior.
 %a = arith.ceildivui %b, %c : i64
 ```
 """
-function ceildivui(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function ceildivui(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.ceildivui",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.ceildivui", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -323,29 +279,18 @@ attribute by the parser.
 %r3 = \"arith.cmpf\"(%0, %1) {predicate: 0} : (f8, f8) -> i1
 ```
 """
-function cmpf(
-    lhs::Value,
-    rhs::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    predicate,
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[lhs, rhs]
+function cmpf(lhs::Value, rhs::Value; result::IR.Type, predicate, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("predicate", predicate),]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.cmpf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    attributes = NamedAttribute[namedattribute("predicate", predicate), ]
+    
+    IR.create_operation(
+        "arith.cmpf", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -414,29 +359,18 @@ complement or large positives
     : (vector<4xi64>, vector<4xi64>) -> vector<4xi1>
 ```
 """
-function cmpi(
-    lhs::Value,
-    rhs::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    predicate,
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[lhs, rhs]
+function cmpi(lhs::Value, rhs::Value; result::IR.Type, predicate, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("predicate", predicate),]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.cmpi",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    attributes = NamedAttribute[namedattribute("predicate", predicate), ]
+    
+    IR.create_operation(
+        "arith.cmpi", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -457,23 +391,19 @@ forms simple integer and floating point constants.
 %1 = \"arith.constant\"() {value = 42 : i32} : () -> i32
 ```
 """
-function constant(; result=nothing::Union{Nothing,IR.Type}, value, location=Location())
+function constant(; result=nothing::Union{Nothing, IR.Type}, value, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("value", value),]
+    attributes = NamedAttribute[namedattribute("value", value), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.constant",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.constant", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -481,30 +411,20 @@ end
 `divf`
 
 """
-function divf(
-    lhs::Value,
-    rhs::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function divf(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "arith.divf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.divf", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -530,25 +450,19 @@ value divided by -1) is TBD; do NOT assume any specific behavior.
 %x = arith.divsi %y, %z : tensor<4x?xi8>
 ```
 """
-function divsi(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function divsi(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.divsi",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.divsi", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -575,25 +489,19 @@ behavior.
 %x = arith.divui %y, %z : tensor<4x?xi8>
 ```
 """
-function divui(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function divui(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.divui",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.divui", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -605,21 +513,17 @@ The destination type must to be strictly wider than the source type.
 When operating on vectors, casts elementwise.
 """
 function extf(in::Value; out::IR.Type, location=Location())
-    results = IR.Type[out,]
-    operands = Value[in,]
+    results = IR.Type[out, ]
+    operands = Value[in, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arith.extf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.extf", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -644,21 +548,17 @@ of the most-significant bit of the input.
 ```
 """
 function extsi(in::Value; out::IR.Type, location=Location())
-    results = IR.Type[out,]
-    operands = Value[in,]
+    results = IR.Type[out, ]
+    operands = Value[in, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arith.extsi",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.extsi", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -682,21 +582,17 @@ The top-most (N - M) bits of the output are filled with zeros.
 ```
 """
 function extui(in::Value; out::IR.Type, location=Location())
-    results = IR.Type[out,]
-    operands = Value[in,]
+    results = IR.Type[out, ]
+    operands = Value[in, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arith.extui",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.extui", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -708,21 +604,17 @@ towards zero) signed integer value. When operating on vectors, casts
 elementwise.
 """
 function fptosi(in::Value; out::IR.Type, location=Location())
-    results = IR.Type[out,]
-    operands = Value[in,]
+    results = IR.Type[out, ]
+    operands = Value[in, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arith.fptosi",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.fptosi", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -734,21 +626,17 @@ towards zero) unsigned integer value. When operating on vectors, casts
 elementwise.
 """
 function fptoui(in::Value; out::IR.Type, location=Location())
-    results = IR.Type[out,]
-    operands = Value[in,]
+    results = IR.Type[out, ]
+    operands = Value[in, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arith.fptoui",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.fptoui", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -768,25 +656,19 @@ value divided by -1) is TBD; do NOT assume any specific behavior.
 
 ```
 """
-function floordivsi(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function floordivsi(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.floordivsi",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.floordivsi", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -799,21 +681,17 @@ a wider integer, the value is sign-extended. If casting to a narrower
 integer, the value is truncated.
 """
 function index_cast(in::Value; out::IR.Type, location=Location())
-    results = IR.Type[out,]
-    operands = Value[in,]
+    results = IR.Type[out, ]
+    operands = Value[in, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arith.index_cast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.index_cast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -826,21 +704,17 @@ a wider integer, the value is zero-extended. If casting to a narrower
 integer, the value is truncated.
 """
 function index_castui(in::Value; out::IR.Type, location=Location())
-    results = IR.Type[out,]
-    operands = Value[in,]
+    results = IR.Type[out, ]
+    operands = Value[in, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arith.index_castui",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.index_castui", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -863,30 +737,20 @@ If one of the arguments is NaN, then the result is also NaN.
 %a = arith.maxf %b, %c : f64
 ```
 """
-function maxf(
-    lhs::Value,
-    rhs::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function maxf(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "arith.maxf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.maxf", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -894,25 +758,19 @@ end
 `maxsi`
 
 """
-function maxsi(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function maxsi(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.maxsi",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.maxsi", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -920,25 +778,19 @@ end
 `maxui`
 
 """
-function maxui(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function maxui(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.maxui",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.maxui", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -961,30 +813,20 @@ If one of the arguments is NaN, then the result is also NaN.
 %a = arith.minf %b, %c : f64
 ```
 """
-function minf(
-    lhs::Value,
-    rhs::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function minf(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "arith.minf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.minf", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -992,25 +834,19 @@ end
 `minsi`
 
 """
-function minsi(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function minsi(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.minsi",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.minsi", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1018,25 +854,19 @@ end
 `minui`
 
 """
-function minui(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function minui(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.minui",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.minui", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1064,30 +894,20 @@ floating point tensor.
 TODO: In the distant future, this will accept optional attributes for fast
 math, contraction, rounding mode, and other controls.
 """
-function mulf(
-    lhs::Value,
-    rhs::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function mulf(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "arith.mulf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.mulf", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1095,25 +915,19 @@ end
 `muli`
 
 """
-function muli(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function muli(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.muli",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.muli", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1138,30 +952,20 @@ the same operands.
 %x:2 = arith.mulsi_extended %y, %z : tensor<4x?xi8>
 ```
 """
-function mulsi_extended(
-    lhs::Value,
-    rhs::Value;
-    low=nothing::Union{Nothing,IR.Type},
-    high=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function mulsi_extended(lhs::Value, rhs::Value; low=nothing::Union{Nothing, IR.Type}, high=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(low) && push!(results, low)
     !isnothing(high) && push!(results, high)
-
-    return IR.create_operation(
-        "arith.mulsi_extended",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.mulsi_extended", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1186,30 +990,20 @@ the same operands.
 %x:2 = arith.mului_extended %y, %z : tensor<4x?xi8>
 ```
 """
-function mului_extended(
-    lhs::Value,
-    rhs::Value;
-    low=nothing::Union{Nothing,IR.Type},
-    high=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function mului_extended(lhs::Value, rhs::Value; low=nothing::Union{Nothing, IR.Type}, high=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(low) && push!(results, low)
     !isnothing(high) && push!(results, high)
-
-    return IR.create_operation(
-        "arith.mului_extended",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.mului_extended", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1234,29 +1028,20 @@ It has no standard attributes.
 %x = arith.negf %y : tensor<4x?xf8>
 ```
 """
-function negf(
-    operand::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function negf(operand::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "arith.negf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.negf", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1281,25 +1066,19 @@ standard attributes.
 %x = arith.ori %y, %z : tensor<4x?xi8>
 ```
 """
-function ori(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function ori(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.ori",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.ori", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1307,30 +1086,20 @@ end
 `remf`
 
 """
-function remf(
-    lhs::Value,
-    rhs::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function remf(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "arith.remf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.remf", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1356,25 +1125,19 @@ behavior.
 %x = arith.remsi %y, %z : tensor<4x?xi8>
 ```
 """
-function remsi(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function remsi(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.remsi",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.remsi", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1400,25 +1163,19 @@ behavior.
 %x = arith.remui %y, %z : tensor<4x?xi8>
 ```
 """
-function remui(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function remui(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.remui",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.remui", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1431,21 +1188,17 @@ rounded using the default rounding mode. When operating on vectors, casts
 elementwise.
 """
 function sitofp(in::Value; out::IR.Type, location=Location())
-    results = IR.Type[out,]
-    operands = Value[in,]
+    results = IR.Type[out, ]
+    operands = Value[in, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arith.sitofp",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.sitofp", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1463,25 +1216,19 @@ amount. The low order bits are filled with zeros.
 %3 = arith.shli %1, %2 : (i8, i8) -> i8    // %3 is 0b00101000
 ```
 """
-function shli(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function shli(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.shli",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.shli", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1503,25 +1250,19 @@ value (which means that the sign of the value is preserved).
 %5 = arith.shrsi %4, %2 : (i8, i8) -> i8   // %5 is 0b00001100
 ```
 """
-function shrsi(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function shrsi(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.shrsi",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.shrsi", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1540,25 +1281,19 @@ always filled with zeros.
 %3 = arith.shrui %1, %2 : (i8, i8) -> i8   // %3 is 0b00010100
 ```
 """
-function shrui(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function shrui(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.shrui",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.shrui", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1586,30 +1321,20 @@ floating point tensor.
 TODO: In the distant future, this will accept optional attributes for fast
 math, contraction, rounding mode, and other controls.
 """
-function subf(
-    lhs::Value,
-    rhs::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function subf(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "arith.subf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.subf", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1617,25 +1342,19 @@ end
 `subi`
 
 """
-function subi(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function subi(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.subi",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.subi", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1648,21 +1367,17 @@ If the value cannot be exactly represented, it is rounded using the default
 rounding mode. When operating on vectors, casts elementwise.
 """
 function truncf(in::Value; out::IR.Type, location=Location())
-    results = IR.Type[out,]
-    operands = Value[in,]
+    results = IR.Type[out, ]
+    operands = Value[in, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arith.truncf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.truncf", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1685,21 +1400,17 @@ The top-most (N - M) bits of the input are discarded.
 ```
 """
 function trunci(in::Value; out::IR.Type, location=Location())
-    results = IR.Type[out,]
-    operands = Value[in,]
+    results = IR.Type[out, ]
+    operands = Value[in, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arith.trunci",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.trunci", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1712,21 +1423,17 @@ rounded using the default rounding mode. When operating on vectors, casts
 elementwise.
 """
 function uitofp(in::Value; out::IR.Type, location=Location())
-    results = IR.Type[out,]
-    operands = Value[in,]
+    results = IR.Type[out, ]
+    operands = Value[in, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arith.uitofp",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.uitofp", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1751,25 +1458,19 @@ has no standard attributes.
 %x = arith.xori %y, %z : tensor<4x?xi8>
 ```
 """
-function xori(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function xori(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.xori",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.xori", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1803,29 +1504,19 @@ or tensor is chosen.
 %vx = arith.select %cond, %vtrue, %vfalse : vector<42xf32>
 ```
 """
-function select(
-    condition::Value,
-    true_value::Value,
-    false_value::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function select(condition::Value, true_value::Value, false_value::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[condition, true_value, false_value]
+    operands = Value[condition, true_value, false_value, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.select",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.select", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 

--- a/src/Dialects/16/ArmNeon.jl
+++ b/src/Dialects/16/ArmNeon.jl
@@ -1,8 +1,8 @@
 module arm_neon
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `intr_smull`
@@ -16,21 +16,17 @@ Source:
 https://developer.arm.com/architectures/instruction-sets/simd-isas/neon/intrinsics
 """
 function intr_smull(a::Value, b::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[a, b]
+    results = IR.Type[res, ]
+    operands = Value[a, b, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_neon.intr.smull",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_neon.intr.smull", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -47,21 +43,17 @@ res[i] := a[i] + dot_product(b[i, ...], c[i, ...])
 ```
 """
 function _2d_sdot(a::Value, b::Value, c::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[a, b, c]
+    results = IR.Type[res, ]
+    operands = Value[a, b, c, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_neon.2d.sdot",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_neon.2d.sdot", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -76,21 +68,17 @@ Source:
 https://developer.arm.com/architectures/instruction-sets/simd-isas/neon/intrinsics
 """
 function intr_sdot(a::Value, b::Value, c::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[a, b, c]
+    results = IR.Type[res, ]
+    operands = Value[a, b, c, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_neon.intr.sdot",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_neon.intr.sdot", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/16/ArmSVE.jl
+++ b/src/Dialects/16/ArmSVE.jl
@@ -1,31 +1,25 @@
 module arm_sve
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `intr_fadd`
 
 """
-function intr_fadd(
-    operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1, operand_2]
+function intr_fadd(operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, operand_2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.intr.fadd",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.intr.fadd", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -36,24 +30,18 @@ The `arm_sve.masked.addf` operation takes one scalable vector mask
 and two scalable vector operands, and perform floating point addition on active lanes. Inactive lanes will keep the value of
 the first operand.
 """
-function masked_addf(
-    mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[mask, src1, src2]
+function masked_addf(mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[mask, src1, src2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.masked.addf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.masked.addf", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -61,24 +49,18 @@ end
 `intr_add`
 
 """
-function intr_add(
-    operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1, operand_2]
+function intr_add(operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, operand_2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.intr.add",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.intr.add", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -89,24 +71,18 @@ The `arm_sve.masked.addi` operation takes one scalable vector mask
 and two scalable vector operands, and perform integer addition on active lanes. Inactive lanes will keep the value of
 the first operand.
 """
-function masked_addi(
-    mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[mask, src1, src2]
+function masked_addi(mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[mask, src1, src2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.masked.addi",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.masked.addi", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -114,24 +90,18 @@ end
 `intr_fdiv`
 
 """
-function intr_fdiv(
-    operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1, operand_2]
+function intr_fdiv(operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, operand_2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.intr.fdiv",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.intr.fdiv", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -142,24 +112,18 @@ The `arm_sve.masked.divf` operation takes one scalable vector mask
 and two scalable vector operands, and perform floating point division on active lanes. Inactive lanes will keep the value of
 the first operand.
 """
-function masked_divf(
-    mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[mask, src1, src2]
+function masked_divf(mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[mask, src1, src2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.masked.divf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.masked.divf", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -167,24 +131,18 @@ end
 `intr_fmul`
 
 """
-function intr_fmul(
-    operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1, operand_2]
+function intr_fmul(operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, operand_2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.intr.fmul",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.intr.fmul", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -195,24 +153,18 @@ The `arm_sve.masked.mulf` operation takes one scalable vector mask
 and two scalable vector operands, and perform floating point multiplication on active lanes. Inactive lanes will keep the value of
 the first operand.
 """
-function masked_mulf(
-    mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[mask, src1, src2]
+function masked_mulf(mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[mask, src1, src2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.masked.mulf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.masked.mulf", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -220,24 +172,18 @@ end
 `intr_mul`
 
 """
-function intr_mul(
-    operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1, operand_2]
+function intr_mul(operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, operand_2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.intr.mul",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.intr.mul", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -248,24 +194,18 @@ The `arm_sve.masked.muli` operation takes one scalable vector mask
 and two scalable vector operands, and perform integer multiplication on active lanes. Inactive lanes will keep the value of
 the first operand.
 """
-function masked_muli(
-    mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[mask, src1, src2]
+function masked_muli(mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[mask, src1, src2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.masked.muli",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.masked.muli", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -273,24 +213,18 @@ end
 `intr_sdiv`
 
 """
-function intr_sdiv(
-    operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1, operand_2]
+function intr_sdiv(operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, operand_2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.intr.sdiv",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.intr.sdiv", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -301,24 +235,18 @@ The `arm_sve.masked.divi_signed` operation takes one scalable vector mask
 and two scalable vector operands, and perform integer signed division on active lanes. Inactive lanes will keep the value of
 the first operand.
 """
-function masked_divi_signed(
-    mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[mask, src1, src2]
+function masked_divi_signed(mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[mask, src1, src2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.masked.divi_signed",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.masked.divi_signed", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -326,24 +254,18 @@ end
 `intr_fsub`
 
 """
-function intr_fsub(
-    operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1, operand_2]
+function intr_fsub(operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, operand_2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.intr.fsub",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.intr.fsub", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -354,24 +276,18 @@ The `arm_sve.masked.subf` operation takes one scalable vector mask
 and two scalable vector operands, and perform floating point subtraction on active lanes. Inactive lanes will keep the value of
 the first operand.
 """
-function masked_subf(
-    mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[mask, src1, src2]
+function masked_subf(mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[mask, src1, src2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.masked.subf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.masked.subf", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -379,24 +295,18 @@ end
 `intr_sub`
 
 """
-function intr_sub(
-    operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1, operand_2]
+function intr_sub(operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, operand_2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.intr.sub",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.intr.sub", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -407,24 +317,18 @@ The `arm_sve.masked.subi` operation takes one scalable vector mask
 and two scalable vector operands, and perform integer subtraction on active lanes. Inactive lanes will keep the value of
 the first operand.
 """
-function masked_subi(
-    mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[mask, src1, src2]
+function masked_subi(mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[mask, src1, src2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.masked.subi",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.masked.subi", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -432,24 +336,18 @@ end
 `intr_udiv`
 
 """
-function intr_udiv(
-    operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1, operand_2]
+function intr_udiv(operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, operand_2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.intr.udiv",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.intr.udiv", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -460,24 +358,18 @@ The `arm_sve.masked.divi_unsigned` operation takes one scalable vector mask
 and two scalable vector operands, and perform integer unsigned division on active lanes. Inactive lanes will keep the value of
 the first operand.
 """
-function masked_divi_unsigned(
-    mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[mask, src1, src2]
+function masked_divi_unsigned(mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[mask, src1, src2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.masked.divi_unsigned",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.masked.divi_unsigned", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -485,24 +377,18 @@ end
 `intr_sdot`
 
 """
-function intr_sdot(
-    operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1, operand_2]
+function intr_sdot(operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, operand_2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.intr.sdot",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.intr.sdot", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -521,21 +407,17 @@ Source:
 https://developer.arm.com/documentation/100987/0000
 """
 function sdot(acc::Value, src1::Value, src2::Value; dst::IR.Type, location=Location())
-    results = IR.Type[dst,]
-    operands = Value[acc, src1, src2]
+    results = IR.Type[dst, ]
+    operands = Value[acc, src1, src2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.sdot",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.sdot", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -543,24 +425,18 @@ end
 `intr_smmla`
 
 """
-function intr_smmla(
-    operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1, operand_2]
+function intr_smmla(operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, operand_2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.intr.smmla",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.intr.smmla", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -582,21 +458,17 @@ Source:
 https://developer.arm.com/documentation/100987/0000
 """
 function smmla(acc::Value, src1::Value, src2::Value; dst::IR.Type, location=Location())
-    results = IR.Type[dst,]
-    operands = Value[acc, src1, src2]
+    results = IR.Type[dst, ]
+    operands = Value[acc, src1, src2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.smmla",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.smmla", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -604,24 +476,18 @@ end
 `intr_udot`
 
 """
-function intr_udot(
-    operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1, operand_2]
+function intr_udot(operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, operand_2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.intr.udot",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.intr.udot", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -640,21 +506,17 @@ Source:
 https://developer.arm.com/documentation/100987/0000
 """
 function udot(acc::Value, src1::Value, src2::Value; dst::IR.Type, location=Location())
-    results = IR.Type[dst,]
-    operands = Value[acc, src1, src2]
+    results = IR.Type[dst, ]
+    operands = Value[acc, src1, src2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.udot",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.udot", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -662,24 +524,18 @@ end
 `intr_ummla`
 
 """
-function intr_ummla(
-    operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1, operand_2]
+function intr_ummla(operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, operand_2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.intr.ummla",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.intr.ummla", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -701,21 +557,17 @@ Source:
 https://developer.arm.com/documentation/100987/0000
 """
 function ummla(acc::Value, src1::Value, src2::Value; dst::IR.Type, location=Location())
-    results = IR.Type[dst,]
-    operands = Value[acc, src1, src2]
+    results = IR.Type[dst, ]
+    operands = Value[acc, src1, src2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.ummla",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.ummla", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/16/Async.jl
+++ b/src/Dialects/16/Async.jl
@@ -1,8 +1,8 @@
 module async
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `add_to_group`
@@ -19,25 +19,19 @@ for the group lifetime.
 %2 = async.add_to_group %1, %0 : !async.token
 ```
 """
-function add_to_group(
-    operand::Value, group::Value; rank=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function add_to_group(operand::Value, group::Value; rank=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand, group]
+    operands = Value[operand, group, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(rank) && push!(results, rank)
-
-    return IR.create_operation(
-        "async.add_to_group",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.add_to_group", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -63,20 +57,16 @@ async.await_all %0
 """
 function await_all(operand::Value; location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "async.await_all",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.await_all", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -96,23 +86,19 @@ async.await %0 : !async.token
 %2 = async.await %1 : !async.value<f32>
 ```
 """
-function await(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function await(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "async.await",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.await", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -130,24 +116,18 @@ is encoded as a symbol reference attribute named \"callee\".
 %2 = async.call @my_add(%0, %1) : (f32, f32) -> !async.value<f32>
 ```
 """
-function call(
-    operands::Vector{Value}; result_0::Vector{IR.Type}, callee, location=Location()
-)
-    results = IR.Type[result_0...,]
-    operands = Value[operands...,]
+function call(operands_::Vector{Value}; result_0::Vector{IR.Type}, callee, location=Location())
+    results = IR.Type[result_0..., ]
+    operands = Value[operands_..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("callee", callee),]
-
-    return IR.create_operation(
-        "async.call",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("callee", callee), ]
+    
+    IR.create_operation(
+        "async.call", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -157,23 +137,19 @@ end
 The `async.coro.begin` allocates a coroutine frame and returns a handle to
 the coroutine.
 """
-function coro_begin(id::Value; handle=nothing::Union{Nothing,IR.Type}, location=Location())
+function coro_begin(id::Value; handle=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[id,]
+    operands = Value[id, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(handle) && push!(results, handle)
-
-    return IR.create_operation(
-        "async.coro.begin",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.coro.begin", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -186,20 +162,16 @@ coroutine. It the start part of the coroutine is is no-op.
 """
 function coro_end(handle::Value; location=Location())
     results = IR.Type[]
-    operands = Value[handle,]
+    operands = Value[handle, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "async.coro.end",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.coro.end", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -211,20 +183,16 @@ async.coro.begin operation.
 """
 function coro_free(id::Value, handle::Value; location=Location())
     results = IR.Type[]
-    operands = Value[id, handle]
+    operands = Value[id, handle, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "async.coro.free",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.coro.free", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -233,23 +201,19 @@ end
 
 The `async.coro.id` returns a switched-resume coroutine identifier.
 """
-function coro_id(; id=nothing::Union{Nothing,IR.Type}, location=Location())
+function coro_id(; id=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(id) && push!(results, id)
-
-    return IR.create_operation(
-        "async.coro.id",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.coro.id", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -258,25 +222,19 @@ end
 
 The `async.coro.saves` saves the coroutine state.
 """
-function coro_save(
-    handle::Value; state=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function coro_save(handle::Value; state=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[handle,]
+    operands = Value[handle, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(state) && push!(results, state)
-
-    return IR.create_operation(
-        "async.coro.save",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.coro.save", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -292,28 +250,18 @@ In switched-resume lowering coroutine can be already in resumed state when
 suspend operation is called, in this case control will be transferred to the
 `resume` successor skipping the `suspend` successor.
 """
-function coro_suspend(
-    state::Value;
-    suspendDest::Block,
-    resumeDest::Block,
-    cleanupDest::Block,
-    location=Location(),
-)
+function coro_suspend(state::Value; suspendDest::Block, resumeDest::Block, cleanupDest::Block, location=Location())
     results = IR.Type[]
-    operands = Value[state,]
+    operands = Value[state, ]
     owned_regions = Region[]
-    successors = Block[suspendDest, resumeDest, cleanupDest]
+    successors = Block[suspendDest, resumeDest, cleanupDest, ]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "async.coro.suspend",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.coro.suspend", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -334,25 +282,19 @@ wait until the number of added tokens or values reaches the group size.
 async.await_all %group
 ```
 """
-function create_group(
-    size::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function create_group(size::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[size,]
+    operands = Value[size, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "async.create_group",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.create_group", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -397,30 +339,19 @@ In the example above asynchronous execution starts only after dependency
 token and value argument become ready. Unwrapped value passed to the
 attached body region as an %unwrapped value of f32 type.
 """
-function execute(
-    dependencies::Vector{Value},
-    bodyOperands::Vector{Value};
-    token::IR.Type,
-    bodyResults::Vector{IR.Type},
-    bodyRegion::Region,
-    location=Location(),
-)
-    results = IR.Type[token, bodyResults...]
-    operands = Value[dependencies..., bodyOperands...]
-    owned_regions = Region[bodyRegion,]
+function execute(dependencies::Vector{Value}, bodyOperands::Vector{Value}; token::IR.Type, bodyResults::Vector{IR.Type}, bodyRegion::Region, location=Location())
+    results = IR.Type[token, bodyResults..., ]
+    operands = Value[dependencies..., bodyOperands..., ]
+    owned_regions = Region[bodyRegion, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(dependencies), length(bodyOperands)]))
-
-    return IR.create_operation(
-        "async.execute",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(dependencies), length(bodyOperands), ]))
+    
+    IR.create_operation(
+        "async.execute", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -455,36 +386,21 @@ async.func @async.2() -> !async.token, !async.value<i32> {
 }
 ```
 """
-function func(;
-    sym_name,
-    function_type,
-    sym_visibility=nothing,
-    arg_attrs=nothing,
-    res_attrs=nothing,
-    body::Region,
-    location=Location(),
-)
+function func(; sym_name, function_type, sym_visibility=nothing, arg_attrs=nothing, res_attrs=nothing, body::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[body,]
+    owned_regions = Region[body, ]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("sym_name", sym_name), namedattribute("function_type", function_type)
-    ]
-    !isnothing(sym_visibility) &&
-        push!(attributes, namedattribute("sym_visibility", sym_visibility))
+    attributes = NamedAttribute[namedattribute("sym_name", sym_name), namedattribute("function_type", function_type), ]
+    !isnothing(sym_visibility) && push!(attributes, namedattribute("sym_visibility", sym_visibility))
     !isnothing(arg_attrs) && push!(attributes, namedattribute("arg_attrs", arg_attrs))
     !isnothing(res_attrs) && push!(attributes, namedattribute("res_attrs", res_attrs))
-
-    return IR.create_operation(
-        "async.func",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.func", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -501,22 +417,18 @@ async.func @foo() : !async.token {
 }
 ```
 """
-function return_(operands::Vector{Value}; location=Location())
+function return_(operands_::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[operands...,]
+    operands = Value[operands_..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "async.return",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.return", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -528,20 +440,16 @@ The `async.runtime.add_ref` operation adds a reference(s) to async value
 """
 function runtime_add_ref(operand::Value; count, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("count", count),]
-
-    return IR.create_operation(
-        "async.runtime.add_ref",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("count", count), ]
+    
+    IR.create_operation(
+        "async.runtime.add_ref", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -551,25 +459,19 @@ end
 The `async.runtime.add_to_group` adds an async token or value to the async
 group. Returns the rank of the added element in the group.
 """
-function runtime_add_to_group(
-    operand::Value, group::Value; rank=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function runtime_add_to_group(operand::Value, group::Value; rank=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand, group]
+    operands = Value[operand, group, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(rank) && push!(results, rank)
-
-    return IR.create_operation(
-        "async.runtime.add_to_group",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.runtime.add_to_group", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -582,20 +484,16 @@ the runtime.
 """
 function runtime_await_and_resume(operand::Value, handle::Value; location=Location())
     results = IR.Type[]
-    operands = Value[operand, handle]
+    operands = Value[operand, handle, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "async.runtime.await_and_resume",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.runtime.await_and_resume", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -607,20 +505,16 @@ operand becomes available or error.
 """
 function runtime_await(operand::Value; location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "async.runtime.await",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.runtime.await", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -630,25 +524,19 @@ end
 The `async.runtime.create_group` operation creates an async dialect group
 of the given size. Group created in the empty state.
 """
-function runtime_create_group(
-    size::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function runtime_create_group(size::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[size,]
+    operands = Value[size, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "async.runtime.create_group",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.runtime.create_group", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -659,21 +547,17 @@ The `async.runtime.create` operation creates an async dialect token or
 value. Tokens and values are created in the non-ready state.
 """
 function runtime_create(; result::IR.Type, location=Location())
-    results = IR.Type[result,]
+    results = IR.Type[result, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "async.runtime.create",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.runtime.create", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -685,20 +569,16 @@ The `async.runtime.drop_ref` operation drops a reference(s) to async value
 """
 function runtime_drop_ref(operand::Value; count, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("count", count),]
-
-    return IR.create_operation(
-        "async.runtime.drop_ref",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("count", count), ]
+    
+    IR.create_operation(
+        "async.runtime.drop_ref", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -710,25 +590,19 @@ group (any of the async runtime values) is in the error state. It is the
 caller responsibility to check error state after the call to `await` or
 resuming after `await_and_resume`.
 """
-function runtime_is_error(
-    operand::Value; is_error=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function runtime_is_error(operand::Value; is_error=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(is_error) && push!(results, is_error)
-
-    return IR.create_operation(
-        "async.runtime.is_error",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.runtime.is_error", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -738,25 +612,18 @@ end
 The `async.runtime.load` operation loads the value from the runtime
 async.value storage.
 """
-function runtime_load(
-    storage::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
-    results = IR.Type[]
-    operands = Value[storage,]
+function runtime_load(storage::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[storage, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "async.runtime.load",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "async.runtime.load", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -766,25 +633,19 @@ end
 The `async.runtime.num_worker_threads` operation gets the number of threads
 in the threadpool from the runtime.
 """
-function runtime_num_worker_threads(;
-    result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function runtime_num_worker_threads(; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "async.runtime.num_worker_threads",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.runtime.num_worker_threads", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -796,20 +657,16 @@ managed by the runtime.
 """
 function runtime_resume(handle::Value; location=Location())
     results = IR.Type[]
-    operands = Value[handle,]
+    operands = Value[handle, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "async.runtime.resume",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.runtime.resume", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -821,20 +678,16 @@ state to available.
 """
 function runtime_set_available(operand::Value; location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "async.runtime.set_available",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.runtime.set_available", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -846,20 +699,16 @@ state to error.
 """
 function runtime_set_error(operand::Value; location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "async.runtime.set_error",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.runtime.set_error", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -871,20 +720,16 @@ async.value storage.
 """
 function runtime_store(value::Value, storage::Value; location=Location())
     results = IR.Type[]
-    operands = Value[value, storage]
+    operands = Value[value, storage, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "async.runtime.store",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.runtime.store", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -894,22 +739,18 @@ end
 The `async.yield` is a special terminator operation for the block inside
 `async.execute` operation.
 """
-function yield(operands::Vector{Value}; location=Location())
+function yield(operands_::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[operands...,]
+    operands = Value[operands_..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "async.yield",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.yield", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/16/Bufferization.jl
+++ b/src/Dialects/16/Bufferization.jl
@@ -1,8 +1,8 @@
 module bufferization
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `alloc_tensor`
@@ -55,46 +55,22 @@ return %0 : tensor<?x?xf32, #SparseMatrix>
   : tensor<?x?xf32, #SparseMatrix>
 ```
 """
-function alloc_tensor(
-    dynamic_sizes::Vector{Value},
-    copy=nothing::Union{Nothing,Value};
-    size_hint=nothing::Union{Nothing,Value},
-    result::IR.Type,
-    memory_space=nothing,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[dynamic_sizes...,]
+function alloc_tensor(dynamic_sizes::Vector{Value}, copy=nothing::Union{Nothing, Value}; size_hint=nothing::Union{Nothing, Value}, result::IR.Type, memory_space=nothing, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[dynamic_sizes..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(copy) && push!(operands, copy)
     !isnothing(size_hint) && push!(operands, size_hint)
-    push!(
-        attributes,
-        operandsegmentsizes([
-            length(dynamic_sizes),
-            if (copy == nothing)
-                0
-            elseif 1(size_hint == nothing)
-                0
-            else
-                1
-            end,
-        ]),
-    )
-    !isnothing(memory_space) &&
-        push!(attributes, namedattribute("memory_space", memory_space))
-
-    return IR.create_operation(
-        "bufferization.alloc_tensor",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(dynamic_sizes), isnothing(copy) ? 0 : 1, isnothing(size_hint) ? 0 : 1, ]))
+    !isnothing(memory_space) && push!(attributes, namedattribute("memory_space", memory_space))
+    
+    IR.create_operation(
+        "bufferization.alloc_tensor", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -115,21 +91,17 @@ of the clone operation after the clone operation thus leads to undefined
 behavior.
 """
 function clone(input::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input,]
+    results = IR.Type[output, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "bufferization.clone",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "bufferization.clone", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -161,20 +133,16 @@ bufferization.dealloc_tensor %tensor : tensor<1024x1024xf64, #CSR>
 """
 function dealloc_tensor(tensor::Value; location=Location())
     results = IR.Type[]
-    operands = Value[tensor,]
+    operands = Value[tensor, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "bufferization.dealloc_tensor",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "bufferization.dealloc_tensor", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -196,21 +164,17 @@ This operation is a specialized variant of the built-in
 gradual bufferization.
 """
 function to_memref(tensor::Value; memref::IR.Type, location=Location())
-    results = IR.Type[memref,]
-    operands = Value[tensor,]
+    results = IR.Type[memref, ]
+    operands = Value[tensor, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "bufferization.to_memref",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "bufferization.to_memref", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -235,25 +199,18 @@ involving tensors and memrefs.
 If tensor load is used in the bufferization steps, mutating the source
 buffer after loading leads to undefined behavior.
 """
-function to_tensor(
-    memref::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
-    results = IR.Type[]
-    operands = Value[memref,]
+function to_tensor(memref::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[memref, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "bufferization.to_tensor",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "bufferization.to_tensor", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/16/Builtin.jl
+++ b/src/Dialects/16/Builtin.jl
@@ -1,8 +1,8 @@
 module builtin
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `module_`
@@ -23,27 +23,20 @@ module {
 }
 ```
 """
-function module_(;
-    sym_name=nothing, sym_visibility=nothing, bodyRegion::Region, location=Location()
-)
+function module_(; sym_name=nothing, sym_visibility=nothing, bodyRegion::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[bodyRegion,]
+    owned_regions = Region[bodyRegion, ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(sym_name) && push!(attributes, namedattribute("sym_name", sym_name))
-    !isnothing(sym_visibility) &&
-        push!(attributes, namedattribute("sym_visibility", sym_visibility))
-
-    return IR.create_operation(
-        "builtin.module",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(sym_visibility) && push!(attributes, namedattribute("sym_visibility", sym_visibility))
+    
+    IR.create_operation(
+        "builtin.module", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -81,24 +74,18 @@ operands of arity 0-N.
 %result3 = unrealized_conversion_cast %operand, %operand : !foo.type, !foo.type to !bar.tuple_type<!foo.type, !foo.type>
 ```
 """
-function unrealized_conversion_cast(
-    inputs::Vector{Value}; outputs::Vector{IR.Type}, location=Location()
-)
-    results = IR.Type[outputs...,]
-    operands = Value[inputs...,]
+function unrealized_conversion_cast(inputs::Vector{Value}; outputs::Vector{IR.Type}, location=Location())
+    results = IR.Type[outputs..., ]
+    operands = Value[inputs..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "builtin.unrealized_conversion_cast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "builtin.unrealized_conversion_cast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/16/Complex.jl
+++ b/src/Dialects/16/Complex.jl
@@ -1,8 +1,8 @@
 module complex
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `abs`
@@ -15,23 +15,18 @@ The `abs` op takes a single complex number and computes its absolute value.
 %a = complex.abs %b : complex<f32>
 ```
 """
-function abs(complex::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
-    results = IR.Type[]
-    operands = Value[complex,]
+function abs(complex::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[complex, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "complex.abs",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "complex.abs", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -46,25 +41,19 @@ The `add` operation takes two complex numbers and returns their sum.
 %a = complex.add %b, %c : complex<f32>
 ```
 """
-function add(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function add(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "complex.add",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.add", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -79,23 +68,18 @@ The `angle` op takes a single complex number and computes its argument value wit
      %a = complex.angle %b : complex<f32>
 ```
 """
-function angle(complex::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
-    results = IR.Type[]
-    operands = Value[complex,]
+function angle(complex::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[complex, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "complex.angle",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "complex.angle", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -111,25 +95,19 @@ atan2(y, x) = -i * log((x + i * y) / sqrt(x**2 + y**2))
 %a = complex.atan2 %b, %c : complex<f32>
 ```
 """
-function atan2(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function atan2(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "complex.atan2",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.atan2", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -145,23 +123,19 @@ complex conjugate.
 %a = complex.conj %b: complex<f32>
 ```
 """
-function conj(complex::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function conj(complex::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[complex,]
+    operands = Value[complex, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "complex.conj",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.conj", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -178,21 +152,17 @@ attribute containing the real and imaginary parts.
 ```
 """
 function constant(; complex::IR.Type, value, location=Location())
-    results = IR.Type[complex,]
+    results = IR.Type[complex, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("value", value),]
-
-    return IR.create_operation(
-        "complex.constant",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("value", value), ]
+    
+    IR.create_operation(
+        "complex.constant", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -208,23 +178,19 @@ it, i.e. `cos(x)`, where `x` is the input value.
 %a = complex.cos %b : complex<f32>
 ```
 """
-function cos(complex::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function cos(complex::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[complex,]
+    operands = Value[complex, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "complex.cos",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.cos", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -241,21 +207,17 @@ floating-point operands, the real and the imaginary part.
 ```
 """
 function create(real::Value, imaginary::Value; complex::IR.Type, location=Location())
-    results = IR.Type[complex,]
-    operands = Value[real, imaginary]
+    results = IR.Type[complex, ]
+    operands = Value[real, imaginary, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "complex.create",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.create", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -269,25 +231,19 @@ division:
 %a = complex.div %b, %c : complex<f32>
 ```
 """
-function div(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function div(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "complex.div",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.div", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -302,25 +258,19 @@ The `eq` op takes two complex numbers and returns whether they are equal.
 %a = complex.eq %b, %c : complex<f32>
 ```
 """
-function eq(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function eq(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "complex.eq",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.eq", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -337,23 +287,19 @@ it, i.e. `exp(x)` or `e^(x)`, where `x` is the input value.
 %a = complex.exp %b : complex<f32>
 ```
 """
-function exp(complex::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function exp(complex::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[complex,]
+    operands = Value[complex, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "complex.exp",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.exp", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -374,23 +320,19 @@ complex.expm1(x) := complex.exp(x) - 1
 %a = complex.expm1 %b : complex<f32>
 ```
 """
-function expm1(complex::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function expm1(complex::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[complex,]
+    operands = Value[complex, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "complex.expm1",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.expm1", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -405,23 +347,18 @@ The `im` op takes a single complex number and extracts the imaginary part.
 %a = complex.im %b : complex<f32>
 ```
 """
-function im(complex::Value; imaginary=nothing::Union{Nothing,IR.Type}, location=Location())
-    results = IR.Type[]
-    operands = Value[complex,]
+function im(complex::Value; imaginary::IR.Type, location=Location())
+    results = IR.Type[imaginary, ]
+    operands = Value[complex, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(imaginary) && push!(results, imaginary)
-
-    return IR.create_operation(
-        "complex.im",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "complex.im", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -439,23 +376,19 @@ approximately equal to 2.718281.
 %a = complex.log1p %b : complex<f32>
 ```
 """
-function log1p(complex::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function log1p(complex::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[complex,]
+    operands = Value[complex, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "complex.log1p",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.log1p", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -472,23 +405,19 @@ logarithm of it, i.e. `log(x)` or `log_e(x)`, where `x` is the input value.
 %a = complex.log %b : complex<f32>
 ```
 """
-function log(complex::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function log(complex::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[complex,]
+    operands = Value[complex, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "complex.log",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.log", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -501,25 +430,19 @@ The `mul` operation takes two complex numbers and returns their product:
 %a = complex.mul %b, %c : complex<f32>
 ```
 """
-function mul(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function mul(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "complex.mul",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.mul", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -534,23 +457,19 @@ The `neg` op takes a single complex number `complex` and returns `-complex`.
 %a = complex.neg %b : complex<f32>
 ```
 """
-function neg(complex::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function neg(complex::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[complex,]
+    operands = Value[complex, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "complex.neg",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.neg", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -566,25 +485,19 @@ equal.
 %a = complex.neq %b, %c : complex<f32>
 ```
 """
-function neq(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function neq(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "complex.neq",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.neq", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -600,25 +513,19 @@ exponent.
 %a = complex.pow %b, %c : complex<f32>
 ```
 """
-function pow(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function pow(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "complex.pow",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.pow", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -633,23 +540,18 @@ The `re` op takes a single complex number and extracts the real part.
 %a = complex.re %b : complex<f32>
 ```
 """
-function re(complex::Value; real=nothing::Union{Nothing,IR.Type}, location=Location())
-    results = IR.Type[]
-    operands = Value[complex,]
+function re(complex::Value; real::IR.Type, location=Location())
+    results = IR.Type[real, ]
+    operands = Value[complex, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(real) && push!(results, real)
-
-    return IR.create_operation(
-        "complex.re",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "complex.re", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -664,23 +566,19 @@ The `rsqrt` operation computes reciprocal of square root.
 %a = complex.rsqrt %b : complex<f32>
 ```
 """
-function rsqrt(complex::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function rsqrt(complex::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[complex,]
+    operands = Value[complex, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "complex.rsqrt",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.rsqrt", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -696,23 +594,19 @@ it, i.e. `y = sign(x) = x / |x|` if `x != 0`, otherwise `y = 0`.
 %a = complex.sign %b : complex<f32>
 ```
 """
-function sign(complex::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function sign(complex::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[complex,]
+    operands = Value[complex, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "complex.sign",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.sign", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -728,23 +622,19 @@ it, i.e. `sin(x)`, where `x` is the input value.
 %a = complex.sin %b : complex<f32>
 ```
 """
-function sin(complex::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function sin(complex::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[complex,]
+    operands = Value[complex, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "complex.sin",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.sin", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -759,23 +649,19 @@ The `sqrt` operation takes a complex number and returns its square root.
 %a = complex.sqrt %b : complex<f32>
 ```
 """
-function sqrt(complex::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function sqrt(complex::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[complex,]
+    operands = Value[complex, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "complex.sqrt",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.sqrt", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -790,25 +676,19 @@ The `sub` operation takes two complex numbers and returns their difference.
 %a = complex.sub %b, %c : complex<f32>
 ```
 """
-function sub(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function sub(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "complex.sub",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.sub", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -824,23 +704,19 @@ it, i.e. `tan(x)`, where `x` is the input value.
 %a = complex.tan %b : complex<f32>
 ```
 """
-function tan(complex::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function tan(complex::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[complex,]
+    operands = Value[complex, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "complex.tan",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.tan", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -856,23 +732,19 @@ tangent.
 %a = complex.tanh %b : complex<f32>
 ```
 """
-function tanh(complex::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function tanh(complex::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[complex,]
+    operands = Value[complex, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "complex.tanh",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.tanh", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 

--- a/src/Dialects/16/ControlFlow.jl
+++ b/src/Dialects/16/ControlFlow.jl
@@ -1,8 +1,8 @@
 module cf
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `assert`
@@ -20,20 +20,16 @@ assert %b, \"Expected ... to be true\"
 """
 function assert(arg::Value; msg, location=Location())
     results = IR.Type[]
-    operands = Value[arg,]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("msg", msg),]
-
-    return IR.create_operation(
-        "cf.assert",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("msg", msg), ]
+    
+    IR.create_operation(
+        "cf.assert", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -56,20 +52,16 @@ target block.
 """
 function br(destOperands::Vector{Value}; dest::Block, location=Location())
     results = IR.Type[]
-    operands = Value[destOperands...,]
+    operands = Value[destOperands..., ]
     owned_regions = Region[]
-    successors = Block[dest,]
+    successors = Block[dest, ]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "cf.br",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "cf.br", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -101,33 +93,19 @@ func.func @select(%a: i32, %b: i32, %flag: i1) -> i32 {
 }
 ```
 """
-function cond_br(
-    condition::Value,
-    trueDestOperands::Vector{Value},
-    falseDestOperands::Vector{Value};
-    trueDest::Block,
-    falseDest::Block,
-    location=Location(),
-)
+function cond_br(condition::Value, trueDestOperands::Vector{Value}, falseDestOperands::Vector{Value}; trueDest::Block, falseDest::Block, location=Location())
     results = IR.Type[]
-    operands = Value[condition, trueDestOperands..., falseDestOperands...]
+    operands = Value[condition, trueDestOperands..., falseDestOperands..., ]
     owned_regions = Region[]
-    successors = Block[trueDest, falseDest]
+    successors = Block[trueDest, falseDest, ]
     attributes = NamedAttribute[]
-    push!(
-        attributes,
-        operandsegmentsizes([1, length(trueDestOperands), length(falseDestOperands)]),
-    )
-
-    return IR.create_operation(
-        "cf.cond_br",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([1, length(trueDestOperands), length(falseDestOperands), ]))
+    
+    IR.create_operation(
+        "cf.cond_br", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -150,37 +128,20 @@ switch %flag : i32, [
 ]
 ```
 """
-function switch(
-    flag::Value,
-    defaultOperands::Vector{Value},
-    caseOperands::Vector{Value};
-    case_values=nothing,
-    case_operand_segments,
-    defaultDestination::Block,
-    caseDestinations::Vector{Block},
-    location=Location(),
-)
+function switch(flag::Value, defaultOperands::Vector{Value}, caseOperands::Vector{Value}; case_values=nothing, case_operand_segments, defaultDestination::Block, caseDestinations::Vector{Block}, location=Location())
     results = IR.Type[]
-    operands = Value[flag, defaultOperands..., caseOperands...]
+    operands = Value[flag, defaultOperands..., caseOperands..., ]
     owned_regions = Region[]
-    successors = Block[defaultDestination, caseDestinations...]
-    attributes = NamedAttribute[namedattribute(
-        "case_operand_segments", case_operand_segments
-    ),]
-    push!(
-        attributes, operandsegmentsizes([1, length(defaultOperands), length(caseOperands)])
-    )
+    successors = Block[defaultDestination, caseDestinations..., ]
+    attributes = NamedAttribute[namedattribute("case_operand_segments", case_operand_segments), ]
+    push!(attributes, operandsegmentsizes([1, length(defaultOperands), length(caseOperands), ]))
     !isnothing(case_values) && push!(attributes, namedattribute("case_values", case_values))
-
-    return IR.create_operation(
-        "cf.switch",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "cf.switch", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/16/EmitC.jl
+++ b/src/Dialects/16/EmitC.jl
@@ -1,8 +1,8 @@
 module emitc
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `apply`
@@ -23,21 +23,17 @@ can be applied to a single operand.
 ```
 """
 function apply(operand::Value; result::IR.Type, applicableOperator, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand,]
+    results = IR.Type[result, ]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("applicableOperator", applicableOperator),]
-
-    return IR.create_operation(
-        "emitc.apply",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("applicableOperator", applicableOperator), ]
+    
+    IR.create_operation(
+        "emitc.apply", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -60,32 +56,20 @@ specifying order of operands and attributes in the call as follows:
 %0 = \"emitc.call\"() {callee = \"foo\"} : () -> i32
 ```
 """
-function call(
-    operands::Vector{Value};
-    result_0::Vector{IR.Type},
-    callee,
-    args=nothing,
-    template_args=nothing,
-    location=Location(),
-)
-    results = IR.Type[result_0...,]
-    operands = Value[operands...,]
+function call(operands_::Vector{Value}; result_0::Vector{IR.Type}, callee, args=nothing, template_args=nothing, location=Location())
+    results = IR.Type[result_0..., ]
+    operands = Value[operands_..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("callee", callee),]
+    attributes = NamedAttribute[namedattribute("callee", callee), ]
     !isnothing(args) && push!(attributes, namedattribute("args", args))
-    !isnothing(template_args) &&
-        push!(attributes, namedattribute("template_args", template_args))
-
-    return IR.create_operation(
-        "emitc.call",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(template_args) && push!(attributes, namedattribute("template_args", template_args))
+    
+    IR.create_operation(
+        "emitc.call", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -108,21 +92,17 @@ and EmitC types.
 ```
 """
 function cast(source::Value; dest::IR.Type, location=Location())
-    results = IR.Type[dest,]
-    operands = Value[source,]
+    results = IR.Type[dest, ]
+    operands = Value[source, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "emitc.cast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "emitc.cast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -149,21 +129,17 @@ it should not be used with pointers.
 ```
 """
 function constant(; result_0::IR.Type, value, location=Location())
-    results = IR.Type[result_0,]
+    results = IR.Type[result_0, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("value", value),]
-
-    return IR.create_operation(
-        "emitc.constant",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("value", value), ]
+    
+    IR.create_operation(
+        "emitc.constant", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -194,19 +170,14 @@ function include_(; include_, is_standard_include=nothing, location=Location())
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("include", include_),]
-    !isnothing(is_standard_include) &&
-        push!(attributes, namedattribute("is_standard_include", is_standard_include))
-
-    return IR.create_operation(
-        "emitc.include",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("include", include_), ]
+    !isnothing(is_standard_include) && push!(attributes, namedattribute("is_standard_include", is_standard_include))
+    
+    IR.create_operation(
+        "emitc.include", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -245,21 +216,17 @@ emitc.call \"write\"(%2, %3) : (!emitc.ptr<i32>, !emitc.ptr<i32>) -> ()
 ```
 """
 function variable(; result_0::IR.Type, value, location=Location())
-    results = IR.Type[result_0,]
+    results = IR.Type[result_0, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("value", value),]
-
-    return IR.create_operation(
-        "emitc.variable",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("value", value), ]
+    
+    IR.create_operation(
+        "emitc.variable", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/16/Func.jl
+++ b/src/Dialects/16/Func.jl
@@ -1,8 +1,8 @@
 module func
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `call_indirect`
@@ -21,27 +21,18 @@ Function values can be created with the
 %result = func.call_indirect %func(%0, %1) : (tensor<16xf32>, tensor<16xf32>) -> tensor<16xf32>
 ```
 """
-function call_indirect(
-    callee::Value,
-    callee_operands::Vector{Value};
-    results::Vector{IR.Type},
-    location=Location(),
-)
-    results = IR.Type[results...,]
-    operands = Value[callee, callee_operands...]
+function call_indirect(callee::Value, callee_operands::Vector{Value}; results_::Vector{IR.Type}, location=Location())
+    results = IR.Type[results_..., ]
+    operands = Value[callee, callee_operands..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "func.call_indirect",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "func.call_indirect", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -59,24 +50,18 @@ symbol reference attribute named \"callee\".
 %2 = func.call @my_add(%0, %1) : (f32, f32) -> f32
 ```
 """
-function call(
-    operands::Vector{Value}; result_0::Vector{IR.Type}, callee, location=Location()
-)
-    results = IR.Type[result_0...,]
-    operands = Value[operands...,]
+function call(operands_::Vector{Value}; result_0::Vector{IR.Type}, callee, location=Location())
+    results = IR.Type[result_0..., ]
+    operands = Value[operands_..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("callee", callee),]
-
-    return IR.create_operation(
-        "func.call",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("callee", callee), ]
+    
+    IR.create_operation(
+        "func.call", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -102,21 +87,17 @@ reference a function simplifies this
 ([rationale](../Rationale/Rationale.md#multithreading-the-compiler)).
 """
 function constant(; result_0::IR.Type, value, location=Location())
-    results = IR.Type[result_0,]
+    results = IR.Type[result_0, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("value", value),]
-
-    return IR.create_operation(
-        "func.constant",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("value", value), ]
+    
+    IR.create_operation(
+        "func.constant", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -159,36 +140,21 @@ func.func @example_fn_result() -> (f64 {dialectName.attrName = 0 : i64})
 func.func @example_fn_attr() attributes {dialectName.attrName = false}
 ```
 """
-function func_(;
-    sym_name,
-    function_type,
-    sym_visibility=nothing,
-    arg_attrs=nothing,
-    res_attrs=nothing,
-    body::Region,
-    location=Location(),
-)
+function func_(; sym_name, function_type, sym_visibility=nothing, arg_attrs=nothing, res_attrs=nothing, body::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[body,]
+    owned_regions = Region[body, ]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("sym_name", sym_name), namedattribute("function_type", function_type)
-    ]
-    !isnothing(sym_visibility) &&
-        push!(attributes, namedattribute("sym_visibility", sym_visibility))
+    attributes = NamedAttribute[namedattribute("sym_name", sym_name), namedattribute("function_type", function_type), ]
+    !isnothing(sym_visibility) && push!(attributes, namedattribute("sym_visibility", sym_visibility))
     !isnothing(arg_attrs) && push!(attributes, namedattribute("arg_attrs", arg_attrs))
     !isnothing(res_attrs) && push!(attributes, namedattribute("res_attrs", res_attrs))
-
-    return IR.create_operation(
-        "func.func",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "func.func", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -209,22 +175,18 @@ func.func @foo() : (i32, f8) {
 }
 ```
 """
-function return_(operands::Vector{Value}; location=Location())
+function return_(operands_::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[operands...,]
+    operands = Value[operands_..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "func.return",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "func.return", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/16/GPU.jl
+++ b/src/Dialects/16/GPU.jl
@@ -1,8 +1,8 @@
 module gpu
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `all_reduce`
@@ -29,32 +29,21 @@ accumulation as code region. The accumulation operation must be one of:
 If `uniform` flag is set either none or all work items of a workgroup
 need to execute this op in convergence.
 """
-function all_reduce(
-    value::Value;
-    result_0=nothing::Union{Nothing,IR.Type},
-    op=nothing,
-    uniform=nothing,
-    body::Region,
-    location=Location(),
-)
+function all_reduce(value::Value; result_0=nothing::Union{Nothing, IR.Type}, op=nothing, uniform=nothing, body::Region, location=Location())
     results = IR.Type[]
-    operands = Value[value,]
-    owned_regions = Region[body,]
+    operands = Value[value, ]
+    owned_regions = Region[body, ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result_0) && push!(results, result_0)
     !isnothing(op) && push!(attributes, namedattribute("op", op))
     !isnothing(uniform) && push!(attributes, namedattribute("uniform", uniform))
-
-    return IR.create_operation(
-        "gpu.all_reduce",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.all_reduce", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -80,38 +69,21 @@ memory accessible both on host and on device.
 %memref, %token = gpu.alloc async [%dep] host_shared (%width) : memref<64x?xf32, 1>
 ```
 """
-function alloc(
-    asyncDependencies::Vector{Value},
-    dynamicSizes::Vector{Value},
-    symbolOperands::Vector{Value};
-    memref::IR.Type,
-    asyncToken=nothing::Union{Nothing,IR.Type},
-    hostShared=nothing,
-    location=Location(),
-)
-    results = IR.Type[memref,]
-    operands = Value[asyncDependencies..., dynamicSizes..., symbolOperands...]
+function alloc(asyncDependencies::Vector{Value}, dynamicSizes::Vector{Value}, symbolOperands::Vector{Value}; memref::IR.Type, asyncToken=nothing::Union{Nothing, IR.Type}, hostShared=nothing, location=Location())
+    results = IR.Type[memref, ]
+    operands = Value[asyncDependencies..., dynamicSizes..., symbolOperands..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(
-        attributes,
-        operandsegmentsizes([
-            length(asyncDependencies), length(dynamicSizes), length(symbolOperands)
-        ]),
-    )
+    push!(attributes, operandsegmentsizes([length(asyncDependencies), length(dynamicSizes), length(symbolOperands), ]))
     !isnothing(asyncToken) && push!(results, asyncToken)
     !isnothing(hostShared) && push!(attributes, namedattribute("hostShared", hostShared))
-
-    return IR.create_operation(
-        "gpu.alloc",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.alloc", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -140,16 +112,12 @@ function barrier(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "gpu.barrier",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.barrier", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -165,25 +133,19 @@ the x, y, or z `dimension`.
 %bDimX = gpu.block_dim x
 ```
 """
-function block_dim(;
-    result_0=nothing::Union{Nothing,IR.Type}, dimension, location=Location()
-)
+function block_dim(; result_0=nothing::Union{Nothing, IR.Type}, dimension, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("dimension", dimension),]
+    attributes = NamedAttribute[namedattribute("dimension", dimension), ]
     !isnothing(result_0) && push!(results, result_0)
-
-    return IR.create_operation(
-        "gpu.block_dim",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.block_dim", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -199,25 +161,19 @@ along the x, y, or z `dimension`.
 %bIdY = gpu.block_id y
 ```
 """
-function block_id(;
-    result_0=nothing::Union{Nothing,IR.Type}, dimension, location=Location()
-)
+function block_id(; result_0=nothing::Union{Nothing, IR.Type}, dimension, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("dimension", dimension),]
+    attributes = NamedAttribute[namedattribute("dimension", dimension), ]
     !isnothing(result_0) && push!(results, result_0)
-
-    return IR.create_operation(
-        "gpu.block_id",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.block_id", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -241,28 +197,19 @@ that case, it returns a !gpu.async.token.
 %token = gpu.dealloc async [%dep] %memref : memref<8x64xf32, 1>
 ```
 """
-function dealloc(
-    asyncDependencies::Vector{Value},
-    memref::Value;
-    asyncToken=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function dealloc(asyncDependencies::Vector{Value}, memref::Value; asyncToken=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[asyncDependencies..., memref]
+    operands = Value[asyncDependencies..., memref, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(asyncToken) && push!(results, asyncToken)
-
-    return IR.create_operation(
-        "gpu.dealloc",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.dealloc", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -333,26 +280,20 @@ The generic form illustrates the concept
 Note the non-default memory spaces used in memref types in memory
 attribution.
 """
-function func(;
-    function_type, arg_attrs=nothing, res_attrs=nothing, body::Region, location=Location()
-)
+function func(; function_type, arg_attrs=nothing, res_attrs=nothing, body::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[body,]
+    owned_regions = Region[body, ]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("function_type", function_type),]
+    attributes = NamedAttribute[namedattribute("function_type", function_type), ]
     !isnothing(arg_attrs) && push!(attributes, namedattribute("arg_attrs", arg_attrs))
     !isnothing(res_attrs) && push!(attributes, namedattribute("res_attrs", res_attrs))
-
-    return IR.create_operation(
-        "gpu.func",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.func", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -385,19 +326,15 @@ or not intended to be run on the separate device.
 function module_(; bodyRegion::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[bodyRegion,]
+    owned_regions = Region[bodyRegion, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "gpu.module",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.module", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -414,25 +351,19 @@ current workitem/thread within all workgroups / grid along the x, y, or z
 %gidX = gpu.global_id x
 ```
 """
-function global_id(;
-    result_0=nothing::Union{Nothing,IR.Type}, dimension, location=Location()
-)
+function global_id(; result_0=nothing::Union{Nothing, IR.Type}, dimension, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("dimension", dimension),]
+    attributes = NamedAttribute[namedattribute("dimension", dimension), ]
     !isnothing(result_0) && push!(results, result_0)
-
-    return IR.create_operation(
-        "gpu.global_id",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.global_id", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -448,25 +379,19 @@ Returns the number of thread blocks in the grid along the x, y, or z
 %gDimZ = gpu.grid_dim z
 ```
 """
-function grid_dim(;
-    result_0=nothing::Union{Nothing,IR.Type}, dimension, location=Location()
-)
+function grid_dim(; result_0=nothing::Union{Nothing, IR.Type}, dimension, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("dimension", dimension),]
+    attributes = NamedAttribute[namedattribute("dimension", dimension), ]
     !isnothing(result_0) && push!(results, result_0)
-
-    return IR.create_operation(
-        "gpu.grid_dim",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.grid_dim", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -484,20 +409,16 @@ the host after synchronizing with the device kernel completion.
 """
 function host_register(value::Value; location=Location())
     results = IR.Type[]
-    operands = Value[value,]
+    operands = Value[value, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "gpu.host_register",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.host_register", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -511,23 +432,19 @@ Returns the lane id within the subgroup (warp/wave).
 %laneId = gpu.lane_id
 ```
 """
-function lane_id(; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function lane_id(; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "gpu.lane_id",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.lane_id", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -612,59 +529,21 @@ module attributes {gpu.container_module} {
 }
 ```
 """
-function launch_func(
-    asyncDependencies::Vector{Value},
-    gridSizeX::Value,
-    gridSizeY::Value,
-    gridSizeZ::Value,
-    blockSizeX::Value,
-    blockSizeY::Value,
-    blockSizeZ::Value,
-    dynamicSharedMemorySize=nothing::Union{Nothing,Value};
-    kernelOperands::Vector{Value},
-    asyncToken=nothing::Union{Nothing,IR.Type},
-    kernel,
-    location=Location(),
-)
+function launch_func(asyncDependencies::Vector{Value}, gridSizeX::Value, gridSizeY::Value, gridSizeZ::Value, blockSizeX::Value, blockSizeY::Value, blockSizeZ::Value, dynamicSharedMemorySize=nothing::Union{Nothing, Value}; kernelOperands::Vector{Value}, asyncToken=nothing::Union{Nothing, IR.Type}, kernel, location=Location())
     results = IR.Type[]
-    operands = Value[
-        asyncDependencies...,
-        gridSizeX,
-        gridSizeY,
-        gridSizeZ,
-        blockSizeX,
-        blockSizeY,
-        blockSizeZ,
-        kernelOperands...,
-    ]
+    operands = Value[asyncDependencies..., gridSizeX, gridSizeY, gridSizeZ, blockSizeX, blockSizeY, blockSizeZ, kernelOperands..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("kernel", kernel),]
+    attributes = NamedAttribute[namedattribute("kernel", kernel), ]
     !isnothing(dynamicSharedMemorySize) && push!(operands, dynamicSharedMemorySize)
-    push!(
-        attributes,
-        operandsegmentsizes([
-            length(asyncDependencies),
-            1,
-            1,
-            1,
-            1,
-            1,
-            1,
-            (dynamicSharedMemorySize == nothing) ? 0 : 1length(kernelOperands),
-        ]),
-    )
+    push!(attributes, operandsegmentsizes([length(asyncDependencies), 1, 1, 1, 1, 1, 1, isnothing(dynamicSharedMemorySize) ? 0 : 1, length(kernelOperands), ]))
     !isnothing(asyncToken) && push!(results, asyncToken)
-
-    return IR.create_operation(
-        "gpu.launch_func",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.launch_func", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -742,57 +621,21 @@ know what value corresponds to threadIdx.x for coalescing). We can recover
 these properties by analyzing the operations producing values, but it is
 easier just to have that information by construction.
 """
-function launch(
-    asyncDependencies::Vector{Value},
-    gridSizeX::Value,
-    gridSizeY::Value,
-    gridSizeZ::Value,
-    blockSizeX::Value,
-    blockSizeY::Value,
-    blockSizeZ::Value,
-    dynamicSharedMemorySize=nothing::Union{Nothing,Value};
-    asyncToken=nothing::Union{Nothing,IR.Type},
-    body::Region,
-    location=Location(),
-)
+function launch(asyncDependencies::Vector{Value}, gridSizeX::Value, gridSizeY::Value, gridSizeZ::Value, blockSizeX::Value, blockSizeY::Value, blockSizeZ::Value, dynamicSharedMemorySize=nothing::Union{Nothing, Value}; asyncToken=nothing::Union{Nothing, IR.Type}, body::Region, location=Location())
     results = IR.Type[]
-    operands = Value[
-        asyncDependencies...,
-        gridSizeX,
-        gridSizeY,
-        gridSizeZ,
-        blockSizeX,
-        blockSizeY,
-        blockSizeZ,
-    ]
-    owned_regions = Region[body,]
+    operands = Value[asyncDependencies..., gridSizeX, gridSizeY, gridSizeZ, blockSizeX, blockSizeY, blockSizeZ, ]
+    owned_regions = Region[body, ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(dynamicSharedMemorySize) && push!(operands, dynamicSharedMemorySize)
-    push!(
-        attributes,
-        operandsegmentsizes([
-            length(asyncDependencies),
-            1,
-            1,
-            1,
-            1,
-            1,
-            1,
-            (dynamicSharedMemorySize == nothing) ? 0 : 1,
-        ]),
-    )
+    push!(attributes, operandsegmentsizes([length(asyncDependencies), 1, 1, 1, 1, 1, 1, isnothing(dynamicSharedMemorySize) ? 0 : 1, ]))
     !isnothing(asyncToken) && push!(results, asyncToken)
-
-    return IR.create_operation(
-        "gpu.launch",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.launch", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -814,29 +657,19 @@ that case, it returns a !gpu.async.token.
 %token = gpu.memcpy async [%dep] %dst, %src : memref<?xf32, 1>, memref<?xf32>
 ```
 """
-function memcpy(
-    asyncDependencies::Vector{Value},
-    dst::Value,
-    src::Value;
-    asyncToken=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function memcpy(asyncDependencies::Vector{Value}, dst::Value, src::Value; asyncToken=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[asyncDependencies..., dst, src]
+    operands = Value[asyncDependencies..., dst, src, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(asyncToken) && push!(results, asyncToken)
-
-    return IR.create_operation(
-        "gpu.memcpy",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.memcpy", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -858,29 +691,19 @@ that case, it returns a !gpu.async.token.
 %token = gpu.memset async [%dep] %dst, %value : memref<?xf32, 1>, f32
 ```
 """
-function memset(
-    asyncDependencies::Vector{Value},
-    dst::Value,
-    value::Value;
-    asyncToken=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function memset(asyncDependencies::Vector{Value}, dst::Value, value::Value; asyncToken=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[asyncDependencies..., dst, value]
+    operands = Value[asyncDependencies..., dst, value, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(asyncToken) && push!(results, asyncToken)
-
-    return IR.create_operation(
-        "gpu.memset",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.memset", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -895,16 +718,12 @@ function module_end(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "gpu.module_end",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.module_end", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -919,23 +738,19 @@ Returns the number of subgroups within a workgroup.
 %numSg = gpu.num_subgroups : index
 ```
 """
-function num_subgroups(; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function num_subgroups(; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "gpu.num_subgroups",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.num_subgroups", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -950,20 +765,16 @@ imposed by one\'s target platform.
 """
 function printf(args::Vector{Value}; format, location=Location())
     results = IR.Type[]
-    operands = Value[args...,]
+    operands = Value[args..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("format", format),]
-
-    return IR.create_operation(
-        "gpu.printf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("format", format), ]
+    
+    IR.create_operation(
+        "gpu.printf", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -974,22 +785,18 @@ A terminator operation for regions that appear in the body of  `gpu.func`
 functions. The operands to the `gpu.return` are the result values returned
 by an invocation of the `gpu.func`.
 """
-function return_(operands::Vector{Value}; location=Location())
+function return_(operands_::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[operands...,]
+    operands = Value[operands_..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "gpu.return",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.return", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1002,20 +809,16 @@ thread-local.
 """
 function set_default_device(devIndex::Value; location=Location())
     results = IR.Type[]
-    operands = Value[devIndex,]
+    operands = Value[devIndex, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "gpu.set_default_device",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.set_default_device", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1040,32 +843,20 @@ shuffle. The width needs to be the same for all invocations that participate
 in the shuffle. Exactly the first `width` invocations of a subgroup need to
 execute this op in convergence.
 """
-function shuffle(
-    value::Value,
-    offset::Value,
-    width::Value;
-    shuffleResult=nothing::Union{Nothing,IR.Type},
-    valid=nothing::Union{Nothing,IR.Type},
-    mode,
-    location=Location(),
-)
+function shuffle(value::Value, offset::Value, width::Value; shuffleResult=nothing::Union{Nothing, IR.Type}, valid=nothing::Union{Nothing, IR.Type}, mode, location=Location())
     results = IR.Type[]
-    operands = Value[value, offset, width]
+    operands = Value[value, offset, width, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("mode", mode),]
+    attributes = NamedAttribute[namedattribute("mode", mode), ]
     !isnothing(shuffleResult) && push!(results, shuffleResult)
     !isnothing(valid) && push!(results, valid)
-
-    return IR.create_operation(
-        "gpu.shuffle",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.shuffle", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1081,23 +872,19 @@ workgroup.
 %sgId = gpu.subgroup_id : index
 ```
 """
-function subgroup_id(; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function subgroup_id(; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "gpu.subgroup_id",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.subgroup_id", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1128,33 +915,21 @@ This op is meant to be used along with `gpu.subgroup_mma_store_matrix` and
   -> !gpu.mma_matrix<16x16xf16, \"COp\">
 ```
 """
-function subgroup_mma_compute(
-    opA::Value,
-    opB::Value,
-    opC::Value;
-    res=nothing::Union{Nothing,IR.Type},
-    a_transpose=nothing,
-    b_transpose=nothing,
-    location=Location(),
-)
+function subgroup_mma_compute(opA::Value, opB::Value, opC::Value; res=nothing::Union{Nothing, IR.Type}, a_transpose=nothing, b_transpose=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[opA, opB, opC]
+    operands = Value[opA, opB, opC, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
     !isnothing(a_transpose) && push!(attributes, namedattribute("a_transpose", a_transpose))
     !isnothing(b_transpose) && push!(attributes, namedattribute("b_transpose", b_transpose))
-
-    return IR.create_operation(
-        "gpu.subgroup_mma_compute",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.subgroup_mma_compute", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1182,21 +957,17 @@ This op is meant to be used along with `gpu.subgroup_mma_compute`.
 ```
 """
 function subgroup_mma_constant_matrix(value::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[value,]
+    results = IR.Type[res, ]
+    operands = Value[value, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "gpu.subgroup_mma_constant_matrix",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.subgroup_mma_constant_matrix", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1220,24 +991,18 @@ This op is meant to be used along with `gpu.subgroup_mma_compute`.
   -> !gpu.mma_matrix<16x16xf16, \"COp\">
 ```
 """
-function subgroup_mma_elementwise(
-    args::Vector{Value}; res::IR.Type, opType, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[args...,]
+function subgroup_mma_elementwise(args::Vector{Value}; res::IR.Type, opType, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[args..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("opType", opType),]
-
-    return IR.create_operation(
-        "gpu.subgroup_mma_elementwise",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("opType", opType), ]
+    
+    IR.create_operation(
+        "gpu.subgroup_mma_elementwise", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1265,30 +1030,19 @@ This op is often meant to be used along with `gpu.subgroup_mma_store_matrix` and
       : memref<32x32xf16, 3>, !gpu.mma_matrix<16x16xf16, \"AOp\">
 ```
 """
-function subgroup_mma_load_matrix(
-    srcMemref::Value,
-    indices::Vector{Value};
-    res::IR.Type,
-    leadDimension,
-    transpose=nothing,
-    location=Location(),
-)
-    results = IR.Type[res,]
-    operands = Value[srcMemref, indices...]
+function subgroup_mma_load_matrix(srcMemref::Value, indices::Vector{Value}; res::IR.Type, leadDimension, transpose=nothing, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[srcMemref, indices..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("leadDimension", leadDimension),]
+    attributes = NamedAttribute[namedattribute("leadDimension", leadDimension), ]
     !isnothing(transpose) && push!(attributes, namedattribute("transpose", transpose))
-
-    return IR.create_operation(
-        "gpu.subgroup_mma_load_matrix",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.subgroup_mma_load_matrix", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1315,30 +1069,19 @@ gpu.subgroup_mma_store_matrix %D, %sg[%i,%j] : { leadDimension = 32 : i32}
                 : !gpu.mma_matrix<16x16xf16, \"COp\">, memref<32x32xf16, 3>
 ```
 """
-function subgroup_mma_store_matrix(
-    src::Value,
-    dstMemref::Value,
-    indices::Vector{Value};
-    leadDimension,
-    transpose=nothing,
-    location=Location(),
-)
+function subgroup_mma_store_matrix(src::Value, dstMemref::Value, indices::Vector{Value}; leadDimension, transpose=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[src, dstMemref, indices...]
+    operands = Value[src, dstMemref, indices..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("leadDimension", leadDimension),]
+    attributes = NamedAttribute[namedattribute("leadDimension", leadDimension), ]
     !isnothing(transpose) && push!(attributes, namedattribute("transpose", transpose))
-
-    return IR.create_operation(
-        "gpu.subgroup_mma_store_matrix",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.subgroup_mma_store_matrix", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1357,30 +1100,20 @@ subgroup. The result is equal for all work items of a subgroup.
 If `uniform` flag is set either none or all work items of a subgroup
 need to execute this op in convergence.
 """
-function subgroup_reduce(
-    value::Value;
-    result_0=nothing::Union{Nothing,IR.Type},
-    op,
-    uniform=nothing,
-    location=Location(),
-)
+function subgroup_reduce(value::Value; result_0=nothing::Union{Nothing, IR.Type}, op, uniform=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[value,]
+    operands = Value[value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("op", op),]
+    attributes = NamedAttribute[namedattribute("op", op), ]
     !isnothing(result_0) && push!(results, result_0)
     !isnothing(uniform) && push!(attributes, namedattribute("uniform", uniform))
-
-    return IR.create_operation(
-        "gpu.subgroup_reduce",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.subgroup_reduce", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1395,23 +1128,19 @@ Returns the number of threads within a subgroup.
 %sgSz = gpu.subgroup_size : index
 ```
 """
-function subgroup_size(; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function subgroup_size(; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "gpu.subgroup_size",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.subgroup_size", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1428,16 +1157,12 @@ function terminator(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "gpu.terminator",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.terminator", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1453,25 +1178,19 @@ along the x, y, or z `dimension`.
 %tIdX = gpu.thread_id x
 ```
 """
-function thread_id(;
-    result_0=nothing::Union{Nothing,IR.Type}, dimension, location=Location()
-)
+function thread_id(; result_0=nothing::Union{Nothing, IR.Type}, dimension, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("dimension", dimension),]
+    attributes = NamedAttribute[namedattribute("dimension", dimension), ]
     !isnothing(result_0) && push!(results, result_0)
-
-    return IR.create_operation(
-        "gpu.thread_id",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.thread_id", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1508,27 +1227,19 @@ once this op completes. Example usage:
 gpu.wait [%t0, %t1]
 ```
 """
-function wait(
-    asyncDependencies::Vector{Value};
-    asyncToken=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function wait(asyncDependencies::Vector{Value}; asyncToken=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[asyncDependencies...,]
+    operands = Value[asyncDependencies..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(asyncToken) && push!(results, asyncToken)
-
-    return IR.create_operation(
-        "gpu.wait",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.wait", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1546,20 +1257,16 @@ gpu.yield %f0, %f1 : f32, f32
 """
 function yield(values::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[values...,]
+    operands = Value[values..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "gpu.yield",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.yield", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/16/Index.jl
+++ b/src/Dialects/16/Index.jl
@@ -1,8 +1,8 @@
 module index
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `add`
@@ -16,25 +16,19 @@ The `index.add` operation takes two index values and computes their sum.
 %c = index.add %a, %b
 ```
 """
-function add(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function add(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "index.add",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "index.add", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -51,25 +45,19 @@ and.
 %c = index.and %a, %b
 ```
 """
-function and(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function and(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "index.and",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "index.and", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -88,23 +76,19 @@ This operation is used to materialize bool constants that arise when folding
 %0 = index.bool.constant true
 ```
 """
-function bool_constant(; result=nothing::Union{Nothing,IR.Type}, value, location=Location())
+function bool_constant(; result=nothing::Union{Nothing, IR.Type}, value, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("value", value),]
+    attributes = NamedAttribute[namedattribute("value", value), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "index.bool.constant",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "index.bool.constant", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -127,21 +111,17 @@ truncated.
 ```
 """
 function casts(input::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input,]
+    results = IR.Type[output, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "index.casts",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "index.casts", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -164,21 +144,17 @@ truncated.
 ```
 """
 function castu(input::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input,]
+    results = IR.Type[output, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "index.castu",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "index.castu", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -198,25 +174,19 @@ Note: division by zero and signed division overflow are undefined behaviour.
 %c = index.ceildivs %a, %b
 ```
 """
-function ceildivs(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function ceildivs(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "index.ceildivs",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "index.ceildivs", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -236,25 +206,19 @@ Note: division by zero is undefined behaviour.
 %c = index.ceildivu %a, %b
 ```
 """
-function ceildivu(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function ceildivu(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "index.ceildivu",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "index.ceildivu", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -291,29 +255,19 @@ The result is `1` if the comparison is true and `0` otherwise.
 %2 = index.cmp ne(%a, %b)
 ```
 """
-function cmp(
-    lhs::Value,
-    rhs::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    pred,
-    location=Location(),
-)
+function cmp(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, pred, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("pred", pred),]
+    attributes = NamedAttribute[namedattribute("pred", pred), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "index.cmp",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "index.cmp", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -329,23 +283,19 @@ some index-typed integer constant.
 %0 = index.constant 42
 ```
 """
-function constant(; result=nothing::Union{Nothing,IR.Type}, value, location=Location())
+function constant(; result=nothing::Union{Nothing, IR.Type}, value, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("value", value),]
+    attributes = NamedAttribute[namedattribute("value", value), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "index.constant",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "index.constant", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -365,25 +315,19 @@ Note: division by zero and signed division overflow are undefined behaviour.
 %c = index.divs %a, %b
 ```
 """
-function divs(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function divs(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "index.divs",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "index.divs", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -403,25 +347,19 @@ Note: division by zero is undefined behaviour.
 %c = index.divu %a, %b
 ```
 """
-function divu(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function divu(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "index.divu",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "index.divu", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -441,25 +379,19 @@ Note: division by zero and signed division overflow are undefined behaviour.
 %c = index.floordivs %a, %b
 ```
 """
-function floordivs(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function floordivs(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "index.floordivs",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "index.floordivs", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -476,25 +408,19 @@ maximum value. Treats the leading bit as the sign, i.e. `max(-2, 6) = 6`.
 %c = index.maxs %a, %b
 ```
 """
-function maxs(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function maxs(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "index.maxs",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "index.maxs", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -512,25 +438,19 @@ unsigned maximum value. Treats the leading bit as the most significant, i.e.
 %c = index.maxu %a, %b
 ```
 """
-function maxu(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function maxu(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "index.maxu",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "index.maxu", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -547,25 +467,19 @@ minimum value. Treats the leading bit as the sign, i.e. `min(-2, 6) = -2`.
 %c = index.mins %a, %b
 ```
 """
-function mins(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function mins(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "index.mins",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "index.mins", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -583,25 +497,19 @@ unsigned minimum value. Treats the leading bit as the most significant, i.e.
 %c = index.minu %a, %b
 ```
 """
-function minu(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function minu(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "index.minu",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "index.minu", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -617,25 +525,19 @@ The `index.mul` operation takes two index values and computes their product.
 %c = index.mul %a, %b
 ```
 """
-function mul(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function mul(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "index.mul",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "index.mul", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -652,25 +554,19 @@ or.
 %c = index.or %a, %b
 ```
 """
-function or(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function or(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "index.or",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "index.or", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -687,25 +583,19 @@ remainder. Treats the leading bit as the sign, i.e. `6 % -2 = 0`.
 %c = index.rems %a, %b
 ```
 """
-function rems(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function rems(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "index.rems",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "index.rems", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -723,25 +613,19 @@ unsigned remainder. Treats the leading bit as the most significant, i.e.
 %c = index.remu %a, %b
 ```
 """
-function remu(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function remu(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "index.remu",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "index.remu", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -760,25 +644,19 @@ index bitwidth, the operation is undefined.
 %c = index.shl %a, %b
 ```
 """
-function shl(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function shl(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "index.shl",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "index.shl", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -797,25 +675,19 @@ greater than the index bitwidth, the operation is undefined.
 %c = index.shrs %a, %b
 ```
 """
-function shrs(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function shrs(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "index.shrs",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "index.shrs", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -834,25 +706,19 @@ bitwidth, the operation is undefined.
 %c = index.shru %a, %b
 ```
 """
-function shru(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function shru(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "index.shru",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "index.shru", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -869,23 +735,19 @@ is `32 : index`, and on 64-bit systems, the result is `64 : index`.
 %0 = index.sizeof
 ```
 """
-function sizeof(; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function sizeof(; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "index.sizeof",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "index.sizeof", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -902,25 +764,19 @@ of the first from the second operand.
 %c = index.sub %a, %b
 ```
 """
-function sub(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function sub(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "index.sub",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "index.sub", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -937,25 +793,19 @@ xor.
 %c = index.xor %a, %b
 ```
 """
-function xor(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function xor(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "index.xor",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "index.xor", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 

--- a/src/Dialects/16/LLVMIR.jl
+++ b/src/Dialects/16/LLVMIR.jl
@@ -1,32 +1,26 @@
 module llvm
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `ashr`
 
 """
-function ashr(
-    lhs::Value, rhs::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function ashr(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "llvm.ashr",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.ashr", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -47,17 +41,13 @@ function access_group(; sym_name, location=Location())
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("sym_name", sym_name),]
-
-    return IR.create_operation(
-        "llvm.access_group",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("sym_name", sym_name), ]
+    
+    IR.create_operation(
+        "llvm.access_group", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -65,25 +55,19 @@ end
 `add`
 
 """
-function add(
-    lhs::Value, rhs::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function add(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "llvm.add",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.add", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -92,21 +76,17 @@ end
 
 """
 function addrspacecast(arg::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[arg,]
+    results = IR.Type[res, ]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.addrspacecast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.addrspacecast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -140,21 +120,17 @@ llvm.mlir.global @const(42 : i32) : i32
 ```
 """
 function mlir_addressof(; res::IR.Type, global_name, location=Location())
-    results = IR.Type[res,]
+    results = IR.Type[res, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("global_name", global_name),]
-
-    return IR.create_operation(
-        "llvm.mlir.addressof",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("global_name", global_name), ]
+    
+    IR.create_operation(
+        "llvm.mlir.addressof", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -171,18 +147,14 @@ function alias_scope_domain(; sym_name, description=nothing, location=Location()
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("sym_name", sym_name),]
+    attributes = NamedAttribute[namedattribute("sym_name", sym_name), ]
     !isnothing(description) && push!(attributes, namedattribute("description", description))
-
-    return IR.create_operation(
-        "llvm.alias_scope_domain",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.alias_scope_domain", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -223,20 +195,14 @@ function alias_scope(; sym_name, domain, description=nothing, location=Location(
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("sym_name", sym_name), namedattribute("domain", domain)
-    ]
+    attributes = NamedAttribute[namedattribute("sym_name", sym_name), namedattribute("domain", domain), ]
     !isnothing(description) && push!(attributes, namedattribute("description", description))
-
-    return IR.create_operation(
-        "llvm.alias_scope",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.alias_scope", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -244,30 +210,20 @@ end
 `alloca`
 
 """
-function alloca(
-    arraySize::Value;
-    res::IR.Type,
-    alignment=nothing,
-    elem_type=nothing,
-    location=Location(),
-)
-    results = IR.Type[res,]
-    operands = Value[arraySize,]
+function alloca(arraySize::Value; res::IR.Type, alignment=nothing, elem_type=nothing, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[arraySize, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(alignment) && push!(attributes, namedattribute("alignment", alignment))
     !isnothing(elem_type) && push!(attributes, namedattribute("elem_type", elem_type))
-
-    return IR.create_operation(
-        "llvm.alloca",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.alloca", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -275,25 +231,19 @@ end
 `and`
 
 """
-function and(
-    lhs::Value, rhs::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function and(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "llvm.and",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.and", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -301,33 +251,18 @@ end
 `cmpxchg`
 
 """
-function cmpxchg(
-    ptr::Value,
-    cmp::Value,
-    val::Value;
-    res::IR.Type,
-    success_ordering,
-    failure_ordering,
-    location=Location(),
-)
-    results = IR.Type[res,]
-    operands = Value[ptr, cmp, val]
+function cmpxchg(ptr::Value, cmp::Value, val::Value; res::IR.Type, success_ordering, failure_ordering, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[ptr, cmp, val, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("success_ordering", success_ordering),
-        namedattribute("failure_ordering", failure_ordering),
-    ]
-
-    return IR.create_operation(
-        "llvm.cmpxchg",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("success_ordering", success_ordering), namedattribute("failure_ordering", failure_ordering), ]
+    
+    IR.create_operation(
+        "llvm.cmpxchg", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -335,26 +270,18 @@ end
 `atomicrmw`
 
 """
-function atomicrmw(
-    ptr::Value, val::Value; res::IR.Type, bin_op, ordering, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[ptr, val]
+function atomicrmw(ptr::Value, val::Value; res::IR.Type, bin_op, ordering, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[ptr, val, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("bin_op", bin_op), namedattribute("ordering", ordering)
-    ]
-
-    return IR.create_operation(
-        "llvm.atomicrmw",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("bin_op", bin_op), namedattribute("ordering", ordering), ]
+    
+    IR.create_operation(
+        "llvm.atomicrmw", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -363,21 +290,17 @@ end
 
 """
 function bitcast(arg::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[arg,]
+    results = IR.Type[res, ]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.bitcast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.bitcast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -387,20 +310,16 @@ end
 """
 function br(destOperands::Vector{Value}; dest::Block, location=Location())
     results = IR.Type[]
-    operands = Value[destOperands...,]
+    operands = Value[destOperands..., ]
     owned_regions = Region[]
-    successors = Block[dest,]
+    successors = Block[dest, ]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.br",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.br", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -432,35 +351,22 @@ llvm.call @bar(%0) : (f32) -> ()
 llvm.call %1(%0) : (f32) -> ()
 ```
 """
-function call(
-    operand_0::Vector{Value};
-    result=nothing::Union{Nothing,IR.Type},
-    callee=nothing,
-    fastmathFlags=nothing,
-    branch_weights=nothing,
-    location=Location(),
-)
+function call(operand_0::Vector{Value}; result=nothing::Union{Nothing, IR.Type}, callee=nothing, fastmathFlags=nothing, branch_weights=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[operand_0...,]
+    operands = Value[operand_0..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(callee) && push!(attributes, namedattribute("callee", callee))
-    !isnothing(fastmathFlags) &&
-        push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
-    !isnothing(branch_weights) &&
-        push!(attributes, namedattribute("branch_weights", branch_weights))
-
-    return IR.create_operation(
-        "llvm.call",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(fastmathFlags) && push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
+    !isnothing(branch_weights) && push!(attributes, namedattribute("branch_weights", branch_weights))
+    
+    IR.create_operation(
+        "llvm.call", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -468,36 +374,20 @@ end
 `cond_br`
 
 """
-function cond_br(
-    condition::Value,
-    trueDestOperands::Vector{Value},
-    falseDestOperands::Vector{Value};
-    branch_weights=nothing,
-    trueDest::Block,
-    falseDest::Block,
-    location=Location(),
-)
+function cond_br(condition::Value, trueDestOperands::Vector{Value}, falseDestOperands::Vector{Value}; branch_weights=nothing, trueDest::Block, falseDest::Block, location=Location())
     results = IR.Type[]
-    operands = Value[condition, trueDestOperands..., falseDestOperands...]
+    operands = Value[condition, trueDestOperands..., falseDestOperands..., ]
     owned_regions = Region[]
-    successors = Block[trueDest, falseDest]
+    successors = Block[trueDest, falseDest, ]
     attributes = NamedAttribute[]
-    push!(
-        attributes,
-        operandsegmentsizes([1, length(trueDestOperands), length(falseDestOperands)]),
-    )
-    !isnothing(branch_weights) &&
-        push!(attributes, namedattribute("branch_weights", branch_weights))
-
-    return IR.create_operation(
-        "llvm.cond_br",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([1, length(trueDestOperands), length(falseDestOperands), ]))
+    !isnothing(branch_weights) && push!(attributes, namedattribute("branch_weights", branch_weights))
+    
+    IR.create_operation(
+        "llvm.cond_br", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -532,21 +422,17 @@ Examples:
 ```
 """
 function mlir_constant(; res::IR.Type, value, location=Location())
-    results = IR.Type[res,]
+    results = IR.Type[res, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("value", value),]
-
-    return IR.create_operation(
-        "llvm.mlir.constant",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("value", value), ]
+    
+    IR.create_operation(
+        "llvm.mlir.constant", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -554,25 +440,18 @@ end
 `extractelement`
 
 """
-function extractelement(
-    vector::Value, position::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
-)
-    results = IR.Type[]
-    operands = Value[vector, position]
+function extractelement(vector::Value, position::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[vector, position, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "llvm.extractelement",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "llvm.extractelement", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -581,21 +460,17 @@ end
 
 """
 function extractvalue(container::Value; res::IR.Type, position, location=Location())
-    results = IR.Type[res,]
-    operands = Value[container,]
+    results = IR.Type[res, ]
+    operands = Value[container, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("position", position),]
-
-    return IR.create_operation(
-        "llvm.extractvalue",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("position", position), ]
+    
+    IR.create_operation(
+        "llvm.extractvalue", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -603,31 +478,20 @@ end
 `fadd`
 
 """
-function fadd(
-    lhs::Value,
-    rhs::Value;
-    res=nothing::Union{Nothing,IR.Type},
-    fastmathFlags=nothing,
-    location=Location(),
-)
+function fadd(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, fastmathFlags=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-    !isnothing(fastmathFlags) &&
-        push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
-
-    return IR.create_operation(
-        "llvm.fadd",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(fastmathFlags) && push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
+    
+    IR.create_operation(
+        "llvm.fadd", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -635,32 +499,19 @@ end
 `fcmp`
 
 """
-function fcmp(
-    lhs::Value,
-    rhs::Value;
-    res=nothing::Union{Nothing,IR.Type},
-    predicate,
-    fastmathFlags=nothing,
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[lhs, rhs]
+function fcmp(lhs::Value, rhs::Value; res::IR.Type, predicate, fastmathFlags=nothing, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("predicate", predicate),]
-    !isnothing(res) && push!(results, res)
-    !isnothing(fastmathFlags) &&
-        push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
-
-    return IR.create_operation(
-        "llvm.fcmp",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    attributes = NamedAttribute[namedattribute("predicate", predicate), ]
+    !isnothing(fastmathFlags) && push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
+    
+    IR.create_operation(
+        "llvm.fcmp", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -668,31 +519,20 @@ end
 `fdiv`
 
 """
-function fdiv(
-    lhs::Value,
-    rhs::Value;
-    res=nothing::Union{Nothing,IR.Type},
-    fastmathFlags=nothing,
-    location=Location(),
-)
+function fdiv(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, fastmathFlags=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-    !isnothing(fastmathFlags) &&
-        push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
-
-    return IR.create_operation(
-        "llvm.fdiv",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(fastmathFlags) && push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
+    
+    IR.create_operation(
+        "llvm.fdiv", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -700,31 +540,20 @@ end
 `fmul`
 
 """
-function fmul(
-    lhs::Value,
-    rhs::Value;
-    res=nothing::Union{Nothing,IR.Type},
-    fastmathFlags=nothing,
-    location=Location(),
-)
+function fmul(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, fastmathFlags=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-    !isnothing(fastmathFlags) &&
-        push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
-
-    return IR.create_operation(
-        "llvm.fmul",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(fastmathFlags) && push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
+    
+    IR.create_operation(
+        "llvm.fmul", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -732,30 +561,20 @@ end
 `fneg`
 
 """
-function fneg(
-    operand::Value;
-    res=nothing::Union{Nothing,IR.Type},
-    fastmathFlags=nothing,
-    location=Location(),
-)
+function fneg(operand::Value; res=nothing::Union{Nothing, IR.Type}, fastmathFlags=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-    !isnothing(fastmathFlags) &&
-        push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
-
-    return IR.create_operation(
-        "llvm.fneg",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(fastmathFlags) && push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
+    
+    IR.create_operation(
+        "llvm.fneg", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -764,21 +583,17 @@ end
 
 """
 function fpext(arg::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[arg,]
+    results = IR.Type[res, ]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.fpext",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.fpext", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -787,21 +602,17 @@ end
 
 """
 function fptosi(arg::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[arg,]
+    results = IR.Type[res, ]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.fptosi",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.fptosi", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -810,21 +621,17 @@ end
 
 """
 function fptoui(arg::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[arg,]
+    results = IR.Type[res, ]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.fptoui",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.fptoui", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -833,21 +640,17 @@ end
 
 """
 function fptrunc(arg::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[arg,]
+    results = IR.Type[res, ]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.fptrunc",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.fptrunc", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -855,31 +658,20 @@ end
 `frem`
 
 """
-function frem(
-    lhs::Value,
-    rhs::Value;
-    res=nothing::Union{Nothing,IR.Type},
-    fastmathFlags=nothing,
-    location=Location(),
-)
+function frem(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, fastmathFlags=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-    !isnothing(fastmathFlags) &&
-        push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
-
-    return IR.create_operation(
-        "llvm.frem",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(fastmathFlags) && push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
+    
+    IR.create_operation(
+        "llvm.frem", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -887,31 +679,20 @@ end
 `fsub`
 
 """
-function fsub(
-    lhs::Value,
-    rhs::Value;
-    res=nothing::Union{Nothing,IR.Type},
-    fastmathFlags=nothing,
-    location=Location(),
-)
+function fsub(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, fastmathFlags=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-    !isnothing(fastmathFlags) &&
-        push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
-
-    return IR.create_operation(
-        "llvm.fsub",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(fastmathFlags) && push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
+    
+    IR.create_operation(
+        "llvm.fsub", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -924,19 +705,13 @@ function fence(; ordering, syncscope, location=Location())
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("ordering", ordering), namedattribute("syncscope", syncscope)
-    ]
-
-    return IR.create_operation(
-        "llvm.fence",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("ordering", ordering), namedattribute("syncscope", syncscope), ]
+    
+    IR.create_operation(
+        "llvm.fence", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -944,23 +719,19 @@ end
 `freeze`
 
 """
-function freeze(val::Value; res=nothing::Union{Nothing,IR.Type}, location=Location())
+function freeze(val::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[val,]
+    operands = Value[val, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "llvm.freeze",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.freeze", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -991,32 +762,20 @@ Examples:
    : (!llvm.ptr<struct(i32, f32)>) -> !llvm.ptr<f32>
 ```
 """
-function getelementptr(
-    base::Value,
-    dynamicIndices::Vector{Value};
-    res::IR.Type,
-    rawConstantIndices,
-    elem_type=nothing,
-    inbounds=nothing,
-    location=Location(),
-)
-    results = IR.Type[res,]
-    operands = Value[base, dynamicIndices...]
+function getelementptr(base::Value, dynamicIndices::Vector{Value}; res::IR.Type, rawConstantIndices, elem_type=nothing, inbounds=nothing, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[base, dynamicIndices..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("rawConstantIndices", rawConstantIndices),]
+    attributes = NamedAttribute[namedattribute("rawConstantIndices", rawConstantIndices), ]
     !isnothing(elem_type) && push!(attributes, namedattribute("elem_type", elem_type))
     !isnothing(inbounds) && push!(attributes, namedattribute("inbounds", inbounds))
-
-    return IR.create_operation(
-        "llvm.getelementptr",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.getelementptr", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1047,19 +806,13 @@ function mlir_global_ctors(; ctors, priorities, location=Location())
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("ctors", ctors), namedattribute("priorities", priorities)
-    ]
-
-    return IR.create_operation(
-        "llvm.mlir.global_ctors",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("ctors", ctors), namedattribute("priorities", priorities), ]
+    
+    IR.create_operation(
+        "llvm.mlir.global_ctors", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1087,19 +840,13 @@ function mlir_global_dtors(; dtors, priorities, location=Location())
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("dtors", dtors), namedattribute("priorities", priorities)
-    ]
-
-    return IR.create_operation(
-        "llvm.mlir.global_dtors",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("dtors", dtors), namedattribute("priorities", priorities), ]
+    
+    IR.create_operation(
+        "llvm.mlir.global_dtors", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1200,50 +947,26 @@ Examples:
 llvm.mlir.global private constant @y(dense<1.0> : tensor<8xf32>) { alignment = 32 : i64 } : !llvm.array<8 x f32>
 ```
 """
-function mlir_global(;
-    global_type,
-    constant=nothing,
-    sym_name,
-    linkage,
-    dso_local=nothing,
-    thread_local_=nothing,
-    value=nothing,
-    alignment=nothing,
-    addr_space=nothing,
-    unnamed_addr=nothing,
-    section=nothing,
-    initializer::Region,
-    location=Location(),
-)
+function mlir_global(; global_type, constant=nothing, sym_name, linkage, dso_local=nothing, thread_local_=nothing, value=nothing, alignment=nothing, addr_space=nothing, unnamed_addr=nothing, section=nothing, initializer::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[initializer,]
+    owned_regions = Region[initializer, ]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("global_type", global_type),
-        namedattribute("sym_name", sym_name),
-        namedattribute("linkage", linkage),
-    ]
+    attributes = NamedAttribute[namedattribute("global_type", global_type), namedattribute("sym_name", sym_name), namedattribute("linkage", linkage), ]
     !isnothing(constant) && push!(attributes, namedattribute("constant", constant))
     !isnothing(dso_local) && push!(attributes, namedattribute("dso_local", dso_local))
-    !isnothing(thread_local_) &&
-        push!(attributes, namedattribute("thread_local_", thread_local_))
+    !isnothing(thread_local_) && push!(attributes, namedattribute("thread_local_", thread_local_))
     !isnothing(value) && push!(attributes, namedattribute("value", value))
     !isnothing(alignment) && push!(attributes, namedattribute("alignment", alignment))
     !isnothing(addr_space) && push!(attributes, namedattribute("addr_space", addr_space))
-    !isnothing(unnamed_addr) &&
-        push!(attributes, namedattribute("unnamed_addr", unnamed_addr))
+    !isnothing(unnamed_addr) && push!(attributes, namedattribute("unnamed_addr", unnamed_addr))
     !isnothing(section) && push!(attributes, namedattribute("section", section))
-
-    return IR.create_operation(
-        "llvm.mlir.global",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.mlir.global", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1251,29 +974,18 @@ end
 `icmp`
 
 """
-function icmp(
-    lhs::Value,
-    rhs::Value;
-    res=nothing::Union{Nothing,IR.Type},
-    predicate,
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[lhs, rhs]
+function icmp(lhs::Value, rhs::Value; res::IR.Type, predicate, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("predicate", predicate),]
-    !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "llvm.icmp",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    attributes = NamedAttribute[namedattribute("predicate", predicate), ]
+    
+    IR.create_operation(
+        "llvm.icmp", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -1287,42 +999,23 @@ written, or referenced.
 Attempting to define or reference any symbol or any global behavior is
 considered undefined behavior at this time.
 """
-function inline_asm(
-    operands::Vector{Value};
-    res=nothing::Union{Nothing,IR.Type},
-    asm_string,
-    constraints,
-    has_side_effects=nothing,
-    is_align_stack=nothing,
-    asm_dialect=nothing,
-    operand_attrs=nothing,
-    location=Location(),
-)
+function inline_asm(operands_::Vector{Value}; res=nothing::Union{Nothing, IR.Type}, asm_string, constraints, has_side_effects=nothing, is_align_stack=nothing, asm_dialect=nothing, operand_attrs=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[operands...,]
+    operands = Value[operands_..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("asm_string", asm_string), namedattribute("constraints", constraints)
-    ]
+    attributes = NamedAttribute[namedattribute("asm_string", asm_string), namedattribute("constraints", constraints), ]
     !isnothing(res) && push!(results, res)
-    !isnothing(has_side_effects) &&
-        push!(attributes, namedattribute("has_side_effects", has_side_effects))
-    !isnothing(is_align_stack) &&
-        push!(attributes, namedattribute("is_align_stack", is_align_stack))
+    !isnothing(has_side_effects) && push!(attributes, namedattribute("has_side_effects", has_side_effects))
+    !isnothing(is_align_stack) && push!(attributes, namedattribute("is_align_stack", is_align_stack))
     !isnothing(asm_dialect) && push!(attributes, namedattribute("asm_dialect", asm_dialect))
-    !isnothing(operand_attrs) &&
-        push!(attributes, namedattribute("operand_attrs", operand_attrs))
-
-    return IR.create_operation(
-        "llvm.inline_asm",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(operand_attrs) && push!(attributes, namedattribute("operand_attrs", operand_attrs))
+    
+    IR.create_operation(
+        "llvm.inline_asm", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1330,29 +1023,19 @@ end
 `insertelement`
 
 """
-function insertelement(
-    vector::Value,
-    value::Value,
-    position::Value;
-    res=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function insertelement(vector::Value, value::Value, position::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[vector, value, position]
+    operands = Value[vector, value, position, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "llvm.insertelement",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.insertelement", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1360,29 +1043,19 @@ end
 `insertvalue`
 
 """
-function insertvalue(
-    container::Value,
-    value::Value;
-    res=nothing::Union{Nothing,IR.Type},
-    position,
-    location=Location(),
-)
+function insertvalue(container::Value, value::Value; res=nothing::Union{Nothing, IR.Type}, position, location=Location())
     results = IR.Type[]
-    operands = Value[container, value]
+    operands = Value[container, value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("position", position),]
+    attributes = NamedAttribute[namedattribute("position", position), ]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "llvm.insertvalue",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.insertvalue", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1391,21 +1064,17 @@ end
 
 """
 function inttoptr(arg::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[arg,]
+    results = IR.Type[res, ]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.inttoptr",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.inttoptr", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1413,41 +1082,21 @@ end
 `invoke`
 
 """
-function invoke(
-    callee_operands::Vector{Value},
-    normalDestOperands::Vector{Value},
-    unwindDestOperands::Vector{Value};
-    result_0::Vector{IR.Type},
-    callee=nothing,
-    branch_weights=nothing,
-    normalDest::Block,
-    unwindDest::Block,
-    location=Location(),
-)
-    results = IR.Type[result_0...,]
-    operands = Value[callee_operands..., normalDestOperands..., unwindDestOperands...]
+function invoke(callee_operands::Vector{Value}, normalDestOperands::Vector{Value}, unwindDestOperands::Vector{Value}; result_0::Vector{IR.Type}, callee=nothing, branch_weights=nothing, normalDest::Block, unwindDest::Block, location=Location())
+    results = IR.Type[result_0..., ]
+    operands = Value[callee_operands..., normalDestOperands..., unwindDestOperands..., ]
     owned_regions = Region[]
-    successors = Block[normalDest, unwindDest]
+    successors = Block[normalDest, unwindDest, ]
     attributes = NamedAttribute[]
-    push!(
-        attributes,
-        operandsegmentsizes([
-            length(callee_operands), length(normalDestOperands), length(unwindDestOperands)
-        ]),
-    )
+    push!(attributes, operandsegmentsizes([length(callee_operands), length(normalDestOperands), length(unwindDestOperands), ]))
     !isnothing(callee) && push!(attributes, namedattribute("callee", callee))
-    !isnothing(branch_weights) &&
-        push!(attributes, namedattribute("branch_weights", branch_weights))
-
-    return IR.create_operation(
-        "llvm.invoke",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(branch_weights) && push!(attributes, namedattribute("branch_weights", branch_weights))
+    
+    IR.create_operation(
+        "llvm.invoke", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1480,51 +1129,28 @@ llvm.func internal @internal_func() {
 }
 ```
 """
-function func(;
-    sym_name,
-    function_type,
-    linkage=nothing,
-    dso_local=nothing,
-    CConv=nothing,
-    personality=nothing,
-    garbageCollector=nothing,
-    passthrough=nothing,
-    arg_attrs=nothing,
-    res_attrs=nothing,
-    function_entry_count=nothing,
-    memory=nothing,
-    body::Region,
-    location=Location(),
-)
+function func(; sym_name, function_type, linkage=nothing, dso_local=nothing, CConv=nothing, personality=nothing, garbageCollector=nothing, passthrough=nothing, arg_attrs=nothing, res_attrs=nothing, function_entry_count=nothing, memory=nothing, body::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[body,]
+    owned_regions = Region[body, ]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("sym_name", sym_name), namedattribute("function_type", function_type)
-    ]
+    attributes = NamedAttribute[namedattribute("sym_name", sym_name), namedattribute("function_type", function_type), ]
     !isnothing(linkage) && push!(attributes, namedattribute("linkage", linkage))
     !isnothing(dso_local) && push!(attributes, namedattribute("dso_local", dso_local))
     !isnothing(CConv) && push!(attributes, namedattribute("CConv", CConv))
     !isnothing(personality) && push!(attributes, namedattribute("personality", personality))
-    !isnothing(garbageCollector) &&
-        push!(attributes, namedattribute("garbageCollector", garbageCollector))
+    !isnothing(garbageCollector) && push!(attributes, namedattribute("garbageCollector", garbageCollector))
     !isnothing(passthrough) && push!(attributes, namedattribute("passthrough", passthrough))
     !isnothing(arg_attrs) && push!(attributes, namedattribute("arg_attrs", arg_attrs))
     !isnothing(res_attrs) && push!(attributes, namedattribute("res_attrs", res_attrs))
-    !isnothing(function_entry_count) &&
-        push!(attributes, namedattribute("function_entry_count", function_entry_count))
+    !isnothing(function_entry_count) && push!(attributes, namedattribute("function_entry_count", function_entry_count))
     !isnothing(memory) && push!(attributes, namedattribute("memory", memory))
-
-    return IR.create_operation(
-        "llvm.func",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.func", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1532,25 +1158,19 @@ end
 `lshr`
 
 """
-function lshr(
-    lhs::Value, rhs::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function lshr(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "llvm.lshr",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.lshr", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1558,25 +1178,19 @@ end
 `landingpad`
 
 """
-function landingpad(
-    operand_0::Vector{Value}; res::IR.Type, cleanup=nothing, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0...,]
+function landingpad(operand_0::Vector{Value}; res::IR.Type, cleanup=nothing, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(cleanup) && push!(attributes, namedattribute("cleanup", cleanup))
-
-    return IR.create_operation(
-        "llvm.landingpad",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.landingpad", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1584,41 +1198,24 @@ end
 `load`
 
 """
-function load(
-    addr::Value;
-    res::IR.Type,
-    access_groups=nothing,
-    alias_scopes=nothing,
-    noalias_scopes=nothing,
-    alignment=nothing,
-    volatile_=nothing,
-    nontemporal=nothing,
-    location=Location(),
-)
-    results = IR.Type[res,]
-    operands = Value[addr,]
+function load(addr::Value; res::IR.Type, access_groups=nothing, alias_scopes=nothing, noalias_scopes=nothing, alignment=nothing, volatile_=nothing, nontemporal=nothing, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[addr, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(access_groups) &&
-        push!(attributes, namedattribute("access_groups", access_groups))
-    !isnothing(alias_scopes) &&
-        push!(attributes, namedattribute("alias_scopes", alias_scopes))
-    !isnothing(noalias_scopes) &&
-        push!(attributes, namedattribute("noalias_scopes", noalias_scopes))
+    !isnothing(access_groups) && push!(attributes, namedattribute("access_groups", access_groups))
+    !isnothing(alias_scopes) && push!(attributes, namedattribute("alias_scopes", alias_scopes))
+    !isnothing(noalias_scopes) && push!(attributes, namedattribute("noalias_scopes", noalias_scopes))
     !isnothing(alignment) && push!(attributes, namedattribute("alignment", alignment))
     !isnothing(volatile_) && push!(attributes, namedattribute("volatile_", volatile_))
     !isnothing(nontemporal) && push!(attributes, namedattribute("nontemporal", nontemporal))
-
-    return IR.create_operation(
-        "llvm.load",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.load", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1636,19 +1233,15 @@ llvm.metadata op defines one or more metadata nodes.
 function metadata(; sym_name, body::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[body,]
+    owned_regions = Region[body, ]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("sym_name", sym_name),]
-
-    return IR.create_operation(
-        "llvm.metadata",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("sym_name", sym_name), ]
+    
+    IR.create_operation(
+        "llvm.metadata", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1656,25 +1249,19 @@ end
 `mul`
 
 """
-function mul(
-    lhs::Value, rhs::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function mul(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "llvm.mul",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.mul", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1697,21 +1284,17 @@ Examples:
 ```
 """
 function mlir_null(; res::IR.Type, location=Location())
-    results = IR.Type[res,]
+    results = IR.Type[res, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.mlir.null",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.mlir.null", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1719,25 +1302,19 @@ end
 `or`
 
 """
-function or(
-    lhs::Value, rhs::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function or(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "llvm.or",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.or", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1746,21 +1323,17 @@ end
 
 """
 function ptrtoint(arg::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[arg,]
+    results = IR.Type[res, ]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.ptrtoint",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.ptrtoint", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1770,20 +1343,16 @@ end
 """
 function resume(value::Value; location=Location())
     results = IR.Type[]
-    operands = Value[value,]
+    operands = Value[value, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.resume",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.resume", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1791,23 +1360,19 @@ end
 `return_`
 
 """
-function return_(arg=nothing::Union{Nothing,Value}; location=Location())
+function return_(arg=nothing::Union{Nothing, Value}; location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(arg) && push!(operands, arg)
-
-    return IR.create_operation(
-        "llvm.return",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.return", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1815,25 +1380,19 @@ end
 `sdiv`
 
 """
-function sdiv(
-    lhs::Value, rhs::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function sdiv(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "llvm.sdiv",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.sdiv", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1842,21 +1401,17 @@ end
 
 """
 function sext(arg::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[arg,]
+    results = IR.Type[res, ]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.sext",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.sext", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1865,21 +1420,17 @@ end
 
 """
 function sitofp(arg::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[arg,]
+    results = IR.Type[res, ]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.sitofp",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.sitofp", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1887,25 +1438,19 @@ end
 `srem`
 
 """
-function srem(
-    lhs::Value, rhs::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function srem(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "llvm.srem",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.srem", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1913,29 +1458,19 @@ end
 `select`
 
 """
-function select(
-    condition::Value,
-    trueValue::Value,
-    falseValue::Value;
-    res=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function select(condition::Value, trueValue::Value, falseValue::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[condition, trueValue, falseValue]
+    operands = Value[condition, trueValue, falseValue, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "llvm.select",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.select", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1943,25 +1478,19 @@ end
 `shl`
 
 """
-function shl(
-    lhs::Value, rhs::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function shl(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "llvm.shl",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.shl", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1970,21 +1499,17 @@ end
 
 """
 function shufflevector(v1::Value, v2::Value; res::IR.Type, mask, location=Location())
-    results = IR.Type[res,]
-    operands = Value[v1, v2]
+    results = IR.Type[res, ]
+    operands = Value[v1, v2, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("mask", mask),]
-
-    return IR.create_operation(
-        "llvm.shufflevector",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("mask", mask), ]
+    
+    IR.create_operation(
+        "llvm.shufflevector", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1992,41 +1517,24 @@ end
 `store`
 
 """
-function store(
-    value::Value,
-    addr::Value;
-    access_groups=nothing,
-    alias_scopes=nothing,
-    noalias_scopes=nothing,
-    alignment=nothing,
-    volatile_=nothing,
-    nontemporal=nothing,
-    location=Location(),
-)
+function store(value::Value, addr::Value; access_groups=nothing, alias_scopes=nothing, noalias_scopes=nothing, alignment=nothing, volatile_=nothing, nontemporal=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[value, addr]
+    operands = Value[value, addr, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(access_groups) &&
-        push!(attributes, namedattribute("access_groups", access_groups))
-    !isnothing(alias_scopes) &&
-        push!(attributes, namedattribute("alias_scopes", alias_scopes))
-    !isnothing(noalias_scopes) &&
-        push!(attributes, namedattribute("noalias_scopes", noalias_scopes))
+    !isnothing(access_groups) && push!(attributes, namedattribute("access_groups", access_groups))
+    !isnothing(alias_scopes) && push!(attributes, namedattribute("alias_scopes", alias_scopes))
+    !isnothing(noalias_scopes) && push!(attributes, namedattribute("noalias_scopes", noalias_scopes))
     !isnothing(alignment) && push!(attributes, namedattribute("alignment", alignment))
     !isnothing(volatile_) && push!(attributes, namedattribute("volatile_", volatile_))
     !isnothing(nontemporal) && push!(attributes, namedattribute("nontemporal", nontemporal))
-
-    return IR.create_operation(
-        "llvm.store",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.store", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2034,25 +1542,19 @@ end
 `sub`
 
 """
-function sub(
-    lhs::Value, rhs::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function sub(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "llvm.sub",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.sub", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -2060,40 +1562,21 @@ end
 `switch`
 
 """
-function switch(
-    value::Value,
-    defaultOperands::Vector{Value},
-    caseOperands::Vector{Value};
-    case_values=nothing,
-    case_operand_segments,
-    branch_weights=nothing,
-    defaultDestination::Block,
-    caseDestinations::Vector{Block},
-    location=Location(),
-)
+function switch(value::Value, defaultOperands::Vector{Value}, caseOperands::Vector{Value}; case_values=nothing, case_operand_segments, branch_weights=nothing, defaultDestination::Block, caseDestinations::Vector{Block}, location=Location())
     results = IR.Type[]
-    operands = Value[value, defaultOperands..., caseOperands...]
+    operands = Value[value, defaultOperands..., caseOperands..., ]
     owned_regions = Region[]
-    successors = Block[defaultDestination, caseDestinations...]
-    attributes = NamedAttribute[namedattribute(
-        "case_operand_segments", case_operand_segments
-    ),]
-    push!(
-        attributes, operandsegmentsizes([1, length(defaultOperands), length(caseOperands)])
-    )
+    successors = Block[defaultDestination, caseDestinations..., ]
+    attributes = NamedAttribute[namedattribute("case_operand_segments", case_operand_segments), ]
+    push!(attributes, operandsegmentsizes([1, length(defaultOperands), length(caseOperands), ]))
     !isnothing(case_values) && push!(attributes, namedattribute("case_values", case_values))
-    !isnothing(branch_weights) &&
-        push!(attributes, namedattribute("branch_weights", branch_weights))
-
-    return IR.create_operation(
-        "llvm.switch",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(branch_weights) && push!(attributes, namedattribute("branch_weights", branch_weights))
+    
+    IR.create_operation(
+        "llvm.switch", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2115,19 +1598,13 @@ function tbaa_root(; sym_name, identity, location=Location())
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("sym_name", sym_name), namedattribute("identity", identity)
-    ]
-
-    return IR.create_operation(
-        "llvm.tbaa_root",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("sym_name", sym_name), namedattribute("identity", identity), ]
+    
+    IR.create_operation(
+        "llvm.tbaa_root", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2179,30 +1656,19 @@ Defines a TBAA node describing a memory access.
 See the following link for more details:
 https://llvm.org/docs/LangRef.html#tbaa-metadata
 """
-function tbaa_tag(;
-    sym_name, base_type, access_type, offset, constant=nothing, location=Location()
-)
+function tbaa_tag(; sym_name, base_type, access_type, offset, constant=nothing, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("sym_name", sym_name),
-        namedattribute("base_type", base_type),
-        namedattribute("access_type", access_type),
-        namedattribute("offset", offset),
-    ]
+    attributes = NamedAttribute[namedattribute("sym_name", sym_name), namedattribute("base_type", base_type), namedattribute("access_type", access_type), namedattribute("offset", offset), ]
     !isnothing(constant) && push!(attributes, namedattribute("constant", constant))
-
-    return IR.create_operation(
-        "llvm.tbaa_tag",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.tbaa_tag", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2249,22 +1715,14 @@ function tbaa_type_desc(; sym_name, identity=nothing, members, offsets, location
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("sym_name", sym_name),
-        namedattribute("members", members),
-        namedattribute("offsets", offsets),
-    ]
+    attributes = NamedAttribute[namedattribute("sym_name", sym_name), namedattribute("members", members), namedattribute("offsets", offsets), ]
     !isnothing(identity) && push!(attributes, namedattribute("identity", identity))
-
-    return IR.create_operation(
-        "llvm.tbaa_type_desc",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.tbaa_type_desc", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2273,21 +1731,17 @@ end
 
 """
 function trunc(arg::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[arg,]
+    results = IR.Type[res, ]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.trunc",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.trunc", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2295,25 +1749,19 @@ end
 `udiv`
 
 """
-function udiv(
-    lhs::Value, rhs::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function udiv(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "llvm.udiv",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.udiv", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -2322,21 +1770,17 @@ end
 
 """
 function uitofp(arg::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[arg,]
+    results = IR.Type[res, ]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.uitofp",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.uitofp", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2344,25 +1788,19 @@ end
 `urem`
 
 """
-function urem(
-    lhs::Value, rhs::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function urem(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "llvm.urem",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.urem", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -2382,21 +1820,17 @@ IR dialect type wrapping an LLVM IR structure type.
 ```
 """
 function mlir_undef(; res::IR.Type, location=Location())
-    results = IR.Type[res,]
+    results = IR.Type[res, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.mlir.undef",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.mlir.undef", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2410,16 +1844,12 @@ function unreachable(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.unreachable",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.unreachable", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2427,25 +1857,19 @@ end
 `xor`
 
 """
-function xor(
-    lhs::Value, rhs::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function xor(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "llvm.xor",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.xor", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -2454,48 +1878,40 @@ end
 
 """
 function zext(arg::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[arg,]
+    results = IR.Type[res, ]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.zext",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.zext", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `intr_abs`
 
 """
 function intr_abs(in::Value, is_int_min_poison::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[in, is_int_min_poison]
+    results = IR.Type[res, ]
+    operands = Value[in, is_int_min_poison, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.intr.abs",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.abs", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2505,20 +1921,16 @@ end
 """
 function intr_assume(cond::Value; location=Location())
     results = IR.Type[]
-    operands = Value[cond,]
+    operands = Value[cond, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.intr.assume",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.assume", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2526,25 +1938,19 @@ end
 `intr_bitreverse`
 
 """
-function intr_bitreverse(
-    in::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function intr_bitreverse(in::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[in,]
+    operands = Value[in, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "llvm.intr.bitreverse",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.bitreverse", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -2554,24 +1960,18 @@ end
 Call the specified llvm intrinsic. If the intrinsic is overloaded, use
 the MLIR function type of this op to determine which intrinsic to call.
 """
-function call_intrinsic(
-    args::Vector{Value}; results::Vector{IR.Type}, intrin, location=Location()
-)
-    results = IR.Type[results...,]
-    operands = Value[args...,]
+function call_intrinsic(args::Vector{Value}; results_::Vector{IR.Type}, intrin, location=Location())
+    results = IR.Type[results_..., ]
+    operands = Value[args..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("intrin", intrin),]
-
-    return IR.create_operation(
-        "llvm.call_intrinsic",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("intrin", intrin), ]
+    
+    IR.create_operation(
+        "llvm.call_intrinsic", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2579,31 +1979,20 @@ end
 `intr_copysign`
 
 """
-function intr_copysign(
-    a::Value,
-    b::Value;
-    res=nothing::Union{Nothing,IR.Type},
-    fastmathFlags=nothing,
-    location=Location(),
-)
+function intr_copysign(a::Value, b::Value; res=nothing::Union{Nothing, IR.Type}, fastmathFlags=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[a, b]
+    operands = Value[a, b, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-    !isnothing(fastmathFlags) &&
-        push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
-
-    return IR.create_operation(
-        "llvm.intr.copysign",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(fastmathFlags) && push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
+    
+    IR.create_operation(
+        "llvm.intr.copysign", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -2612,21 +2001,17 @@ end
 
 """
 function intr_coro_align(; res::IR.Type, location=Location())
-    results = IR.Type[res,]
+    results = IR.Type[res, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.intr.coro.align",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.coro.align", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2635,21 +2020,17 @@ end
 
 """
 function intr_coro_begin(token::Value, mem::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[token, mem]
+    results = IR.Type[res, ]
+    operands = Value[token, mem, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.intr.coro.begin",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.coro.begin", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2658,21 +2039,17 @@ end
 
 """
 function intr_coro_end(handle::Value, unwind::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[handle, unwind]
+    results = IR.Type[res, ]
+    operands = Value[handle, unwind, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.intr.coro.end",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.coro.end", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2681,21 +2058,17 @@ end
 
 """
 function intr_coro_free(id::Value, handle::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[id, handle]
+    results = IR.Type[res, ]
+    operands = Value[id, handle, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.intr.coro.free",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.coro.free", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2703,29 +2076,18 @@ end
 `intr_coro_id`
 
 """
-function intr_coro_id(
-    align::Value,
-    promise::Value,
-    coroaddr::Value,
-    fnaddrs::Value;
-    res::IR.Type,
-    location=Location(),
-)
-    results = IR.Type[res,]
-    operands = Value[align, promise, coroaddr, fnaddrs]
+function intr_coro_id(align::Value, promise::Value, coroaddr::Value, fnaddrs::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[align, promise, coroaddr, fnaddrs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.intr.coro.id",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.coro.id", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2735,20 +2097,16 @@ end
 """
 function intr_coro_resume(handle::Value; location=Location())
     results = IR.Type[]
-    operands = Value[handle,]
+    operands = Value[handle, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.intr.coro.resume",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.coro.resume", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2757,21 +2115,17 @@ end
 
 """
 function intr_coro_save(handle::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[handle,]
+    results = IR.Type[res, ]
+    operands = Value[handle, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.intr.coro.save",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.coro.save", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2780,21 +2134,17 @@ end
 
 """
 function intr_coro_size(; res::IR.Type, location=Location())
-    results = IR.Type[res,]
+    results = IR.Type[res, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.intr.coro.size",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.coro.size", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2803,21 +2153,17 @@ end
 
 """
 function intr_coro_suspend(save::Value, final::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[save, final]
+    results = IR.Type[res, ]
+    operands = Value[save, final, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.intr.coro.suspend",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.coro.suspend", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2825,30 +2171,20 @@ end
 `intr_cos`
 
 """
-function intr_cos(
-    in::Value;
-    res=nothing::Union{Nothing,IR.Type},
-    fastmathFlags=nothing,
-    location=Location(),
-)
+function intr_cos(in::Value; res=nothing::Union{Nothing, IR.Type}, fastmathFlags=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[in,]
+    operands = Value[in, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-    !isnothing(fastmathFlags) &&
-        push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
-
-    return IR.create_operation(
-        "llvm.intr.cos",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(fastmathFlags) && push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
+    
+    IR.create_operation(
+        "llvm.intr.cos", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -2857,21 +2193,17 @@ end
 
 """
 function intr_ctlz(in::Value, zero_undefined::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[in, zero_undefined]
+    results = IR.Type[res, ]
+    operands = Value[in, zero_undefined, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.intr.ctlz",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.ctlz", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2880,21 +2212,17 @@ end
 
 """
 function intr_cttz(in::Value, zero_undefined::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[in, zero_undefined]
+    results = IR.Type[res, ]
+    operands = Value[in, zero_undefined, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.intr.cttz",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.cttz", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2902,23 +2230,19 @@ end
 `intr_ctpop`
 
 """
-function intr_ctpop(in::Value; res=nothing::Union{Nothing,IR.Type}, location=Location())
+function intr_ctpop(in::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[in,]
+    operands = Value[in, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "llvm.intr.ctpop",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.ctpop", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -2928,20 +2252,16 @@ end
 """
 function intr_dbg_addr(addr::Value; varInfo, location=Location())
     results = IR.Type[]
-    operands = Value[addr,]
+    operands = Value[addr, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("varInfo", varInfo),]
-
-    return IR.create_operation(
-        "llvm.intr.dbg.addr",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("varInfo", varInfo), ]
+    
+    IR.create_operation(
+        "llvm.intr.dbg.addr", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2951,20 +2271,16 @@ end
 """
 function intr_dbg_declare(addr::Value; varInfo, location=Location())
     results = IR.Type[]
-    operands = Value[addr,]
+    operands = Value[addr, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("varInfo", varInfo),]
-
-    return IR.create_operation(
-        "llvm.intr.dbg.declare",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("varInfo", varInfo), ]
+    
+    IR.create_operation(
+        "llvm.intr.dbg.declare", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2974,20 +2290,16 @@ end
 """
 function intr_dbg_value(value::Value; varInfo, location=Location())
     results = IR.Type[]
-    operands = Value[value,]
+    operands = Value[value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("varInfo", varInfo),]
-
-    return IR.create_operation(
-        "llvm.intr.dbg.value",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("varInfo", varInfo), ]
+    
+    IR.create_operation(
+        "llvm.intr.dbg.value", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2996,21 +2308,17 @@ end
 
 """
 function intr_eh_typeid_for(type_info::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[type_info,]
+    results = IR.Type[res, ]
+    operands = Value[type_info, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.intr.eh.typeid.for",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.eh.typeid.for", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -3018,30 +2326,20 @@ end
 `intr_exp2`
 
 """
-function intr_exp2(
-    in::Value;
-    res=nothing::Union{Nothing,IR.Type},
-    fastmathFlags=nothing,
-    location=Location(),
-)
+function intr_exp2(in::Value; res=nothing::Union{Nothing, IR.Type}, fastmathFlags=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[in,]
+    operands = Value[in, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-    !isnothing(fastmathFlags) &&
-        push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
-
-    return IR.create_operation(
-        "llvm.intr.exp2",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(fastmathFlags) && push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
+    
+    IR.create_operation(
+        "llvm.intr.exp2", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -3049,30 +2347,20 @@ end
 `intr_exp`
 
 """
-function intr_exp(
-    in::Value;
-    res=nothing::Union{Nothing,IR.Type},
-    fastmathFlags=nothing,
-    location=Location(),
-)
+function intr_exp(in::Value; res=nothing::Union{Nothing, IR.Type}, fastmathFlags=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[in,]
+    operands = Value[in, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-    !isnothing(fastmathFlags) &&
-        push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
-
-    return IR.create_operation(
-        "llvm.intr.exp",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(fastmathFlags) && push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
+    
+    IR.create_operation(
+        "llvm.intr.exp", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -3080,30 +2368,20 @@ end
 `intr_fabs`
 
 """
-function intr_fabs(
-    in::Value;
-    res=nothing::Union{Nothing,IR.Type},
-    fastmathFlags=nothing,
-    location=Location(),
-)
+function intr_fabs(in::Value; res=nothing::Union{Nothing, IR.Type}, fastmathFlags=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[in,]
+    operands = Value[in, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-    !isnothing(fastmathFlags) &&
-        push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
-
-    return IR.create_operation(
-        "llvm.intr.fabs",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(fastmathFlags) && push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
+    
+    IR.create_operation(
+        "llvm.intr.fabs", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -3111,30 +2389,20 @@ end
 `intr_ceil`
 
 """
-function intr_ceil(
-    in::Value;
-    res=nothing::Union{Nothing,IR.Type},
-    fastmathFlags=nothing,
-    location=Location(),
-)
+function intr_ceil(in::Value; res=nothing::Union{Nothing, IR.Type}, fastmathFlags=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[in,]
+    operands = Value[in, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-    !isnothing(fastmathFlags) &&
-        push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
-
-    return IR.create_operation(
-        "llvm.intr.ceil",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(fastmathFlags) && push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
+    
+    IR.create_operation(
+        "llvm.intr.ceil", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -3142,30 +2410,20 @@ end
 `intr_floor`
 
 """
-function intr_floor(
-    in::Value;
-    res=nothing::Union{Nothing,IR.Type},
-    fastmathFlags=nothing,
-    location=Location(),
-)
+function intr_floor(in::Value; res=nothing::Union{Nothing, IR.Type}, fastmathFlags=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[in,]
+    operands = Value[in, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-    !isnothing(fastmathFlags) &&
-        push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
-
-    return IR.create_operation(
-        "llvm.intr.floor",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(fastmathFlags) && push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
+    
+    IR.create_operation(
+        "llvm.intr.floor", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -3173,32 +2431,20 @@ end
 `intr_fma`
 
 """
-function intr_fma(
-    a::Value,
-    b::Value,
-    c::Value;
-    res=nothing::Union{Nothing,IR.Type},
-    fastmathFlags=nothing,
-    location=Location(),
-)
+function intr_fma(a::Value, b::Value, c::Value; res=nothing::Union{Nothing, IR.Type}, fastmathFlags=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[a, b, c]
+    operands = Value[a, b, c, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-    !isnothing(fastmathFlags) &&
-        push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
-
-    return IR.create_operation(
-        "llvm.intr.fma",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(fastmathFlags) && push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
+    
+    IR.create_operation(
+        "llvm.intr.fma", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -3206,32 +2452,20 @@ end
 `intr_fmuladd`
 
 """
-function intr_fmuladd(
-    a::Value,
-    b::Value,
-    c::Value;
-    res=nothing::Union{Nothing,IR.Type},
-    fastmathFlags=nothing,
-    location=Location(),
-)
+function intr_fmuladd(a::Value, b::Value, c::Value; res=nothing::Union{Nothing, IR.Type}, fastmathFlags=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[a, b, c]
+    operands = Value[a, b, c, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-    !isnothing(fastmathFlags) &&
-        push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
-
-    return IR.create_operation(
-        "llvm.intr.fmuladd",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(fastmathFlags) && push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
+    
+    IR.create_operation(
+        "llvm.intr.fmuladd", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -3239,30 +2473,20 @@ end
 `intr_trunc`
 
 """
-function intr_trunc(
-    in::Value;
-    res=nothing::Union{Nothing,IR.Type},
-    fastmathFlags=nothing,
-    location=Location(),
-)
+function intr_trunc(in::Value; res=nothing::Union{Nothing, IR.Type}, fastmathFlags=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[in,]
+    operands = Value[in, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-    !isnothing(fastmathFlags) &&
-        push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
-
-    return IR.create_operation(
-        "llvm.intr.trunc",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(fastmathFlags) && push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
+    
+    IR.create_operation(
+        "llvm.intr.trunc", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -3271,21 +2495,17 @@ end
 
 """
 function intr_get_active_lane_mask(base::Value, n::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[base, n]
+    results = IR.Type[res, ]
+    operands = Value[base, n, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.intr.get.active.lane.mask",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.get.active.lane.mask", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -3294,21 +2514,17 @@ end
 
 """
 function intr_is_fpclass(in::Value, bit::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[in, bit]
+    results = IR.Type[res, ]
+    operands = Value[in, bit, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.intr.is.fpclass",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.is.fpclass", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -3318,20 +2534,16 @@ end
 """
 function intr_lifetime_end(ptr::Value; size, location=Location())
     results = IR.Type[]
-    operands = Value[ptr,]
+    operands = Value[ptr, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("size", size),]
-
-    return IR.create_operation(
-        "llvm.intr.lifetime.end",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("size", size), ]
+    
+    IR.create_operation(
+        "llvm.intr.lifetime.end", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -3341,20 +2553,16 @@ end
 """
 function intr_lifetime_start(ptr::Value; size, location=Location())
     results = IR.Type[]
-    operands = Value[ptr,]
+    operands = Value[ptr, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("size", size),]
-
-    return IR.create_operation(
-        "llvm.intr.lifetime.start",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("size", size), ]
+    
+    IR.create_operation(
+        "llvm.intr.lifetime.start", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -3362,30 +2570,20 @@ end
 `intr_log10`
 
 """
-function intr_log10(
-    in::Value;
-    res=nothing::Union{Nothing,IR.Type},
-    fastmathFlags=nothing,
-    location=Location(),
-)
+function intr_log10(in::Value; res=nothing::Union{Nothing, IR.Type}, fastmathFlags=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[in,]
+    operands = Value[in, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-    !isnothing(fastmathFlags) &&
-        push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
-
-    return IR.create_operation(
-        "llvm.intr.log10",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(fastmathFlags) && push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
+    
+    IR.create_operation(
+        "llvm.intr.log10", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -3393,30 +2591,20 @@ end
 `intr_log2`
 
 """
-function intr_log2(
-    in::Value;
-    res=nothing::Union{Nothing,IR.Type},
-    fastmathFlags=nothing,
-    location=Location(),
-)
+function intr_log2(in::Value; res=nothing::Union{Nothing, IR.Type}, fastmathFlags=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[in,]
+    operands = Value[in, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-    !isnothing(fastmathFlags) &&
-        push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
-
-    return IR.create_operation(
-        "llvm.intr.log2",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(fastmathFlags) && push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
+    
+    IR.create_operation(
+        "llvm.intr.log2", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -3424,30 +2612,20 @@ end
 `intr_log`
 
 """
-function intr_log(
-    in::Value;
-    res=nothing::Union{Nothing,IR.Type},
-    fastmathFlags=nothing,
-    location=Location(),
-)
+function intr_log(in::Value; res=nothing::Union{Nothing, IR.Type}, fastmathFlags=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[in,]
+    operands = Value[in, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-    !isnothing(fastmathFlags) &&
-        push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
-
-    return IR.create_operation(
-        "llvm.intr.log",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(fastmathFlags) && push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
+    
+    IR.create_operation(
+        "llvm.intr.log", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -3455,29 +2633,18 @@ end
 `intr_masked_load`
 
 """
-function intr_masked_load(
-    data::Value,
-    mask::Value,
-    pass_thru::Vector{Value};
-    res::IR.Type,
-    alignment,
-    location=Location(),
-)
-    results = IR.Type[res,]
-    operands = Value[data, mask, pass_thru...]
+function intr_masked_load(data::Value, mask::Value, pass_thru::Vector{Value}; res::IR.Type, alignment, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[data, mask, pass_thru..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("alignment", alignment),]
-
-    return IR.create_operation(
-        "llvm.intr.masked.load",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("alignment", alignment), ]
+    
+    IR.create_operation(
+        "llvm.intr.masked.load", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -3485,24 +2652,18 @@ end
 `intr_masked_store`
 
 """
-function intr_masked_store(
-    value::Value, data::Value, mask::Value; alignment, location=Location()
-)
+function intr_masked_store(value::Value, data::Value, mask::Value; alignment, location=Location())
     results = IR.Type[]
-    operands = Value[value, data, mask]
+    operands = Value[value, data, mask, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("alignment", alignment),]
-
-    return IR.create_operation(
-        "llvm.intr.masked.store",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("alignment", alignment), ]
+    
+    IR.create_operation(
+        "llvm.intr.masked.store", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -3510,28 +2671,18 @@ end
 `intr_matrix_column_major_load`
 
 """
-function intr_matrix_column_major_load(
-    data::Value, stride::Value; res::IR.Type, isVolatile, rows, columns, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[data, stride]
+function intr_matrix_column_major_load(data::Value, stride::Value; res::IR.Type, isVolatile, rows, columns, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[data, stride, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("isVolatile", isVolatile),
-        namedattribute("rows", rows),
-        namedattribute("columns", columns),
-    ]
-
-    return IR.create_operation(
-        "llvm.intr.matrix.column.major.load",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("isVolatile", isVolatile), namedattribute("rows", rows), namedattribute("columns", columns), ]
+    
+    IR.create_operation(
+        "llvm.intr.matrix.column.major.load", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -3539,34 +2690,18 @@ end
 `intr_matrix_column_major_store`
 
 """
-function intr_matrix_column_major_store(
-    matrix::Value,
-    data::Value,
-    stride::Value;
-    isVolatile,
-    rows,
-    columns,
-    location=Location(),
-)
+function intr_matrix_column_major_store(matrix::Value, data::Value, stride::Value; isVolatile, rows, columns, location=Location())
     results = IR.Type[]
-    operands = Value[matrix, data, stride]
+    operands = Value[matrix, data, stride, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("isVolatile", isVolatile),
-        namedattribute("rows", rows),
-        namedattribute("columns", columns),
-    ]
-
-    return IR.create_operation(
-        "llvm.intr.matrix.column.major.store",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("isVolatile", isVolatile), namedattribute("rows", rows), namedattribute("columns", columns), ]
+    
+    IR.create_operation(
+        "llvm.intr.matrix.column.major.store", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -3574,34 +2709,18 @@ end
 `intr_matrix_multiply`
 
 """
-function intr_matrix_multiply(
-    lhs::Value,
-    rhs::Value;
-    res::IR.Type,
-    lhs_rows,
-    lhs_columns,
-    rhs_columns,
-    location=Location(),
-)
-    results = IR.Type[res,]
-    operands = Value[lhs, rhs]
+function intr_matrix_multiply(lhs::Value, rhs::Value; res::IR.Type, lhs_rows, lhs_columns, rhs_columns, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("lhs_rows", lhs_rows),
-        namedattribute("lhs_columns", lhs_columns),
-        namedattribute("rhs_columns", rhs_columns),
-    ]
-
-    return IR.create_operation(
-        "llvm.intr.matrix.multiply",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("lhs_rows", lhs_rows), namedattribute("lhs_columns", lhs_columns), namedattribute("rhs_columns", rhs_columns), ]
+    
+    IR.create_operation(
+        "llvm.intr.matrix.multiply", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -3609,26 +2728,18 @@ end
 `intr_matrix_transpose`
 
 """
-function intr_matrix_transpose(
-    matrix::Value; res::IR.Type, rows, columns, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[matrix,]
+function intr_matrix_transpose(matrix::Value; res::IR.Type, rows, columns, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[matrix, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("rows", rows), namedattribute("columns", columns)
-    ]
-
-    return IR.create_operation(
-        "llvm.intr.matrix.transpose",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("rows", rows), namedattribute("columns", columns), ]
+    
+    IR.create_operation(
+        "llvm.intr.matrix.transpose", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -3636,31 +2747,20 @@ end
 `intr_maxnum`
 
 """
-function intr_maxnum(
-    a::Value,
-    b::Value;
-    res=nothing::Union{Nothing,IR.Type},
-    fastmathFlags=nothing,
-    location=Location(),
-)
+function intr_maxnum(a::Value, b::Value; res=nothing::Union{Nothing, IR.Type}, fastmathFlags=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[a, b]
+    operands = Value[a, b, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-    !isnothing(fastmathFlags) &&
-        push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
-
-    return IR.create_operation(
-        "llvm.intr.maxnum",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(fastmathFlags) && push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
+    
+    IR.create_operation(
+        "llvm.intr.maxnum", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -3668,31 +2768,20 @@ end
 `intr_maximum`
 
 """
-function intr_maximum(
-    a::Value,
-    b::Value;
-    res=nothing::Union{Nothing,IR.Type},
-    fastmathFlags=nothing,
-    location=Location(),
-)
+function intr_maximum(a::Value, b::Value; res=nothing::Union{Nothing, IR.Type}, fastmathFlags=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[a, b]
+    operands = Value[a, b, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-    !isnothing(fastmathFlags) &&
-        push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
-
-    return IR.create_operation(
-        "llvm.intr.maximum",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(fastmathFlags) && push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
+    
+    IR.create_operation(
+        "llvm.intr.maximum", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -3700,24 +2789,18 @@ end
 `intr_memcpy_inline`
 
 """
-function intr_memcpy_inline(
-    dst::Value, src::Value, len::Value, isVolatile::Value; location=Location()
-)
+function intr_memcpy_inline(dst::Value, src::Value, len::Value, isVolatile::Value; location=Location())
     results = IR.Type[]
-    operands = Value[dst, src, len, isVolatile]
+    operands = Value[dst, src, len, isVolatile, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.intr.memcpy.inline",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.memcpy.inline", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -3725,24 +2808,18 @@ end
 `intr_memcpy`
 
 """
-function intr_memcpy(
-    dst::Value, src::Value, len::Value, isVolatile::Value; location=Location()
-)
+function intr_memcpy(dst::Value, src::Value, len::Value, isVolatile::Value; location=Location())
     results = IR.Type[]
-    operands = Value[dst, src, len, isVolatile]
+    operands = Value[dst, src, len, isVolatile, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.intr.memcpy",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.memcpy", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -3750,24 +2827,18 @@ end
 `intr_memmove`
 
 """
-function intr_memmove(
-    dst::Value, src::Value, len::Value, isVolatile::Value; location=Location()
-)
+function intr_memmove(dst::Value, src::Value, len::Value, isVolatile::Value; location=Location())
     results = IR.Type[]
-    operands = Value[dst, src, len, isVolatile]
+    operands = Value[dst, src, len, isVolatile, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.intr.memmove",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.memmove", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -3775,24 +2846,18 @@ end
 `intr_memset`
 
 """
-function intr_memset(
-    dst::Value, val::Value, len::Value, isVolatile::Value; location=Location()
-)
+function intr_memset(dst::Value, val::Value, len::Value, isVolatile::Value; location=Location())
     results = IR.Type[]
-    operands = Value[dst, val, len, isVolatile]
+    operands = Value[dst, val, len, isVolatile, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.intr.memset",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.memset", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -3800,31 +2865,20 @@ end
 `intr_minnum`
 
 """
-function intr_minnum(
-    a::Value,
-    b::Value;
-    res=nothing::Union{Nothing,IR.Type},
-    fastmathFlags=nothing,
-    location=Location(),
-)
+function intr_minnum(a::Value, b::Value; res=nothing::Union{Nothing, IR.Type}, fastmathFlags=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[a, b]
+    operands = Value[a, b, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-    !isnothing(fastmathFlags) &&
-        push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
-
-    return IR.create_operation(
-        "llvm.intr.minnum",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(fastmathFlags) && push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
+    
+    IR.create_operation(
+        "llvm.intr.minnum", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -3832,31 +2886,20 @@ end
 `intr_minimum`
 
 """
-function intr_minimum(
-    a::Value,
-    b::Value;
-    res=nothing::Union{Nothing,IR.Type},
-    fastmathFlags=nothing,
-    location=Location(),
-)
+function intr_minimum(a::Value, b::Value; res=nothing::Union{Nothing, IR.Type}, fastmathFlags=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[a, b]
+    operands = Value[a, b, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-    !isnothing(fastmathFlags) &&
-        push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
-
-    return IR.create_operation(
-        "llvm.intr.minimum",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(fastmathFlags) && push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
+    
+    IR.create_operation(
+        "llvm.intr.minimum", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -3864,26 +2907,19 @@ end
 `intr_powi`
 
 """
-function intr_powi(
-    val::Value, power::Value; res::IR.Type, fastmathFlags=nothing, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[val, power]
+function intr_powi(val::Value, power::Value; res::IR.Type, fastmathFlags=nothing, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[val, power, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(fastmathFlags) &&
-        push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
-
-    return IR.create_operation(
-        "llvm.intr.powi",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(fastmathFlags) && push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
+    
+    IR.create_operation(
+        "llvm.intr.powi", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -3891,31 +2927,20 @@ end
 `intr_pow`
 
 """
-function intr_pow(
-    a::Value,
-    b::Value;
-    res=nothing::Union{Nothing,IR.Type},
-    fastmathFlags=nothing,
-    location=Location(),
-)
+function intr_pow(a::Value, b::Value; res=nothing::Union{Nothing, IR.Type}, fastmathFlags=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[a, b]
+    operands = Value[a, b, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-    !isnothing(fastmathFlags) &&
-        push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
-
-    return IR.create_operation(
-        "llvm.intr.pow",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(fastmathFlags) && push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
+    
+    IR.create_operation(
+        "llvm.intr.pow", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -3923,24 +2948,18 @@ end
 `intr_prefetch`
 
 """
-function intr_prefetch(
-    addr::Value, rw::Value, hint::Value, cache::Value; location=Location()
-)
+function intr_prefetch(addr::Value, rw::Value, hint::Value, cache::Value; location=Location())
     results = IR.Type[]
-    operands = Value[addr, rw, hint, cache]
+    operands = Value[addr, rw, hint, cache, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.intr.prefetch",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.prefetch", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -3948,30 +2967,20 @@ end
 `intr_roundeven`
 
 """
-function intr_roundeven(
-    in::Value;
-    res=nothing::Union{Nothing,IR.Type},
-    fastmathFlags=nothing,
-    location=Location(),
-)
+function intr_roundeven(in::Value; res=nothing::Union{Nothing, IR.Type}, fastmathFlags=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[in,]
+    operands = Value[in, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-    !isnothing(fastmathFlags) &&
-        push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
-
-    return IR.create_operation(
-        "llvm.intr.roundeven",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(fastmathFlags) && push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
+    
+    IR.create_operation(
+        "llvm.intr.roundeven", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -3979,30 +2988,20 @@ end
 `intr_round`
 
 """
-function intr_round(
-    in::Value;
-    res=nothing::Union{Nothing,IR.Type},
-    fastmathFlags=nothing,
-    location=Location(),
-)
+function intr_round(in::Value; res=nothing::Union{Nothing, IR.Type}, fastmathFlags=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[in,]
+    operands = Value[in, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-    !isnothing(fastmathFlags) &&
-        push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
-
-    return IR.create_operation(
-        "llvm.intr.round",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(fastmathFlags) && push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
+    
+    IR.create_operation(
+        "llvm.intr.round", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -4010,24 +3009,18 @@ end
 `intr_sadd_with_overflow`
 
 """
-function intr_sadd_with_overflow(
-    operand_0::Value, operand_1::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1]
+function intr_sadd_with_overflow(operand_0::Value, operand_1::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.intr.sadd.with.overflow",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.sadd.with.overflow", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -4035,25 +3028,19 @@ end
 `intr_smax`
 
 """
-function intr_smax(
-    a::Value, b::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function intr_smax(a::Value, b::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[a, b]
+    operands = Value[a, b, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "llvm.intr.smax",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.smax", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -4061,25 +3048,19 @@ end
 `intr_smin`
 
 """
-function intr_smin(
-    a::Value, b::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function intr_smin(a::Value, b::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[a, b]
+    operands = Value[a, b, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "llvm.intr.smin",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.smin", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -4087,24 +3068,18 @@ end
 `intr_smul_with_overflow`
 
 """
-function intr_smul_with_overflow(
-    operand_0::Value, operand_1::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1]
+function intr_smul_with_overflow(operand_0::Value, operand_1::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.intr.smul.with.overflow",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.smul.with.overflow", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -4112,24 +3087,18 @@ end
 `intr_ssub_with_overflow`
 
 """
-function intr_ssub_with_overflow(
-    operand_0::Value, operand_1::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1]
+function intr_ssub_with_overflow(operand_0::Value, operand_1::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.intr.ssub.with.overflow",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.ssub.with.overflow", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -4137,30 +3106,20 @@ end
 `intr_sin`
 
 """
-function intr_sin(
-    in::Value;
-    res=nothing::Union{Nothing,IR.Type},
-    fastmathFlags=nothing,
-    location=Location(),
-)
+function intr_sin(in::Value; res=nothing::Union{Nothing, IR.Type}, fastmathFlags=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[in,]
+    operands = Value[in, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-    !isnothing(fastmathFlags) &&
-        push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
-
-    return IR.create_operation(
-        "llvm.intr.sin",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(fastmathFlags) && push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
+    
+    IR.create_operation(
+        "llvm.intr.sin", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -4168,30 +3127,20 @@ end
 `intr_sqrt`
 
 """
-function intr_sqrt(
-    in::Value;
-    res=nothing::Union{Nothing,IR.Type},
-    fastmathFlags=nothing,
-    location=Location(),
-)
+function intr_sqrt(in::Value; res=nothing::Union{Nothing, IR.Type}, fastmathFlags=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[in,]
+    operands = Value[in, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-    !isnothing(fastmathFlags) &&
-        push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
-
-    return IR.create_operation(
-        "llvm.intr.sqrt",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(fastmathFlags) && push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
+    
+    IR.create_operation(
+        "llvm.intr.sqrt", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -4201,20 +3150,16 @@ end
 """
 function intr_stackrestore(ptr::Value; location=Location())
     results = IR.Type[]
-    operands = Value[ptr,]
+    operands = Value[ptr, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.intr.stackrestore",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.stackrestore", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -4223,21 +3168,17 @@ end
 
 """
 function intr_stacksave(; res::IR.Type, location=Location())
-    results = IR.Type[res,]
+    results = IR.Type[res, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.intr.stacksave",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.stacksave", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -4246,21 +3187,17 @@ end
 
 """
 function intr_experimental_stepvector(; res::IR.Type, location=Location())
-    results = IR.Type[res,]
+    results = IR.Type[res, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.intr.experimental.stepvector",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.experimental.stepvector", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -4268,24 +3205,18 @@ end
 `intr_uadd_with_overflow`
 
 """
-function intr_uadd_with_overflow(
-    operand_0::Value, operand_1::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1]
+function intr_uadd_with_overflow(operand_0::Value, operand_1::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.intr.uadd.with.overflow",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.uadd.with.overflow", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -4293,25 +3224,19 @@ end
 `intr_umax`
 
 """
-function intr_umax(
-    a::Value, b::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function intr_umax(a::Value, b::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[a, b]
+    operands = Value[a, b, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "llvm.intr.umax",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.umax", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -4319,25 +3244,19 @@ end
 `intr_umin`
 
 """
-function intr_umin(
-    a::Value, b::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function intr_umin(a::Value, b::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[a, b]
+    operands = Value[a, b, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "llvm.intr.umin",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.umin", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -4345,24 +3264,18 @@ end
 `intr_umul_with_overflow`
 
 """
-function intr_umul_with_overflow(
-    operand_0::Value, operand_1::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1]
+function intr_umul_with_overflow(operand_0::Value, operand_1::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.intr.umul.with.overflow",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.umul.with.overflow", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -4370,24 +3283,18 @@ end
 `intr_usub_with_overflow`
 
 """
-function intr_usub_with_overflow(
-    operand_0::Value, operand_1::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1]
+function intr_usub_with_overflow(operand_0::Value, operand_1::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.intr.usub.with.overflow",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.usub.with.overflow", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -4395,24 +3302,18 @@ end
 `intr_vp_ashr`
 
 """
-function intr_vp_ashr(
-    lhs::Value, rhs::Value, mask::Value, evl::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[lhs, rhs, mask, evl]
+function intr_vp_ashr(lhs::Value, rhs::Value, mask::Value, evl::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[lhs, rhs, mask, evl, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.intr.vp.ashr",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.vp.ashr", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -4420,24 +3321,18 @@ end
 `intr_vp_add`
 
 """
-function intr_vp_add(
-    lhs::Value, rhs::Value, mask::Value, evl::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[lhs, rhs, mask, evl]
+function intr_vp_add(lhs::Value, rhs::Value, mask::Value, evl::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[lhs, rhs, mask, evl, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.intr.vp.add",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.vp.add", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -4445,24 +3340,18 @@ end
 `intr_vp_and`
 
 """
-function intr_vp_and(
-    lhs::Value, rhs::Value, mask::Value, evl::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[lhs, rhs, mask, evl]
+function intr_vp_and(lhs::Value, rhs::Value, mask::Value, evl::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[lhs, rhs, mask, evl, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.intr.vp.and",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.vp.and", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -4470,24 +3359,18 @@ end
 `intr_vp_fadd`
 
 """
-function intr_vp_fadd(
-    lhs::Value, rhs::Value, mask::Value, evl::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[lhs, rhs, mask, evl]
+function intr_vp_fadd(lhs::Value, rhs::Value, mask::Value, evl::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[lhs, rhs, mask, evl, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.intr.vp.fadd",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.vp.fadd", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -4495,24 +3378,18 @@ end
 `intr_vp_fdiv`
 
 """
-function intr_vp_fdiv(
-    lhs::Value, rhs::Value, mask::Value, evl::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[lhs, rhs, mask, evl]
+function intr_vp_fdiv(lhs::Value, rhs::Value, mask::Value, evl::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[lhs, rhs, mask, evl, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.intr.vp.fdiv",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.vp.fdiv", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -4520,24 +3397,18 @@ end
 `intr_vp_fmul`
 
 """
-function intr_vp_fmul(
-    lhs::Value, rhs::Value, mask::Value, evl::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[lhs, rhs, mask, evl]
+function intr_vp_fmul(lhs::Value, rhs::Value, mask::Value, evl::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[lhs, rhs, mask, evl, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.intr.vp.fmul",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.vp.fmul", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -4546,21 +3417,17 @@ end
 
 """
 function intr_vp_fneg(op::Value, mask::Value, evl::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[op, mask, evl]
+    results = IR.Type[res, ]
+    operands = Value[op, mask, evl, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.intr.vp.fneg",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.vp.fneg", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -4568,24 +3435,18 @@ end
 `intr_vp_fpext`
 
 """
-function intr_vp_fpext(
-    src::Value, mask::Value, evl::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[src, mask, evl]
+function intr_vp_fpext(src::Value, mask::Value, evl::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[src, mask, evl, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.intr.vp.fpext",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.vp.fpext", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -4593,24 +3454,18 @@ end
 `intr_vp_fptosi`
 
 """
-function intr_vp_fptosi(
-    src::Value, mask::Value, evl::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[src, mask, evl]
+function intr_vp_fptosi(src::Value, mask::Value, evl::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[src, mask, evl, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.intr.vp.fptosi",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.vp.fptosi", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -4618,24 +3473,18 @@ end
 `intr_vp_fptoui`
 
 """
-function intr_vp_fptoui(
-    src::Value, mask::Value, evl::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[src, mask, evl]
+function intr_vp_fptoui(src::Value, mask::Value, evl::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[src, mask, evl, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.intr.vp.fptoui",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.vp.fptoui", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -4643,24 +3492,18 @@ end
 `intr_vp_fptrunc`
 
 """
-function intr_vp_fptrunc(
-    src::Value, mask::Value, evl::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[src, mask, evl]
+function intr_vp_fptrunc(src::Value, mask::Value, evl::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[src, mask, evl, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.intr.vp.fptrunc",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.vp.fptrunc", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -4668,24 +3511,18 @@ end
 `intr_vp_frem`
 
 """
-function intr_vp_frem(
-    lhs::Value, rhs::Value, mask::Value, evl::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[lhs, rhs, mask, evl]
+function intr_vp_frem(lhs::Value, rhs::Value, mask::Value, evl::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[lhs, rhs, mask, evl, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.intr.vp.frem",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.vp.frem", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -4693,24 +3530,18 @@ end
 `intr_vp_fsub`
 
 """
-function intr_vp_fsub(
-    lhs::Value, rhs::Value, mask::Value, evl::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[lhs, rhs, mask, evl]
+function intr_vp_fsub(lhs::Value, rhs::Value, mask::Value, evl::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[lhs, rhs, mask, evl, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.intr.vp.fsub",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.vp.fsub", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -4718,30 +3549,18 @@ end
 `intr_vp_fma`
 
 """
-function intr_vp_fma(
-    op1::Value,
-    op2::Value,
-    op3::Value,
-    mask::Value,
-    evl::Value;
-    res::IR.Type,
-    location=Location(),
-)
-    results = IR.Type[res,]
-    operands = Value[op1, op2, op3, mask, evl]
+function intr_vp_fma(op1::Value, op2::Value, op3::Value, mask::Value, evl::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[op1, op2, op3, mask, evl, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.intr.vp.fma",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.vp.fma", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -4749,24 +3568,18 @@ end
 `intr_vp_inttoptr`
 
 """
-function intr_vp_inttoptr(
-    src::Value, mask::Value, evl::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[src, mask, evl]
+function intr_vp_inttoptr(src::Value, mask::Value, evl::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[src, mask, evl, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.intr.vp.inttoptr",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.vp.inttoptr", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -4774,24 +3587,18 @@ end
 `intr_vp_lshr`
 
 """
-function intr_vp_lshr(
-    lhs::Value, rhs::Value, mask::Value, evl::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[lhs, rhs, mask, evl]
+function intr_vp_lshr(lhs::Value, rhs::Value, mask::Value, evl::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[lhs, rhs, mask, evl, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.intr.vp.lshr",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.vp.lshr", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -4799,24 +3606,18 @@ end
 `intr_vp_load`
 
 """
-function intr_vp_load(
-    ptr::Value, mask::Value, evl::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[ptr, mask, evl]
+function intr_vp_load(ptr::Value, mask::Value, evl::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[ptr, mask, evl, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.intr.vp.load",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.vp.load", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -4824,29 +3625,18 @@ end
 `intr_vp_merge`
 
 """
-function intr_vp_merge(
-    cond::Value,
-    true_val::Value,
-    false_val::Value,
-    evl::Value;
-    res::IR.Type,
-    location=Location(),
-)
-    results = IR.Type[res,]
-    operands = Value[cond, true_val, false_val, evl]
+function intr_vp_merge(cond::Value, true_val::Value, false_val::Value, evl::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[cond, true_val, false_val, evl, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.intr.vp.merge",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.vp.merge", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -4854,24 +3644,18 @@ end
 `intr_vp_mul`
 
 """
-function intr_vp_mul(
-    lhs::Value, rhs::Value, mask::Value, evl::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[lhs, rhs, mask, evl]
+function intr_vp_mul(lhs::Value, rhs::Value, mask::Value, evl::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[lhs, rhs, mask, evl, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.intr.vp.mul",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.vp.mul", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -4879,24 +3663,18 @@ end
 `intr_vp_or`
 
 """
-function intr_vp_or(
-    lhs::Value, rhs::Value, mask::Value, evl::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[lhs, rhs, mask, evl]
+function intr_vp_or(lhs::Value, rhs::Value, mask::Value, evl::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[lhs, rhs, mask, evl, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.intr.vp.or",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.vp.or", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -4904,24 +3682,18 @@ end
 `intr_vp_ptrtoint`
 
 """
-function intr_vp_ptrtoint(
-    src::Value, mask::Value, evl::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[src, mask, evl]
+function intr_vp_ptrtoint(src::Value, mask::Value, evl::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[src, mask, evl, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.intr.vp.ptrtoint",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.vp.ptrtoint", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -4929,29 +3701,18 @@ end
 `intr_vp_reduce_add`
 
 """
-function intr_vp_reduce_add(
-    satrt_value::Value,
-    val::Value,
-    mask::Value,
-    evl::Value;
-    res::IR.Type,
-    location=Location(),
-)
-    results = IR.Type[res,]
-    operands = Value[satrt_value, val, mask, evl]
+function intr_vp_reduce_add(satrt_value::Value, val::Value, mask::Value, evl::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[satrt_value, val, mask, evl, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.intr.vp.reduce.add",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.vp.reduce.add", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -4959,29 +3720,18 @@ end
 `intr_vp_reduce_and`
 
 """
-function intr_vp_reduce_and(
-    satrt_value::Value,
-    val::Value,
-    mask::Value,
-    evl::Value;
-    res::IR.Type,
-    location=Location(),
-)
-    results = IR.Type[res,]
-    operands = Value[satrt_value, val, mask, evl]
+function intr_vp_reduce_and(satrt_value::Value, val::Value, mask::Value, evl::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[satrt_value, val, mask, evl, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.intr.vp.reduce.and",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.vp.reduce.and", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -4989,29 +3739,18 @@ end
 `intr_vp_reduce_fadd`
 
 """
-function intr_vp_reduce_fadd(
-    satrt_value::Value,
-    val::Value,
-    mask::Value,
-    evl::Value;
-    res::IR.Type,
-    location=Location(),
-)
-    results = IR.Type[res,]
-    operands = Value[satrt_value, val, mask, evl]
+function intr_vp_reduce_fadd(satrt_value::Value, val::Value, mask::Value, evl::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[satrt_value, val, mask, evl, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.intr.vp.reduce.fadd",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.vp.reduce.fadd", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -5019,29 +3758,18 @@ end
 `intr_vp_reduce_fmax`
 
 """
-function intr_vp_reduce_fmax(
-    satrt_value::Value,
-    val::Value,
-    mask::Value,
-    evl::Value;
-    res::IR.Type,
-    location=Location(),
-)
-    results = IR.Type[res,]
-    operands = Value[satrt_value, val, mask, evl]
+function intr_vp_reduce_fmax(satrt_value::Value, val::Value, mask::Value, evl::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[satrt_value, val, mask, evl, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.intr.vp.reduce.fmax",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.vp.reduce.fmax", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -5049,29 +3777,18 @@ end
 `intr_vp_reduce_fmin`
 
 """
-function intr_vp_reduce_fmin(
-    satrt_value::Value,
-    val::Value,
-    mask::Value,
-    evl::Value;
-    res::IR.Type,
-    location=Location(),
-)
-    results = IR.Type[res,]
-    operands = Value[satrt_value, val, mask, evl]
+function intr_vp_reduce_fmin(satrt_value::Value, val::Value, mask::Value, evl::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[satrt_value, val, mask, evl, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.intr.vp.reduce.fmin",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.vp.reduce.fmin", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -5079,29 +3796,18 @@ end
 `intr_vp_reduce_fmul`
 
 """
-function intr_vp_reduce_fmul(
-    satrt_value::Value,
-    val::Value,
-    mask::Value,
-    evl::Value;
-    res::IR.Type,
-    location=Location(),
-)
-    results = IR.Type[res,]
-    operands = Value[satrt_value, val, mask, evl]
+function intr_vp_reduce_fmul(satrt_value::Value, val::Value, mask::Value, evl::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[satrt_value, val, mask, evl, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.intr.vp.reduce.fmul",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.vp.reduce.fmul", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -5109,29 +3815,18 @@ end
 `intr_vp_reduce_mul`
 
 """
-function intr_vp_reduce_mul(
-    satrt_value::Value,
-    val::Value,
-    mask::Value,
-    evl::Value;
-    res::IR.Type,
-    location=Location(),
-)
-    results = IR.Type[res,]
-    operands = Value[satrt_value, val, mask, evl]
+function intr_vp_reduce_mul(satrt_value::Value, val::Value, mask::Value, evl::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[satrt_value, val, mask, evl, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.intr.vp.reduce.mul",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.vp.reduce.mul", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -5139,29 +3834,18 @@ end
 `intr_vp_reduce_or`
 
 """
-function intr_vp_reduce_or(
-    satrt_value::Value,
-    val::Value,
-    mask::Value,
-    evl::Value;
-    res::IR.Type,
-    location=Location(),
-)
-    results = IR.Type[res,]
-    operands = Value[satrt_value, val, mask, evl]
+function intr_vp_reduce_or(satrt_value::Value, val::Value, mask::Value, evl::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[satrt_value, val, mask, evl, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.intr.vp.reduce.or",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.vp.reduce.or", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -5169,29 +3853,18 @@ end
 `intr_vp_reduce_smax`
 
 """
-function intr_vp_reduce_smax(
-    satrt_value::Value,
-    val::Value,
-    mask::Value,
-    evl::Value;
-    res::IR.Type,
-    location=Location(),
-)
-    results = IR.Type[res,]
-    operands = Value[satrt_value, val, mask, evl]
+function intr_vp_reduce_smax(satrt_value::Value, val::Value, mask::Value, evl::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[satrt_value, val, mask, evl, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.intr.vp.reduce.smax",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.vp.reduce.smax", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -5199,29 +3872,18 @@ end
 `intr_vp_reduce_smin`
 
 """
-function intr_vp_reduce_smin(
-    satrt_value::Value,
-    val::Value,
-    mask::Value,
-    evl::Value;
-    res::IR.Type,
-    location=Location(),
-)
-    results = IR.Type[res,]
-    operands = Value[satrt_value, val, mask, evl]
+function intr_vp_reduce_smin(satrt_value::Value, val::Value, mask::Value, evl::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[satrt_value, val, mask, evl, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.intr.vp.reduce.smin",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.vp.reduce.smin", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -5229,29 +3891,18 @@ end
 `intr_vp_reduce_umax`
 
 """
-function intr_vp_reduce_umax(
-    satrt_value::Value,
-    val::Value,
-    mask::Value,
-    evl::Value;
-    res::IR.Type,
-    location=Location(),
-)
-    results = IR.Type[res,]
-    operands = Value[satrt_value, val, mask, evl]
+function intr_vp_reduce_umax(satrt_value::Value, val::Value, mask::Value, evl::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[satrt_value, val, mask, evl, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.intr.vp.reduce.umax",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.vp.reduce.umax", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -5259,29 +3910,18 @@ end
 `intr_vp_reduce_umin`
 
 """
-function intr_vp_reduce_umin(
-    satrt_value::Value,
-    val::Value,
-    mask::Value,
-    evl::Value;
-    res::IR.Type,
-    location=Location(),
-)
-    results = IR.Type[res,]
-    operands = Value[satrt_value, val, mask, evl]
+function intr_vp_reduce_umin(satrt_value::Value, val::Value, mask::Value, evl::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[satrt_value, val, mask, evl, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.intr.vp.reduce.umin",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.vp.reduce.umin", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -5289,29 +3929,18 @@ end
 `intr_vp_reduce_xor`
 
 """
-function intr_vp_reduce_xor(
-    satrt_value::Value,
-    val::Value,
-    mask::Value,
-    evl::Value;
-    res::IR.Type,
-    location=Location(),
-)
-    results = IR.Type[res,]
-    operands = Value[satrt_value, val, mask, evl]
+function intr_vp_reduce_xor(satrt_value::Value, val::Value, mask::Value, evl::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[satrt_value, val, mask, evl, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.intr.vp.reduce.xor",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.vp.reduce.xor", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -5319,24 +3948,18 @@ end
 `intr_vp_sdiv`
 
 """
-function intr_vp_sdiv(
-    lhs::Value, rhs::Value, mask::Value, evl::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[lhs, rhs, mask, evl]
+function intr_vp_sdiv(lhs::Value, rhs::Value, mask::Value, evl::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[lhs, rhs, mask, evl, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.intr.vp.sdiv",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.vp.sdiv", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -5344,24 +3967,18 @@ end
 `intr_vp_sext`
 
 """
-function intr_vp_sext(
-    src::Value, mask::Value, evl::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[src, mask, evl]
+function intr_vp_sext(src::Value, mask::Value, evl::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[src, mask, evl, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.intr.vp.sext",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.vp.sext", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -5369,24 +3986,18 @@ end
 `intr_vp_sitofp`
 
 """
-function intr_vp_sitofp(
-    src::Value, mask::Value, evl::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[src, mask, evl]
+function intr_vp_sitofp(src::Value, mask::Value, evl::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[src, mask, evl, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.intr.vp.sitofp",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.vp.sitofp", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -5394,24 +4005,18 @@ end
 `intr_vp_srem`
 
 """
-function intr_vp_srem(
-    lhs::Value, rhs::Value, mask::Value, evl::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[lhs, rhs, mask, evl]
+function intr_vp_srem(lhs::Value, rhs::Value, mask::Value, evl::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[lhs, rhs, mask, evl, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.intr.vp.srem",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.vp.srem", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -5419,29 +4024,18 @@ end
 `intr_vp_select`
 
 """
-function intr_vp_select(
-    cond::Value,
-    true_val::Value,
-    false_val::Value,
-    evl::Value;
-    res::IR.Type,
-    location=Location(),
-)
-    results = IR.Type[res,]
-    operands = Value[cond, true_val, false_val, evl]
+function intr_vp_select(cond::Value, true_val::Value, false_val::Value, evl::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[cond, true_val, false_val, evl, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.intr.vp.select",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.vp.select", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -5449,24 +4043,18 @@ end
 `intr_vp_shl`
 
 """
-function intr_vp_shl(
-    lhs::Value, rhs::Value, mask::Value, evl::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[lhs, rhs, mask, evl]
+function intr_vp_shl(lhs::Value, rhs::Value, mask::Value, evl::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[lhs, rhs, mask, evl, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.intr.vp.shl",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.vp.shl", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -5476,20 +4064,16 @@ end
 """
 function intr_vp_store(val::Value, ptr::Value, mask::Value, evl::Value; location=Location())
     results = IR.Type[]
-    operands = Value[val, ptr, mask, evl]
+    operands = Value[val, ptr, mask, evl, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.intr.vp.store",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.vp.store", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -5497,24 +4081,18 @@ end
 `intr_experimental_vp_strided_load`
 
 """
-function intr_experimental_vp_strided_load(
-    ptr::Value, stride::Value, mask::Value, evl::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[ptr, stride, mask, evl]
+function intr_experimental_vp_strided_load(ptr::Value, stride::Value, mask::Value, evl::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[ptr, stride, mask, evl, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.intr.experimental.vp.strided.load",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.experimental.vp.strided.load", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -5522,24 +4100,18 @@ end
 `intr_experimental_vp_strided_store`
 
 """
-function intr_experimental_vp_strided_store(
-    val::Value, ptr::Value, stride::Value, mask::Value, evl::Value; location=Location()
-)
+function intr_experimental_vp_strided_store(val::Value, ptr::Value, stride::Value, mask::Value, evl::Value; location=Location())
     results = IR.Type[]
-    operands = Value[val, ptr, stride, mask, evl]
+    operands = Value[val, ptr, stride, mask, evl, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.intr.experimental.vp.strided.store",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.experimental.vp.strided.store", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -5547,24 +4119,18 @@ end
 `intr_vp_sub`
 
 """
-function intr_vp_sub(
-    lhs::Value, rhs::Value, mask::Value, evl::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[lhs, rhs, mask, evl]
+function intr_vp_sub(lhs::Value, rhs::Value, mask::Value, evl::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[lhs, rhs, mask, evl, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.intr.vp.sub",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.vp.sub", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -5572,24 +4138,18 @@ end
 `intr_vp_trunc`
 
 """
-function intr_vp_trunc(
-    src::Value, mask::Value, evl::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[src, mask, evl]
+function intr_vp_trunc(src::Value, mask::Value, evl::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[src, mask, evl, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.intr.vp.trunc",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.vp.trunc", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -5597,24 +4157,18 @@ end
 `intr_vp_udiv`
 
 """
-function intr_vp_udiv(
-    lhs::Value, rhs::Value, mask::Value, evl::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[lhs, rhs, mask, evl]
+function intr_vp_udiv(lhs::Value, rhs::Value, mask::Value, evl::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[lhs, rhs, mask, evl, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.intr.vp.udiv",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.vp.udiv", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -5622,24 +4176,18 @@ end
 `intr_vp_uitofp`
 
 """
-function intr_vp_uitofp(
-    src::Value, mask::Value, evl::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[src, mask, evl]
+function intr_vp_uitofp(src::Value, mask::Value, evl::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[src, mask, evl, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.intr.vp.uitofp",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.vp.uitofp", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -5647,24 +4195,18 @@ end
 `intr_vp_urem`
 
 """
-function intr_vp_urem(
-    lhs::Value, rhs::Value, mask::Value, evl::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[lhs, rhs, mask, evl]
+function intr_vp_urem(lhs::Value, rhs::Value, mask::Value, evl::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[lhs, rhs, mask, evl, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.intr.vp.urem",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.vp.urem", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -5672,24 +4214,18 @@ end
 `intr_vp_xor`
 
 """
-function intr_vp_xor(
-    lhs::Value, rhs::Value, mask::Value, evl::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[lhs, rhs, mask, evl]
+function intr_vp_xor(lhs::Value, rhs::Value, mask::Value, evl::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[lhs, rhs, mask, evl, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.intr.vp.xor",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.vp.xor", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -5697,24 +4233,18 @@ end
 `intr_vp_zext`
 
 """
-function intr_vp_zext(
-    src::Value, mask::Value, evl::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[src, mask, evl]
+function intr_vp_zext(src::Value, mask::Value, evl::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[src, mask, evl, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.intr.vp.zext",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.vp.zext", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -5724,20 +4254,16 @@ end
 """
 function intr_vacopy(dest_list::Value, src_list::Value; location=Location())
     results = IR.Type[]
-    operands = Value[dest_list, src_list]
+    operands = Value[dest_list, src_list, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.intr.vacopy",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.vacopy", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -5747,20 +4273,16 @@ end
 """
 function intr_vaend(arg_list::Value; location=Location())
     results = IR.Type[]
-    operands = Value[arg_list,]
+    operands = Value[arg_list, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.intr.vaend",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.vaend", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -5770,20 +4292,16 @@ end
 """
 function intr_vastart(arg_list::Value; location=Location())
     results = IR.Type[]
-    operands = Value[arg_list,]
+    operands = Value[arg_list, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.intr.vastart",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.vastart", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -5791,24 +4309,18 @@ end
 `intr_masked_compressstore`
 
 """
-function intr_masked_compressstore(
-    operand_0::Value, operand_1::Value, operand_2::Value; location=Location()
-)
+function intr_masked_compressstore(operand_0::Value, operand_1::Value, operand_2::Value; location=Location())
     results = IR.Type[]
-    operands = Value[operand_0, operand_1, operand_2]
+    operands = Value[operand_0, operand_1, operand_2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.intr.masked.compressstore",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.masked.compressstore", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -5816,24 +4328,18 @@ end
 `intr_masked_expandload`
 
 """
-function intr_masked_expandload(
-    operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1, operand_2]
+function intr_masked_expandload(operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, operand_2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.intr.masked.expandload",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.masked.expandload", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -5841,29 +4347,18 @@ end
 `intr_masked_gather`
 
 """
-function intr_masked_gather(
-    ptrs::Value,
-    mask::Value,
-    pass_thru::Vector{Value};
-    res::IR.Type,
-    alignment,
-    location=Location(),
-)
-    results = IR.Type[res,]
-    operands = Value[ptrs, mask, pass_thru...]
+function intr_masked_gather(ptrs::Value, mask::Value, pass_thru::Vector{Value}; res::IR.Type, alignment, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[ptrs, mask, pass_thru..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("alignment", alignment),]
-
-    return IR.create_operation(
-        "llvm.intr.masked.gather",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("alignment", alignment), ]
+    
+    IR.create_operation(
+        "llvm.intr.masked.gather", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -5871,24 +4366,18 @@ end
 `intr_masked_scatter`
 
 """
-function intr_masked_scatter(
-    value::Value, ptrs::Value, mask::Value; alignment, location=Location()
-)
+function intr_masked_scatter(value::Value, ptrs::Value, mask::Value; alignment, location=Location())
     results = IR.Type[]
-    operands = Value[value, ptrs, mask]
+    operands = Value[value, ptrs, mask, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("alignment", alignment),]
-
-    return IR.create_operation(
-        "llvm.intr.masked.scatter",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("alignment", alignment), ]
+    
+    IR.create_operation(
+        "llvm.intr.masked.scatter", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -5897,21 +4386,17 @@ end
 
 """
 function intr_vector_extract(srcvec::Value; res::IR.Type, pos, location=Location())
-    results = IR.Type[res,]
-    operands = Value[srcvec,]
+    results = IR.Type[res, ]
+    operands = Value[srcvec, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("pos", pos),]
-
-    return IR.create_operation(
-        "llvm.intr.vector.extract",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("pos", pos), ]
+    
+    IR.create_operation(
+        "llvm.intr.vector.extract", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -5919,29 +4404,19 @@ end
 `intr_vector_insert`
 
 """
-function intr_vector_insert(
-    srcvec::Value,
-    dstvec::Value;
-    res=nothing::Union{Nothing,IR.Type},
-    pos,
-    location=Location(),
-)
+function intr_vector_insert(srcvec::Value, dstvec::Value; res=nothing::Union{Nothing, IR.Type}, pos, location=Location())
     results = IR.Type[]
-    operands = Value[srcvec, dstvec]
+    operands = Value[srcvec, dstvec, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("pos", pos),]
+    attributes = NamedAttribute[namedattribute("pos", pos), ]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "llvm.intr.vector.insert",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.vector.insert", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -5950,21 +4425,17 @@ end
 
 """
 function intr_vector_reduce_add(operand_0::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[operand_0,]
+    results = IR.Type[res, ]
+    operands = Value[operand_0, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.intr.vector.reduce.add",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.vector.reduce.add", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -5973,21 +4444,17 @@ end
 
 """
 function intr_vector_reduce_and(operand_0::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[operand_0,]
+    results = IR.Type[res, ]
+    operands = Value[operand_0, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.intr.vector.reduce.and",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.vector.reduce.and", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -5995,25 +4462,19 @@ end
 `intr_vector_reduce_fadd`
 
 """
-function intr_vector_reduce_fadd(
-    start_value::Value, input::Value; res::IR.Type, reassoc=nothing, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[start_value, input]
+function intr_vector_reduce_fadd(start_value::Value, input::Value; res::IR.Type, reassoc=nothing, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[start_value, input, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(reassoc) && push!(attributes, namedattribute("reassoc", reassoc))
-
-    return IR.create_operation(
-        "llvm.intr.vector.reduce.fadd",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.vector.reduce.fadd", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -6022,21 +4483,17 @@ end
 
 """
 function intr_vector_reduce_fmax(operand_0::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[operand_0,]
+    results = IR.Type[res, ]
+    operands = Value[operand_0, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.intr.vector.reduce.fmax",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.vector.reduce.fmax", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -6045,21 +4502,17 @@ end
 
 """
 function intr_vector_reduce_fmin(operand_0::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[operand_0,]
+    results = IR.Type[res, ]
+    operands = Value[operand_0, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.intr.vector.reduce.fmin",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.vector.reduce.fmin", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -6067,25 +4520,19 @@ end
 `intr_vector_reduce_fmul`
 
 """
-function intr_vector_reduce_fmul(
-    start_value::Value, input::Value; res::IR.Type, reassoc=nothing, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[start_value, input]
+function intr_vector_reduce_fmul(start_value::Value, input::Value; res::IR.Type, reassoc=nothing, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[start_value, input, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(reassoc) && push!(attributes, namedattribute("reassoc", reassoc))
-
-    return IR.create_operation(
-        "llvm.intr.vector.reduce.fmul",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.vector.reduce.fmul", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -6094,21 +4541,17 @@ end
 
 """
 function intr_vector_reduce_mul(operand_0::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[operand_0,]
+    results = IR.Type[res, ]
+    operands = Value[operand_0, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.intr.vector.reduce.mul",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.vector.reduce.mul", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -6117,21 +4560,17 @@ end
 
 """
 function intr_vector_reduce_or(operand_0::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[operand_0,]
+    results = IR.Type[res, ]
+    operands = Value[operand_0, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.intr.vector.reduce.or",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.vector.reduce.or", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -6140,21 +4579,17 @@ end
 
 """
 function intr_vector_reduce_smax(operand_0::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[operand_0,]
+    results = IR.Type[res, ]
+    operands = Value[operand_0, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.intr.vector.reduce.smax",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.vector.reduce.smax", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -6163,21 +4598,17 @@ end
 
 """
 function intr_vector_reduce_smin(operand_0::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[operand_0,]
+    results = IR.Type[res, ]
+    operands = Value[operand_0, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.intr.vector.reduce.smin",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.vector.reduce.smin", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -6186,21 +4617,17 @@ end
 
 """
 function intr_vector_reduce_umax(operand_0::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[operand_0,]
+    results = IR.Type[res, ]
+    operands = Value[operand_0, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.intr.vector.reduce.umax",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.vector.reduce.umax", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -6209,21 +4636,17 @@ end
 
 """
 function intr_vector_reduce_umin(operand_0::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[operand_0,]
+    results = IR.Type[res, ]
+    operands = Value[operand_0, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.intr.vector.reduce.umin",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.vector.reduce.umin", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -6232,21 +4655,17 @@ end
 
 """
 function intr_vector_reduce_xor(operand_0::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[operand_0,]
+    results = IR.Type[res, ]
+    operands = Value[operand_0, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.intr.vector.reduce.xor",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.vector.reduce.xor", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -6255,27 +4674,23 @@ end
 
 """
 function intr_vscale(; res::IR.Type, location=Location())
-    results = IR.Type[res,]
+    results = IR.Type[res, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.intr.vscale",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.vscale", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `barrier0`
@@ -6287,16 +4702,12 @@ function barrier0(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "nvvm.barrier0",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "nvvm.barrier0", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -6305,21 +4716,17 @@ end
 
 """
 function read_ptx_sreg_ntid_x(; res::IR.Type, location=Location())
-    results = IR.Type[res,]
+    results = IR.Type[res, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "nvvm.read.ptx.sreg.ntid.x",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "nvvm.read.ptx.sreg.ntid.x", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -6328,21 +4735,17 @@ end
 
 """
 function read_ptx_sreg_ntid_y(; res::IR.Type, location=Location())
-    results = IR.Type[res,]
+    results = IR.Type[res, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "nvvm.read.ptx.sreg.ntid.y",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "nvvm.read.ptx.sreg.ntid.y", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -6351,21 +4754,17 @@ end
 
 """
 function read_ptx_sreg_ntid_z(; res::IR.Type, location=Location())
-    results = IR.Type[res,]
+    results = IR.Type[res, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "nvvm.read.ptx.sreg.ntid.z",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "nvvm.read.ptx.sreg.ntid.z", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -6374,21 +4773,17 @@ end
 
 """
 function read_ptx_sreg_ctaid_x(; res::IR.Type, location=Location())
-    results = IR.Type[res,]
+    results = IR.Type[res, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "nvvm.read.ptx.sreg.ctaid.x",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "nvvm.read.ptx.sreg.ctaid.x", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -6397,21 +4792,17 @@ end
 
 """
 function read_ptx_sreg_ctaid_y(; res::IR.Type, location=Location())
-    results = IR.Type[res,]
+    results = IR.Type[res, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "nvvm.read.ptx.sreg.ctaid.y",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "nvvm.read.ptx.sreg.ctaid.y", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -6420,21 +4811,17 @@ end
 
 """
 function read_ptx_sreg_ctaid_z(; res::IR.Type, location=Location())
-    results = IR.Type[res,]
+    results = IR.Type[res, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "nvvm.read.ptx.sreg.ctaid.z",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "nvvm.read.ptx.sreg.ctaid.z", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -6448,16 +4835,12 @@ function cp_async_commit_group(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "nvvm.cp.async.commit.group",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "nvvm.cp.async.commit.group", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -6465,25 +4848,19 @@ end
 `cp_async_shared_global`
 
 """
-function cp_async_shared_global(
-    dst::Value, src::Value; size, bypass_l1=nothing, location=Location()
-)
+function cp_async_shared_global(dst::Value, src::Value; size, bypass_l1=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[dst, src]
+    operands = Value[dst, src, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("size", size),]
+    attributes = NamedAttribute[namedattribute("size", size), ]
     !isnothing(bypass_l1) && push!(attributes, namedattribute("bypass_l1", bypass_l1))
-
-    return IR.create_operation(
-        "nvvm.cp.async.shared.global",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "nvvm.cp.async.shared.global", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -6496,17 +4873,13 @@ function cp_async_wait_group(; n, location=Location())
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("n", n),]
-
-    return IR.create_operation(
-        "nvvm.cp.async.wait.group",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("n", n), ]
+    
+    IR.create_operation(
+        "nvvm.cp.async.wait.group", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -6515,21 +4888,17 @@ end
 
 """
 function read_ptx_sreg_nctaid_x(; res::IR.Type, location=Location())
-    results = IR.Type[res,]
+    results = IR.Type[res, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "nvvm.read.ptx.sreg.nctaid.x",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "nvvm.read.ptx.sreg.nctaid.x", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -6538,21 +4907,17 @@ end
 
 """
 function read_ptx_sreg_nctaid_y(; res::IR.Type, location=Location())
-    results = IR.Type[res,]
+    results = IR.Type[res, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "nvvm.read.ptx.sreg.nctaid.y",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "nvvm.read.ptx.sreg.nctaid.y", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -6561,21 +4926,17 @@ end
 
 """
 function read_ptx_sreg_nctaid_z(; res::IR.Type, location=Location())
-    results = IR.Type[res,]
+    results = IR.Type[res, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "nvvm.read.ptx.sreg.nctaid.z",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "nvvm.read.ptx.sreg.nctaid.z", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -6584,21 +4945,17 @@ end
 
 """
 function read_ptx_sreg_laneid(; res::IR.Type, location=Location())
-    results = IR.Type[res,]
+    results = IR.Type[res, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "nvvm.read.ptx.sreg.laneid",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "nvvm.read.ptx.sreg.laneid", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -6607,23 +4964,17 @@ end
 
 """
 function ldmatrix(ptr::Value; res::IR.Type, num, layout, location=Location())
-    results = IR.Type[res,]
-    operands = Value[ptr,]
+    results = IR.Type[res, ]
+    operands = Value[ptr, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("num", num), namedattribute("layout", layout)
-    ]
-
-    return IR.create_operation(
-        "nvvm.ldmatrix",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("num", num), namedattribute("layout", layout), ]
+    
+    IR.create_operation(
+        "nvvm.ldmatrix", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -6695,50 +5046,23 @@ combinations are possible for certain layouts according to the table below.
        -> !llvm.struct<(vector<2xf16>, vector<2xf16>)>
 ```
 """
-function mma_sync(
-    operandA::Vector{Value},
-    operandB::Vector{Value},
-    operandC::Vector{Value};
-    res::IR.Type,
-    shape,
-    b1Op=nothing,
-    intOverflowBehavior=nothing,
-    layoutA,
-    layoutB,
-    multiplicandAPtxType=nothing,
-    multiplicandBPtxType=nothing,
-    location=Location(),
-)
-    results = IR.Type[res,]
-    operands = Value[operandA..., operandB..., operandC...]
+function mma_sync(operandA::Vector{Value}, operandB::Vector{Value}, operandC::Vector{Value}; res::IR.Type, shape, b1Op=nothing, intOverflowBehavior=nothing, layoutA, layoutB, multiplicandAPtxType=nothing, multiplicandBPtxType=nothing, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operandA..., operandB..., operandC..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("shape", shape),
-        namedattribute("layoutA", layoutA),
-        namedattribute("layoutB", layoutB),
-    ]
-    push!(
-        attributes,
-        operandsegmentsizes([length(operandA), length(operandB), length(operandC)]),
-    )
+    attributes = NamedAttribute[namedattribute("shape", shape), namedattribute("layoutA", layoutA), namedattribute("layoutB", layoutB), ]
+    push!(attributes, operandsegmentsizes([length(operandA), length(operandB), length(operandC), ]))
     !isnothing(b1Op) && push!(attributes, namedattribute("b1Op", b1Op))
-    !isnothing(intOverflowBehavior) &&
-        push!(attributes, namedattribute("intOverflowBehavior", intOverflowBehavior))
-    !isnothing(multiplicandAPtxType) &&
-        push!(attributes, namedattribute("multiplicandAPtxType", multiplicandAPtxType))
-    !isnothing(multiplicandBPtxType) &&
-        push!(attributes, namedattribute("multiplicandBPtxType", multiplicandBPtxType))
-
-    return IR.create_operation(
-        "nvvm.mma.sync",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(intOverflowBehavior) && push!(attributes, namedattribute("intOverflowBehavior", intOverflowBehavior))
+    !isnothing(multiplicandAPtxType) && push!(attributes, namedattribute("multiplicandAPtxType", multiplicandAPtxType))
+    !isnothing(multiplicandBPtxType) && push!(attributes, namedattribute("multiplicandBPtxType", multiplicandBPtxType))
+    
+    IR.create_operation(
+        "nvvm.mma.sync", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -6747,21 +5071,17 @@ end
 
 """
 function rcp_approx_ftz_f(arg::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[arg,]
+    results = IR.Type[res, ]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "nvvm.rcp.approx.ftz.f",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "nvvm.rcp.approx.ftz.f", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -6769,24 +5089,18 @@ end
 `redux_sync`
 
 """
-function redux_sync(
-    val::Value, mask_and_clamp::Value; res::IR.Type, kind, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[val, mask_and_clamp]
+function redux_sync(val::Value, mask_and_clamp::Value; res::IR.Type, kind, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[val, mask_and_clamp, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("kind", kind),]
-
-    return IR.create_operation(
-        "nvvm.redux.sync",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("kind", kind), ]
+    
+    IR.create_operation(
+        "nvvm.redux.sync", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -6794,35 +5108,19 @@ end
 `shfl_sync`
 
 """
-function shfl_sync(
-    dst::Value,
-    val::Value,
-    offset::Value,
-    mask_and_clamp::Value;
-    res::IR.Type,
-    kind,
-    return_value_and_is_valid=nothing,
-    location=Location(),
-)
-    results = IR.Type[res,]
-    operands = Value[dst, val, offset, mask_and_clamp]
+function shfl_sync(dst::Value, val::Value, offset::Value, mask_and_clamp::Value; res::IR.Type, kind, return_value_and_is_valid=nothing, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[dst, val, offset, mask_and_clamp, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("kind", kind),]
-    !isnothing(return_value_and_is_valid) && push!(
-        attributes,
-        namedattribute("return_value_and_is_valid", return_value_and_is_valid),
-    )
-
-    return IR.create_operation(
-        "nvvm.shfl.sync",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("kind", kind), ]
+    !isnothing(return_value_and_is_valid) && push!(attributes, namedattribute("return_value_and_is_valid", return_value_and_is_valid))
+    
+    IR.create_operation(
+        "nvvm.shfl.sync", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -6832,20 +5130,16 @@ end
 """
 function bar_warp_sync(mask::Value; location=Location())
     results = IR.Type[]
-    operands = Value[mask,]
+    operands = Value[mask, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "nvvm.bar.warp.sync",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "nvvm.bar.warp.sync", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -6854,21 +5148,17 @@ end
 
 """
 function read_ptx_sreg_tid_x(; res::IR.Type, location=Location())
-    results = IR.Type[res,]
+    results = IR.Type[res, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "nvvm.read.ptx.sreg.tid.x",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "nvvm.read.ptx.sreg.tid.x", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -6877,21 +5167,17 @@ end
 
 """
 function read_ptx_sreg_tid_y(; res::IR.Type, location=Location())
-    results = IR.Type[res,]
+    results = IR.Type[res, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "nvvm.read.ptx.sreg.tid.y",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "nvvm.read.ptx.sreg.tid.y", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -6900,21 +5186,17 @@ end
 
 """
 function read_ptx_sreg_tid_z(; res::IR.Type, location=Location())
-    results = IR.Type[res,]
+    results = IR.Type[res, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "nvvm.read.ptx.sreg.tid.z",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "nvvm.read.ptx.sreg.tid.z", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -6923,21 +5205,17 @@ end
 
 """
 function vote_ballot_sync(mask::Value, pred::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[mask, pred]
+    results = IR.Type[res, ]
+    operands = Value[mask, pred, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "nvvm.vote.ballot.sync",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "nvvm.vote.ballot.sync", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -6945,40 +5223,18 @@ end
 `wmma_load`
 
 """
-function wmma_load(
-    ptr::Value,
-    stride::Value;
-    res::IR.Type,
-    m,
-    n,
-    k,
-    layout,
-    eltype,
-    frag,
-    location=Location(),
-)
-    results = IR.Type[res,]
-    operands = Value[ptr, stride]
+function wmma_load(ptr::Value, stride::Value; res::IR.Type, m, n, k, layout, eltype, frag, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[ptr, stride, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("m", m),
-        namedattribute("n", n),
-        namedattribute("k", k),
-        namedattribute("layout", layout),
-        namedattribute("eltype", eltype),
-        namedattribute("frag", frag),
-    ]
-
-    return IR.create_operation(
-        "nvvm.wmma.load",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("m", m), namedattribute("n", n), namedattribute("k", k), namedattribute("layout", layout), namedattribute("eltype", eltype), namedattribute("frag", frag), ]
+    
+    IR.create_operation(
+        "nvvm.wmma.load", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -6986,41 +5242,18 @@ end
 `wmma_mma`
 
 """
-function wmma_mma(
-    args::Vector{Value};
-    res::IR.Type,
-    m,
-    n,
-    k,
-    layoutA,
-    layoutB,
-    eltypeA,
-    eltypeB,
-    location=Location(),
-)
-    results = IR.Type[res,]
-    operands = Value[args...,]
+function wmma_mma(args::Vector{Value}; res::IR.Type, m, n, k, layoutA, layoutB, eltypeA, eltypeB, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[args..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("m", m),
-        namedattribute("n", n),
-        namedattribute("k", k),
-        namedattribute("layoutA", layoutA),
-        namedattribute("layoutB", layoutB),
-        namedattribute("eltypeA", eltypeA),
-        namedattribute("eltypeB", eltypeB),
-    ]
-
-    return IR.create_operation(
-        "nvvm.wmma.mma",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("m", m), namedattribute("n", n), namedattribute("k", k), namedattribute("layoutA", layoutA), namedattribute("layoutB", layoutB), namedattribute("eltypeA", eltypeA), namedattribute("eltypeB", eltypeB), ]
+    
+    IR.create_operation(
+        "nvvm.wmma.mma", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -7028,38 +5261,18 @@ end
 `wmma_store`
 
 """
-function wmma_store(
-    ptr::Value,
-    args::Vector{Value},
-    stride::Value;
-    m,
-    n,
-    k,
-    layout,
-    eltype,
-    location=Location(),
-)
+function wmma_store(ptr::Value, args::Vector{Value}, stride::Value; m, n, k, layout, eltype, location=Location())
     results = IR.Type[]
-    operands = Value[ptr, args..., stride]
+    operands = Value[ptr, args..., stride, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("m", m),
-        namedattribute("n", n),
-        namedattribute("k", k),
-        namedattribute("layout", layout),
-        namedattribute("eltype", eltype),
-    ]
-
-    return IR.create_operation(
-        "nvvm.wmma.store",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("m", m), namedattribute("n", n), namedattribute("k", k), namedattribute("layout", layout), namedattribute("eltype", eltype), ]
+    
+    IR.create_operation(
+        "nvvm.wmma.store", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -7068,27 +5281,23 @@ end
 
 """
 function read_ptx_sreg_warpsize(; res::IR.Type, location=Location())
-    results = IR.Type[res,]
+    results = IR.Type[res, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "nvvm.read.ptx.sreg.warpsize",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "nvvm.read.ptx.sreg.warpsize", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `barrier`
@@ -7100,16 +5309,12 @@ function barrier(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "rocdl.barrier",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "rocdl.barrier", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -7118,21 +5323,17 @@ end
 
 """
 function workgroup_dim_x(; res::IR.Type, location=Location())
-    results = IR.Type[res,]
+    results = IR.Type[res, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "rocdl.workgroup.dim.x",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "rocdl.workgroup.dim.x", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -7141,21 +5342,17 @@ end
 
 """
 function workgroup_dim_y(; res::IR.Type, location=Location())
-    results = IR.Type[res,]
+    results = IR.Type[res, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "rocdl.workgroup.dim.y",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "rocdl.workgroup.dim.y", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -7164,21 +5361,17 @@ end
 
 """
 function workgroup_dim_z(; res::IR.Type, location=Location())
-    results = IR.Type[res,]
+    results = IR.Type[res, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "rocdl.workgroup.dim.z",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "rocdl.workgroup.dim.z", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -7187,21 +5380,17 @@ end
 
 """
 function workgroup_id_x(; res::IR.Type, location=Location())
-    results = IR.Type[res,]
+    results = IR.Type[res, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "rocdl.workgroup.id.x",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "rocdl.workgroup.id.x", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -7210,21 +5399,17 @@ end
 
 """
 function workgroup_id_y(; res::IR.Type, location=Location())
-    results = IR.Type[res,]
+    results = IR.Type[res, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "rocdl.workgroup.id.y",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "rocdl.workgroup.id.y", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -7233,21 +5418,17 @@ end
 
 """
 function workgroup_id_z(; res::IR.Type, location=Location())
-    results = IR.Type[res,]
+    results = IR.Type[res, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "rocdl.workgroup.id.z",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "rocdl.workgroup.id.z", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -7256,21 +5437,17 @@ end
 
 """
 function grid_dim_x(; res::IR.Type, location=Location())
-    results = IR.Type[res,]
+    results = IR.Type[res, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "rocdl.grid.dim.x",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "rocdl.grid.dim.x", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -7279,21 +5456,17 @@ end
 
 """
 function grid_dim_y(; res::IR.Type, location=Location())
-    results = IR.Type[res,]
+    results = IR.Type[res, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "rocdl.grid.dim.y",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "rocdl.grid.dim.y", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -7302,21 +5475,17 @@ end
 
 """
 function grid_dim_z(; res::IR.Type, location=Location())
-    results = IR.Type[res,]
+    results = IR.Type[res, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "rocdl.grid.dim.z",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "rocdl.grid.dim.z", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -7324,30 +5493,18 @@ end
 `buffer_load`
 
 """
-function buffer_load(
-    rsrc::Value,
-    vindex::Value,
-    offset::Value,
-    glc::Value,
-    slc::Value;
-    res::IR.Type,
-    location=Location(),
-)
-    results = IR.Type[res,]
-    operands = Value[rsrc, vindex, offset, glc, slc]
+function buffer_load(rsrc::Value, vindex::Value, offset::Value, glc::Value, slc::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[rsrc, vindex, offset, glc, slc, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "rocdl.buffer.load",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "rocdl.buffer.load", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -7355,30 +5512,18 @@ end
 `buffer_store`
 
 """
-function buffer_store(
-    vdata::Value,
-    rsrc::Value,
-    vindex::Value,
-    offset::Value,
-    glc::Value,
-    slc::Value;
-    location=Location(),
-)
+function buffer_store(vdata::Value, rsrc::Value, vindex::Value, offset::Value, glc::Value, slc::Value; location=Location())
     results = IR.Type[]
-    operands = Value[vdata, rsrc, vindex, offset, glc, slc]
+    operands = Value[vdata, rsrc, vindex, offset, glc, slc, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "rocdl.buffer.store",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "rocdl.buffer.store", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -7386,29 +5531,18 @@ end
 `raw_buffer_atomic_fadd`
 
 """
-function raw_buffer_atomic_fadd(
-    vdata::Value,
-    rsrc::Value,
-    offset::Value,
-    soffset::Value,
-    aux::Value;
-    location=Location(),
-)
+function raw_buffer_atomic_fadd(vdata::Value, rsrc::Value, offset::Value, soffset::Value, aux::Value; location=Location())
     results = IR.Type[]
-    operands = Value[vdata, rsrc, offset, soffset, aux]
+    operands = Value[vdata, rsrc, offset, soffset, aux, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "rocdl.raw.buffer.atomic.fadd",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "rocdl.raw.buffer.atomic.fadd", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -7416,29 +5550,18 @@ end
 `raw_buffer_load`
 
 """
-function raw_buffer_load(
-    rsrc::Value,
-    offset::Value,
-    soffset::Value,
-    aux::Value;
-    res::IR.Type,
-    location=Location(),
-)
-    results = IR.Type[res,]
-    operands = Value[rsrc, offset, soffset, aux]
+function raw_buffer_load(rsrc::Value, offset::Value, soffset::Value, aux::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[rsrc, offset, soffset, aux, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "rocdl.raw.buffer.load",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "rocdl.raw.buffer.load", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -7446,29 +5569,18 @@ end
 `raw_buffer_store`
 
 """
-function raw_buffer_store(
-    vdata::Value,
-    rsrc::Value,
-    offset::Value,
-    soffset::Value,
-    aux::Value;
-    location=Location(),
-)
+function raw_buffer_store(vdata::Value, rsrc::Value, offset::Value, soffset::Value, aux::Value; location=Location())
     results = IR.Type[]
-    operands = Value[vdata, rsrc, offset, soffset, aux]
+    operands = Value[vdata, rsrc, offset, soffset, aux, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "rocdl.raw.buffer.store",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "rocdl.raw.buffer.store", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -7477,21 +5589,17 @@ end
 
 """
 function workitem_id_x(; res::IR.Type, location=Location())
-    results = IR.Type[res,]
+    results = IR.Type[res, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "rocdl.workitem.id.x",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "rocdl.workitem.id.x", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -7500,21 +5608,17 @@ end
 
 """
 function workitem_id_y(; res::IR.Type, location=Location())
-    results = IR.Type[res,]
+    results = IR.Type[res, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "rocdl.workitem.id.y",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "rocdl.workitem.id.y", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -7523,21 +5627,17 @@ end
 
 """
 function workitem_id_z(; res::IR.Type, location=Location())
-    results = IR.Type[res,]
+    results = IR.Type[res, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "rocdl.workitem.id.z",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "rocdl.workitem.id.z", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -7546,21 +5646,17 @@ end
 
 """
 function mfma_f32_16x16x16bf16_1k(args::Vector{Value}; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[args...,]
+    results = IR.Type[res, ]
+    operands = Value[args..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "rocdl.mfma.f32.16x16x16bf16.1k",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "rocdl.mfma.f32.16x16x16bf16.1k", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -7569,21 +5665,17 @@ end
 
 """
 function mfma_f32_16x16x16f16(args::Vector{Value}; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[args...,]
+    results = IR.Type[res, ]
+    operands = Value[args..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "rocdl.mfma.f32.16x16x16f16",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "rocdl.mfma.f32.16x16x16f16", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -7592,21 +5684,17 @@ end
 
 """
 function mfma_f32_16x16x1f32(args::Vector{Value}; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[args...,]
+    results = IR.Type[res, ]
+    operands = Value[args..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "rocdl.mfma.f32.16x16x1f32",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "rocdl.mfma.f32.16x16x1f32", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -7615,21 +5703,17 @@ end
 
 """
 function mfma_f32_16x16x2bf16(args::Vector{Value}; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[args...,]
+    results = IR.Type[res, ]
+    operands = Value[args..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "rocdl.mfma.f32.16x16x2bf16",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "rocdl.mfma.f32.16x16x2bf16", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -7638,21 +5722,17 @@ end
 
 """
 function mfma_f32_16x16x4bf16_1k(args::Vector{Value}; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[args...,]
+    results = IR.Type[res, ]
+    operands = Value[args..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "rocdl.mfma.f32.16x16x4bf16.1k",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "rocdl.mfma.f32.16x16x4bf16.1k", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -7661,21 +5741,17 @@ end
 
 """
 function mfma_f32_16x16x4f16(args::Vector{Value}; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[args...,]
+    results = IR.Type[res, ]
+    operands = Value[args..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "rocdl.mfma.f32.16x16x4f16",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "rocdl.mfma.f32.16x16x4f16", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -7684,21 +5760,17 @@ end
 
 """
 function mfma_f32_16x16x4f32(args::Vector{Value}; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[args...,]
+    results = IR.Type[res, ]
+    operands = Value[args..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "rocdl.mfma.f32.16x16x4f32",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "rocdl.mfma.f32.16x16x4f32", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -7707,21 +5779,17 @@ end
 
 """
 function mfma_f32_16x16x8_xf32(args::Vector{Value}; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[args...,]
+    results = IR.Type[res, ]
+    operands = Value[args..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "rocdl.mfma.f32.16x16x8.xf32",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "rocdl.mfma.f32.16x16x8.xf32", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -7730,21 +5798,17 @@ end
 
 """
 function mfma_f32_16x16x8bf16(args::Vector{Value}; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[args...,]
+    results = IR.Type[res, ]
+    operands = Value[args..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "rocdl.mfma.f32.16x16x8bf16",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "rocdl.mfma.f32.16x16x8bf16", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -7753,21 +5817,17 @@ end
 
 """
 function mfma_f32_32x32x1f32(args::Vector{Value}; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[args...,]
+    results = IR.Type[res, ]
+    operands = Value[args..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "rocdl.mfma.f32.32x32x1f32",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "rocdl.mfma.f32.32x32x1f32", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -7776,21 +5836,17 @@ end
 
 """
 function mfma_f32_32x32x2bf16(args::Vector{Value}; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[args...,]
+    results = IR.Type[res, ]
+    operands = Value[args..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "rocdl.mfma.f32.32x32x2bf16",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "rocdl.mfma.f32.32x32x2bf16", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -7799,21 +5855,17 @@ end
 
 """
 function mfma_f32_32x32x2f32(args::Vector{Value}; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[args...,]
+    results = IR.Type[res, ]
+    operands = Value[args..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "rocdl.mfma.f32.32x32x2f32",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "rocdl.mfma.f32.32x32x2f32", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -7822,21 +5874,17 @@ end
 
 """
 function mfma_f32_32x32x4_xf32(args::Vector{Value}; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[args...,]
+    results = IR.Type[res, ]
+    operands = Value[args..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "rocdl.mfma.f32.32x32x4.xf32",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "rocdl.mfma.f32.32x32x4.xf32", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -7845,21 +5893,17 @@ end
 
 """
 function mfma_f32_32x32x4bf16(args::Vector{Value}; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[args...,]
+    results = IR.Type[res, ]
+    operands = Value[args..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "rocdl.mfma.f32.32x32x4bf16",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "rocdl.mfma.f32.32x32x4bf16", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -7868,21 +5912,17 @@ end
 
 """
 function mfma_f32_32x32x4bf16_1k(args::Vector{Value}; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[args...,]
+    results = IR.Type[res, ]
+    operands = Value[args..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "rocdl.mfma.f32.32x32x4bf16.1k",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "rocdl.mfma.f32.32x32x4bf16.1k", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -7891,21 +5931,17 @@ end
 
 """
 function mfma_f32_32x32x4f16(args::Vector{Value}; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[args...,]
+    results = IR.Type[res, ]
+    operands = Value[args..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "rocdl.mfma.f32.32x32x4f16",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "rocdl.mfma.f32.32x32x4f16", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -7914,21 +5950,17 @@ end
 
 """
 function mfma_f32_32x32x8bf16_1k(args::Vector{Value}; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[args...,]
+    results = IR.Type[res, ]
+    operands = Value[args..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "rocdl.mfma.f32.32x32x8bf16.1k",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "rocdl.mfma.f32.32x32x8bf16.1k", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -7937,21 +5969,17 @@ end
 
 """
 function mfma_f32_32x32x8f16(args::Vector{Value}; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[args...,]
+    results = IR.Type[res, ]
+    operands = Value[args..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "rocdl.mfma.f32.32x32x8f16",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "rocdl.mfma.f32.32x32x8f16", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -7960,21 +5988,17 @@ end
 
 """
 function mfma_f32_4x4x1f32(args::Vector{Value}; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[args...,]
+    results = IR.Type[res, ]
+    operands = Value[args..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "rocdl.mfma.f32.4x4x1f32",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "rocdl.mfma.f32.4x4x1f32", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -7983,21 +6007,17 @@ end
 
 """
 function mfma_f32_4x4x2bf16(args::Vector{Value}; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[args...,]
+    results = IR.Type[res, ]
+    operands = Value[args..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "rocdl.mfma.f32.4x4x2bf16",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "rocdl.mfma.f32.4x4x2bf16", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -8006,21 +6026,17 @@ end
 
 """
 function mfma_f32_4x4x4bf16_1k(args::Vector{Value}; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[args...,]
+    results = IR.Type[res, ]
+    operands = Value[args..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "rocdl.mfma.f32.4x4x4bf16.1k",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "rocdl.mfma.f32.4x4x4bf16.1k", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -8029,21 +6045,17 @@ end
 
 """
 function mfma_f32_4x4x4f16(args::Vector{Value}; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[args...,]
+    results = IR.Type[res, ]
+    operands = Value[args..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "rocdl.mfma.f32.4x4x4f16",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "rocdl.mfma.f32.4x4x4f16", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -8052,21 +6064,17 @@ end
 
 """
 function mfma_f64_16x16x4f64(args::Vector{Value}; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[args...,]
+    results = IR.Type[res, ]
+    operands = Value[args..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "rocdl.mfma.f64.16x16x4f64",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "rocdl.mfma.f64.16x16x4f64", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -8075,21 +6083,17 @@ end
 
 """
 function mfma_f64_4x4x4f64(args::Vector{Value}; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[args...,]
+    results = IR.Type[res, ]
+    operands = Value[args..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "rocdl.mfma.f64.4x4x4f64",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "rocdl.mfma.f64.4x4x4f64", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -8098,21 +6102,17 @@ end
 
 """
 function mfma_i32_16x16x16i8(args::Vector{Value}; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[args...,]
+    results = IR.Type[res, ]
+    operands = Value[args..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "rocdl.mfma.i32.16x16x16i8",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "rocdl.mfma.i32.16x16x16i8", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -8121,21 +6121,17 @@ end
 
 """
 function mfma_i32_16x16x32_i8(args::Vector{Value}; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[args...,]
+    results = IR.Type[res, ]
+    operands = Value[args..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "rocdl.mfma.i32.16x16x32.i8",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "rocdl.mfma.i32.16x16x32.i8", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -8144,21 +6140,17 @@ end
 
 """
 function mfma_i32_16x16x4i8(args::Vector{Value}; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[args...,]
+    results = IR.Type[res, ]
+    operands = Value[args..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "rocdl.mfma.i32.16x16x4i8",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "rocdl.mfma.i32.16x16x4i8", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -8167,21 +6159,17 @@ end
 
 """
 function mfma_i32_32x32x16_i8(args::Vector{Value}; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[args...,]
+    results = IR.Type[res, ]
+    operands = Value[args..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "rocdl.mfma.i32.32x32x16.i8",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "rocdl.mfma.i32.32x32x16.i8", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -8190,21 +6178,17 @@ end
 
 """
 function mfma_i32_32x32x4i8(args::Vector{Value}; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[args...,]
+    results = IR.Type[res, ]
+    operands = Value[args..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "rocdl.mfma.i32.32x32x4i8",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "rocdl.mfma.i32.32x32x4i8", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -8213,21 +6197,17 @@ end
 
 """
 function mfma_i32_32x32x8i8(args::Vector{Value}; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[args...,]
+    results = IR.Type[res, ]
+    operands = Value[args..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "rocdl.mfma.i32.32x32x8i8",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "rocdl.mfma.i32.32x32x8i8", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -8236,21 +6216,17 @@ end
 
 """
 function mfma_i32_4x4x4i8(args::Vector{Value}; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[args...,]
+    results = IR.Type[res, ]
+    operands = Value[args..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "rocdl.mfma.i32.4x4x4i8",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "rocdl.mfma.i32.4x4x4i8", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/16/Linalg.jl
+++ b/src/Dialects/16/Linalg.jl
@@ -1,8 +1,8 @@
 module linalg
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `index`
@@ -41,23 +41,19 @@ scf.for %i = %c0 to %0 step %c1 {
 }
 ```
 """
-function index(; result=nothing::Union{Nothing,IR.Type}, dim, location=Location())
+function index(; result=nothing::Union{Nothing, IR.Type}, dim, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("dim", dim),]
+    attributes = NamedAttribute[namedattribute("dim", dim), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "linalg.index",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.index", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -76,26 +72,22 @@ linalg.yield %f0, %f1 : f32, f32
 """
 function yield(values::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[values...,]
+    operands = Value[values..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "linalg.yield",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.yield", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `batch_matmul`
@@ -103,29 +95,19 @@ import ..Dialects: namedattribute, operandsegmentsizes
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function batch_matmul(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function batch_matmul(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
-
-    return IR.create_operation(
-        "linalg.batch_matmul",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    
+    IR.create_operation(
+        "linalg.batch_matmul", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -137,29 +119,19 @@ dimensions transposed.
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function batch_matmul_transpose_b(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function batch_matmul_transpose_b(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
-
-    return IR.create_operation(
-        "linalg.batch_matmul_transpose_b",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    
+    IR.create_operation(
+        "linalg.batch_matmul_transpose_b", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -169,29 +141,19 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function batch_matvec(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function batch_matvec(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
-
-    return IR.create_operation(
-        "linalg.batch_matvec",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    
+    IR.create_operation(
+        "linalg.batch_matvec", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -203,29 +165,19 @@ The partial multiplication results are reduced into a 2D output.
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function batch_reduce_matmul(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function batch_reduce_matmul(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
-
-    return IR.create_operation(
-        "linalg.batch_reduce_matmul",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    
+    IR.create_operation(
+        "linalg.batch_reduce_matmul", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -242,29 +194,18 @@ Broadcast the input into the given shape by adding `dimensions`.
       dimensions = [1]
 ```
 """
-function broadcast(
-    input::Value,
-    init::Value;
-    result::Vector{IR.Type},
-    dimensions,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result...,]
-    operands = Value[input, init]
-    owned_regions = Region[region,]
+function broadcast(input::Value, init::Value; result::Vector{IR.Type}, dimensions, region::Region, location=Location())
+    results = IR.Type[result..., ]
+    operands = Value[input, init, ]
+    owned_regions = Region[region, ]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("dimensions", dimensions),]
-
-    return IR.create_operation(
-        "linalg.broadcast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("dimensions", dimensions), ]
+    
+    IR.create_operation(
+        "linalg.broadcast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -278,33 +219,21 @@ Layout:
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function conv_1d_ncw_fcw(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function conv_1d_ncw_fcw(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.conv_1d_ncw_fcw",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.conv_1d_ncw_fcw", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -314,33 +243,21 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function conv_1d_nwc_wcf(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function conv_1d_nwc_wcf(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.conv_1d_nwc_wcf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.conv_1d_nwc_wcf", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -350,29 +267,19 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function conv_1d(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function conv_1d(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
-
-    return IR.create_operation(
-        "linalg.conv_1d",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    
+    IR.create_operation(
+        "linalg.conv_1d", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -386,33 +293,21 @@ Layout:
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function conv_2d_nchw_fchw(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function conv_2d_nchw_fchw(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.conv_2d_nchw_fchw",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.conv_2d_nchw_fchw", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -426,33 +321,21 @@ Layout:
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function conv_2d_ngchw_fgchw(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function conv_2d_ngchw_fgchw(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.conv_2d_ngchw_fgchw",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.conv_2d_ngchw_fgchw", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -466,33 +349,21 @@ Layout:
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function conv_2d_nhwc_fhwc(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function conv_2d_nhwc_fhwc(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.conv_2d_nhwc_fhwc",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.conv_2d_nhwc_fhwc", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -506,33 +377,21 @@ Layout:
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function conv_2d_nhwc_hwcf(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function conv_2d_nhwc_hwcf(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.conv_2d_nhwc_hwcf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.conv_2d_nhwc_hwcf", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -547,33 +406,21 @@ Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output. This includes the zero
 point offsets common to quantized operations.
 """
-function conv_2d_nhwc_hwcf_q(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function conv_2d_nhwc_hwcf_q(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.conv_2d_nhwc_hwcf_q",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.conv_2d_nhwc_hwcf_q", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -583,29 +430,19 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function conv_2d(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function conv_2d(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
-
-    return IR.create_operation(
-        "linalg.conv_2d",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    
+    IR.create_operation(
+        "linalg.conv_2d", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -615,33 +452,21 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function conv_3d_ndhwc_dhwcf(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function conv_3d_ndhwc_dhwcf(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.conv_3d_ndhwc_dhwcf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.conv_3d_ndhwc_dhwcf", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -652,33 +477,21 @@ Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output. This includes the zero
 point offsets common to quantized operations.
 """
-function conv_3d_ndhwc_dhwcf_q(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function conv_3d_ndhwc_dhwcf_q(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.conv_3d_ndhwc_dhwcf_q",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.conv_3d_ndhwc_dhwcf_q", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -688,29 +501,19 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function conv_3d(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function conv_3d(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
-
-    return IR.create_operation(
-        "linalg.conv_3d",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    
+    IR.create_operation(
+        "linalg.conv_3d", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -720,31 +523,20 @@ end
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function copy(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    cast=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function copy(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, cast=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(cast) && push!(attributes, namedattribute("cast", cast))
-
-    return IR.create_operation(
-        "linalg.copy",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.copy", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -755,33 +547,21 @@ Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output. Multiplier is set to 1
 which is a special case for most depthwise convolutions.
 """
-function depthwise_conv_1d_nwc_wc(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function depthwise_conv_1d_nwc_wc(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.depthwise_conv_1d_nwc_wc",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.depthwise_conv_1d_nwc_wc", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -791,33 +571,21 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function depthwise_conv_1d_nwc_wcm(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function depthwise_conv_1d_nwc_wcm(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.depthwise_conv_1d_nwc_wcm",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.depthwise_conv_1d_nwc_wcm", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -828,33 +596,21 @@ Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output. Multiplier is set to 1
 which is a special case for most depthwise convolutions.
 """
-function depthwise_conv_2d_nchw_chw(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function depthwise_conv_2d_nchw_chw(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.depthwise_conv_2d_nchw_chw",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.depthwise_conv_2d_nchw_chw", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -865,33 +621,21 @@ Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output. Multiplier is set to 1
 which is a special case for most depthwise convolutions.
 """
-function depthwise_conv_2d_nhwc_hwc(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function depthwise_conv_2d_nhwc_hwc(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.depthwise_conv_2d_nhwc_hwc",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.depthwise_conv_2d_nhwc_hwc", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -901,33 +645,21 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function depthwise_conv_2d_nhwc_hwc_q(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function depthwise_conv_2d_nhwc_hwc_q(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.depthwise_conv_2d_nhwc_hwc_q",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.depthwise_conv_2d_nhwc_hwc_q", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -937,33 +669,21 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function depthwise_conv_2d_nhwc_hwcm(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function depthwise_conv_2d_nhwc_hwcm(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.depthwise_conv_2d_nhwc_hwcm",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.depthwise_conv_2d_nhwc_hwcm", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -973,33 +693,21 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function depthwise_conv_2d_nhwc_hwcm_q(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function depthwise_conv_2d_nhwc_hwcm_q(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.depthwise_conv_2d_nhwc_hwcm_q",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.depthwise_conv_2d_nhwc_hwcm_q", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1010,33 +718,21 @@ Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output. Multiplier is set to 1
 which is a special case for most depthwise convolutions.
 """
-function depthwise_conv_3d_ndhwc_dhwc(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function depthwise_conv_3d_ndhwc_dhwc(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.depthwise_conv_3d_ndhwc_dhwc",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.depthwise_conv_3d_ndhwc_dhwc", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1046,33 +742,21 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function depthwise_conv_3d_ndhwc_dhwcm(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function depthwise_conv_3d_ndhwc_dhwcm(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.depthwise_conv_3d_ndhwc_dhwcm",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.depthwise_conv_3d_ndhwc_dhwcm", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1082,29 +766,19 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function dot(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function dot(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
-
-    return IR.create_operation(
-        "linalg.dot",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    
+    IR.create_operation(
+        "linalg.dot", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1114,33 +788,21 @@ end
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function elemwise_binary(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    fun=nothing,
-    cast=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function elemwise_binary(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, fun=nothing, cast=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(fun) && push!(attributes, namedattribute("fun", fun))
     !isnothing(cast) && push!(attributes, namedattribute("cast", cast))
-
-    return IR.create_operation(
-        "linalg.elemwise_binary",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.elemwise_binary", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1150,33 +812,21 @@ end
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function elemwise_unary(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    fun=nothing,
-    cast=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function elemwise_unary(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, fun=nothing, cast=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(fun) && push!(attributes, namedattribute("fun", fun))
     !isnothing(cast) && push!(attributes, namedattribute("cast", cast))
-
-    return IR.create_operation(
-        "linalg.elemwise_unary",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.elemwise_unary", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1187,29 +837,19 @@ Works for arbitrary ranked output tensors since the operation performs scalar
 accesses only and is thus rank polymorphic. Numeric casting is performed on
 the value operand, promoting it to the same data type as the output.
 """
-function fill(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function fill(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
-
-    return IR.create_operation(
-        "linalg.fill",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    
+    IR.create_operation(
+        "linalg.fill", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1224,29 +864,19 @@ and runs them in parallel. The seed operand and the indices of the data
 element seed the random number generation. The min and max operands limit
 the range of the generated random numbers.
 """
-function fill_rng_2d(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function fill_rng_2d(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
-
-    return IR.create_operation(
-        "linalg.fill_rng_2d",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    
+    IR.create_operation(
+        "linalg.fill_rng_2d", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1349,39 +979,21 @@ tensors and buffers operands and tensor results.
   -> (tensor<?x?xf32>)
 ```
 """
-function generic(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    indexing_maps,
-    iterator_types,
-    doc=nothing,
-    library_call=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function generic(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, indexing_maps, iterator_types, doc=nothing, library_call=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("indexing_maps", indexing_maps),
-        namedattribute("iterator_types", iterator_types),
-    ]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    attributes = NamedAttribute[namedattribute("indexing_maps", indexing_maps), namedattribute("iterator_types", iterator_types), ]
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(doc) && push!(attributes, namedattribute("doc", doc))
-    !isnothing(library_call) &&
-        push!(attributes, namedattribute("library_call", library_call))
-
-    return IR.create_operation(
-        "linalg.generic",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(library_call) && push!(attributes, namedattribute("library_call", library_call))
+    
+    IR.create_operation(
+        "linalg.generic", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1412,28 +1024,18 @@ The example above will be printed as:
       outs(%init: tensor<64xf32>)
 ```
 """
-function map(
-    inputs::Vector{Value},
-    init::Value;
-    result::Vector{IR.Type},
-    mapper::Region,
-    location=Location(),
-)
-    results = IR.Type[result...,]
-    operands = Value[inputs..., init]
-    owned_regions = Region[mapper,]
+function map(inputs::Vector{Value}, init::Value; result::Vector{IR.Type}, mapper::Region, location=Location())
+    results = IR.Type[result..., ]
+    operands = Value[inputs..., init, ]
+    owned_regions = Region[mapper, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "linalg.map",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.map", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1443,31 +1045,20 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function matmul(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    cast=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function matmul(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, cast=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(cast) && push!(attributes, namedattribute("cast", cast))
-
-    return IR.create_operation(
-        "linalg.matmul",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.matmul", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1477,31 +1068,20 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function matmul_transpose_b(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    cast=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function matmul_transpose_b(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, cast=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(cast) && push!(attributes, namedattribute("cast", cast))
-
-    return IR.create_operation(
-        "linalg.matmul_transpose_b",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.matmul_transpose_b", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1511,29 +1091,19 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function matmul_unsigned(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function matmul_unsigned(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
-
-    return IR.create_operation(
-        "linalg.matmul_unsigned",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    
+    IR.create_operation(
+        "linalg.matmul_unsigned", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1543,29 +1113,19 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function matvec(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function matvec(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
-
-    return IR.create_operation(
-        "linalg.matvec",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    
+    IR.create_operation(
+        "linalg.matvec", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1580,29 +1140,19 @@ Differences from linalg.matmul:
   \'0\' suffixes below, for instance the LHS matrix shape (M, K, M0, K0) reads
   as: MxK tiles, each of shape M0xK0.
 """
-function mmt4d(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function mmt4d(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
-
-    return IR.create_operation(
-        "linalg.mmt4d",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    
+    IR.create_operation(
+        "linalg.mmt4d", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1612,33 +1162,21 @@ end
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function pooling_nchw_max(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function pooling_nchw_max(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.pooling_nchw_max",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.pooling_nchw_max", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1652,33 +1190,21 @@ Layout:
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function pooling_nchw_sum(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function pooling_nchw_sum(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.pooling_nchw_sum",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.pooling_nchw_sum", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1688,33 +1214,21 @@ end
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function pooling_ncw_max(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function pooling_ncw_max(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.pooling_ncw_max",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.pooling_ncw_max", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1728,33 +1242,21 @@ Layout:
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function pooling_ncw_sum(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function pooling_ncw_sum(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.pooling_ncw_sum",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.pooling_ncw_sum", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1764,33 +1266,21 @@ end
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function pooling_ndhwc_max(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function pooling_ndhwc_max(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.pooling_ndhwc_max",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.pooling_ndhwc_max", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1800,33 +1290,21 @@ end
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function pooling_ndhwc_min(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function pooling_ndhwc_min(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.pooling_ndhwc_min",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.pooling_ndhwc_min", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1836,33 +1314,21 @@ end
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function pooling_ndhwc_sum(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function pooling_ndhwc_sum(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.pooling_ndhwc_sum",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.pooling_ndhwc_sum", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1872,33 +1338,21 @@ end
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function pooling_nhwc_max(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function pooling_nhwc_max(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.pooling_nhwc_max",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.pooling_nhwc_max", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1908,33 +1362,21 @@ end
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function pooling_nhwc_max_unsigned(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function pooling_nhwc_max_unsigned(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.pooling_nhwc_max_unsigned",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.pooling_nhwc_max_unsigned", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1944,33 +1386,21 @@ end
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function pooling_nhwc_min(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function pooling_nhwc_min(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.pooling_nhwc_min",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.pooling_nhwc_min", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1980,33 +1410,21 @@ end
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function pooling_nhwc_min_unsigned(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function pooling_nhwc_min_unsigned(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.pooling_nhwc_min_unsigned",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.pooling_nhwc_min_unsigned", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2020,33 +1438,21 @@ Layout:
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function pooling_nhwc_sum(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function pooling_nhwc_sum(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.pooling_nhwc_sum",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.pooling_nhwc_sum", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2056,33 +1462,21 @@ end
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function pooling_nwc_max(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function pooling_nwc_max(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.pooling_nwc_max",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.pooling_nwc_max", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2092,33 +1486,21 @@ end
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function pooling_nwc_max_unsigned(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function pooling_nwc_max_unsigned(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.pooling_nwc_max_unsigned",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.pooling_nwc_max_unsigned", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2128,33 +1510,21 @@ end
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function pooling_nwc_min(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function pooling_nwc_min(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.pooling_nwc_min",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.pooling_nwc_min", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2164,33 +1534,21 @@ end
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function pooling_nwc_min_unsigned(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function pooling_nwc_min_unsigned(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.pooling_nwc_min_unsigned",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.pooling_nwc_min_unsigned", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2204,33 +1562,21 @@ Layout:
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function pooling_nwc_sum(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function pooling_nwc_sum(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.pooling_nwc_sum",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.pooling_nwc_sum", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2242,29 +1588,19 @@ them to the same data type as the accumulator/output. The quantized variant
 includes zero-point adjustments for the left and right operands of the
 matmul.
 """
-function quantized_batch_matmul(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function quantized_batch_matmul(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
-
-    return IR.create_operation(
-        "linalg.quantized_batch_matmul",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    
+    IR.create_operation(
+        "linalg.quantized_batch_matmul", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2276,29 +1612,19 @@ them to the same data type as the accumulator/output. The quantized variant
 includes zero-point adjustments for the left and right operands of the
 matmul.
 """
-function quantized_matmul(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function quantized_matmul(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
-
-    return IR.create_operation(
-        "linalg.quantized_matmul",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    
+    IR.create_operation(
+        "linalg.quantized_matmul", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2333,29 +1659,18 @@ The example above will be printed as:
       dimensions = [1]
 ```
 """
-function reduce(
-    inputs::Vector{Value},
-    inits::Vector{Value};
-    result_0::Vector{IR.Type},
-    dimensions,
-    combiner::Region,
-    location=Location(),
-)
-    results = IR.Type[result_0...,]
-    operands = Value[inputs..., inits...]
-    owned_regions = Region[combiner,]
+function reduce(inputs::Vector{Value}, inits::Vector{Value}; result_0::Vector{IR.Type}, dimensions, combiner::Region, location=Location())
+    results = IR.Type[result_0..., ]
+    operands = Value[inputs..., inits..., ]
+    owned_regions = Region[combiner, ]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("dimensions", dimensions),]
-
-    return IR.create_operation(
-        "linalg.reduce",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("dimensions", dimensions), ]
+    
+    IR.create_operation(
+        "linalg.reduce", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2376,29 +1691,18 @@ operation only that produces a transposed \"view\".
       permutation = [1, 0]
 ```
 """
-function transpose(
-    input::Value,
-    init::Value;
-    result::Vector{IR.Type},
-    permutation,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result...,]
-    operands = Value[input, init]
-    owned_regions = Region[region,]
+function transpose(input::Value, init::Value; result::Vector{IR.Type}, permutation, region::Region, location=Location())
+    results = IR.Type[result..., ]
+    operands = Value[input, init, ]
+    owned_regions = Region[region, ]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("permutation", permutation),]
-
-    return IR.create_operation(
-        "linalg.transpose",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("permutation", permutation), ]
+    
+    IR.create_operation(
+        "linalg.transpose", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2408,29 +1712,19 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function vecmat(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function vecmat(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
-
-    return IR.create_operation(
-        "linalg.vecmat",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    
+    IR.create_operation(
+        "linalg.vecmat", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/16/MLProgram.jl
+++ b/src/Dialects/16/MLProgram.jl
@@ -1,8 +1,8 @@
 module ml_program
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `func`
@@ -24,36 +24,21 @@ ml_program.func @compute(%arg0 : i32) -> i32 {
 }
 ```
 """
-function func(;
-    sym_name,
-    function_type,
-    arg_attrs=nothing,
-    res_attrs=nothing,
-    sym_visibility=nothing,
-    body::Region,
-    location=Location(),
-)
+function func(; sym_name, function_type, arg_attrs=nothing, res_attrs=nothing, sym_visibility=nothing, body::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[body,]
+    owned_regions = Region[body, ]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("sym_name", sym_name), namedattribute("function_type", function_type)
-    ]
+    attributes = NamedAttribute[namedattribute("sym_name", sym_name), namedattribute("function_type", function_type), ]
     !isnothing(arg_attrs) && push!(attributes, namedattribute("arg_attrs", arg_attrs))
     !isnothing(res_attrs) && push!(attributes, namedattribute("res_attrs", res_attrs))
-    !isnothing(sym_visibility) &&
-        push!(attributes, namedattribute("sym_visibility", sym_visibility))
-
-    return IR.create_operation(
-        "ml_program.func",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(sym_visibility) && push!(attributes, namedattribute("sym_visibility", sym_visibility))
+    
+    IR.create_operation(
+        "ml_program.func", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -72,21 +57,17 @@ such a load can be considered to have no side effects.
 ```
 """
 function global_load_const(; result::IR.Type, global_, location=Location())
-    results = IR.Type[result,]
+    results = IR.Type[result, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("global", global_),]
-
-    return IR.create_operation(
-        "ml_program.global_load_const",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("global", global_), ]
+    
+    IR.create_operation(
+        "ml_program.global_load_const", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -110,28 +91,18 @@ without additional consideration to evaluation order constraints.
   ordering (%token -> !ml_program.token) : tensor<?xi32>
 ```
 """
-function global_load_graph(
-    consumeTokens::Vector{Value};
-    result::IR.Type,
-    produceToken::IR.Type,
-    global_,
-    location=Location(),
-)
-    results = IR.Type[result, produceToken]
-    operands = Value[consumeTokens...,]
+function global_load_graph(consumeTokens::Vector{Value}; result::IR.Type, produceToken::IR.Type, global_, location=Location())
+    results = IR.Type[result, produceToken, ]
+    operands = Value[consumeTokens..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("global", global_),]
-
-    return IR.create_operation(
-        "ml_program.global_load_graph",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("global", global_), ]
+    
+    IR.create_operation(
+        "ml_program.global_load_graph", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -156,21 +127,17 @@ without additional consideration to evaluation order constraints. See
 ```
 """
 function global_load(; result::IR.Type, global_, location=Location())
-    results = IR.Type[result,]
+    results = IR.Type[result, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("global", global_),]
-
-    return IR.create_operation(
-        "ml_program.global_load",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("global", global_), ]
+    
+    IR.create_operation(
+        "ml_program.global_load", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -204,35 +171,21 @@ ml_program.global mutable @foobar(#ml_program.extern<tensor<4xi32>>)
 ml_program.global mutable @foobar : tensor<?xi32>
 ```
 """
-function global_(;
-    sym_name,
-    type,
-    is_mutable=nothing,
-    value=nothing,
-    sym_visibility=nothing,
-    location=Location(),
-)
+function global_(; sym_name, type, is_mutable=nothing, value=nothing, sym_visibility=nothing, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("sym_name", sym_name), namedattribute("type", type)
-    ]
+    attributes = NamedAttribute[namedattribute("sym_name", sym_name), namedattribute("type", type), ]
     !isnothing(is_mutable) && push!(attributes, namedattribute("is_mutable", is_mutable))
     !isnothing(value) && push!(attributes, namedattribute("value", value))
-    !isnothing(sym_visibility) &&
-        push!(attributes, namedattribute("sym_visibility", sym_visibility))
-
-    return IR.create_operation(
-        "ml_program.global",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(sym_visibility) && push!(attributes, namedattribute("sym_visibility", sym_visibility))
+    
+    IR.create_operation(
+        "ml_program.global", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -256,28 +209,18 @@ without additional consideration to evaluation order constraints.
   ordering (%in_token -> !ml_program.token) : tensor<?xi32>
 ```
 """
-function global_store_graph(
-    value::Value,
-    consumeTokens::Vector{Value};
-    produceToken::IR.Type,
-    global_,
-    location=Location(),
-)
-    results = IR.Type[produceToken,]
-    operands = Value[value, consumeTokens...]
+function global_store_graph(value::Value, consumeTokens::Vector{Value}; produceToken::IR.Type, global_, location=Location())
+    results = IR.Type[produceToken, ]
+    operands = Value[value, consumeTokens..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("global", global_),]
-
-    return IR.create_operation(
-        "ml_program.global_store_graph",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("global", global_), ]
+    
+    IR.create_operation(
+        "ml_program.global_store_graph", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -303,20 +246,16 @@ ml_program.global_store @foobar = %0 : tensor<?xi32>
 """
 function global_store(value::Value; global_, location=Location())
     results = IR.Type[]
-    operands = Value[value,]
+    operands = Value[value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("global", global_),]
-
-    return IR.create_operation(
-        "ml_program.global_store",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("global", global_), ]
+    
+    IR.create_operation(
+        "ml_program.global_store", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -329,22 +268,18 @@ The operation takes variable number of operands and produces no results.
 The operand number and types must match the signature of the function
 that contains the operation.
 """
-function output(operands::Vector{Value}; location=Location())
+function output(operands_::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[operands...,]
+    operands = Value[operands_..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "ml_program.output",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "ml_program.output", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -357,22 +292,18 @@ The operation takes variable number of operands and produces no results.
 The operand number and types must match the signature of the function
 that contains the operation.
 """
-function return_(operands::Vector{Value}; location=Location())
+function return_(operands_::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[operands...,]
+    operands = Value[operands_..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "ml_program.return",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "ml_program.return", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -396,36 +327,21 @@ ml_program.subgraph @compute(%arg0 : i32) -> i32 {
 }
 ```
 """
-function subgraph(;
-    sym_name,
-    function_type,
-    arg_attrs=nothing,
-    res_attrs=nothing,
-    sym_visibility=nothing,
-    body::Region,
-    location=Location(),
-)
+function subgraph(; sym_name, function_type, arg_attrs=nothing, res_attrs=nothing, sym_visibility=nothing, body::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[body,]
+    owned_regions = Region[body, ]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("sym_name", sym_name), namedattribute("function_type", function_type)
-    ]
+    attributes = NamedAttribute[namedattribute("sym_name", sym_name), namedattribute("function_type", function_type), ]
     !isnothing(arg_attrs) && push!(attributes, namedattribute("arg_attrs", arg_attrs))
     !isnothing(res_attrs) && push!(attributes, namedattribute("res_attrs", res_attrs))
-    !isnothing(sym_visibility) &&
-        push!(attributes, namedattribute("sym_visibility", sym_visibility))
-
-    return IR.create_operation(
-        "ml_program.subgraph",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(sym_visibility) && push!(attributes, namedattribute("sym_visibility", sym_visibility))
+    
+    IR.create_operation(
+        "ml_program.subgraph", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -436,21 +352,17 @@ Token values are used to chain side effecting ops in a graph so as to
 establish an execution order. This op produces a token.
 """
 function token(; token::IR.Type, location=Location())
-    results = IR.Type[token,]
+    results = IR.Type[token, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "ml_program.token",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "ml_program.token", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/16/Math.jl
+++ b/src/Dialects/16/Math.jl
@@ -1,8 +1,8 @@
 module math
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `absf`
@@ -18,29 +18,20 @@ of the same type.
 %a = math.absf %b : f64
 ```
 """
-function absf(
-    operand::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function absf(operand::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "math.absf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.absf", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -58,23 +49,19 @@ same type.
 %a = math.absi %b : i64
 ```
 """
-function absi(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function absi(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "math.absi",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.absi", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -105,30 +92,20 @@ See also https://en.wikipedia.org/wiki/Atan2
 %a = math.atan2 %b, %c : f32
 ```
 """
-function atan2(
-    lhs::Value,
-    rhs::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function atan2(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "math.atan2",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.atan2", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -152,29 +129,20 @@ one result of the same type. It has no standard attributes.
 %a = math.atan %b : f64
 ```
 """
-function atan(
-    operand::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function atan(operand::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "math.atan",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.atan", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -194,29 +162,20 @@ of the same type. It has no standard attributes.
 
 Note: This op is not equivalent to powf(..., 1/3.0).
 """
-function cbrt(
-    operand::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function cbrt(operand::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "math.cbrt",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.cbrt", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -240,29 +199,20 @@ result of the same type.  It has no standard attributes.
 %a = math.ceil %b : f64
 ```
 """
-function ceil(
-    operand::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function ceil(operand::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "math.ceil",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.ceil", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -287,30 +237,20 @@ tensor or vector). It has no standard attributes.
 %a = math.copysign %b, %c : f64
 ```
 """
-function copysign(
-    lhs::Value,
-    rhs::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function copysign(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "math.copysign",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.copysign", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -334,29 +274,20 @@ result of the same type.  It has no standard attributes.
 %a = math.cos %b : f64
 ```
 """
-function cos(
-    operand::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function cos(operand::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "math.cos",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.cos", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -373,23 +304,19 @@ It operates on scalar, tensor or vector.
 %a = math.ctlz %b : i32
 ```
 """
-function ctlz(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function ctlz(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "math.ctlz",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.ctlz", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -406,23 +333,19 @@ It operates on scalar, tensor or vector.
 %a = math.cttz %b : i32
 ```
 """
-function cttz(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function cttz(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "math.cttz",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.cttz", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -439,23 +362,19 @@ It operates on scalar, tensor or vector.
 %a = math.ctpop %b : i32
 ```
 """
-function ctpop(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function ctpop(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "math.ctpop",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.ctpop", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -479,29 +398,20 @@ the same type. It has no standard attributes.
 %a = math.erf %b : f64
 ```
 """
-function erf(
-    operand::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function erf(operand::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "math.erf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.erf", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -525,29 +435,20 @@ attributes.
 %a = math.exp2 %b : f64
 ```
 """
-function exp2(
-    operand::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function exp2(operand::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "math.exp2",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.exp2", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -573,29 +474,20 @@ standard attributes.
 %a = math.expm1 %b : f64
 ```
 """
-function expm1(
-    operand::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function expm1(operand::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "math.expm1",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.expm1", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -619,29 +511,20 @@ attributes.
 %a = math.exp %b : f64
 ```
 """
-function exp(
-    operand::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function exp(operand::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "math.exp",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.exp", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -677,30 +560,20 @@ The result is a vector of:
 %a = math.fpowi %base, %power : f64, i32
 ```
 """
-function fpowi(
-    lhs::Value,
-    rhs::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function fpowi(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "math.fpowi",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.fpowi", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -724,29 +597,20 @@ result of the same type.  It has no standard attributes.
 %a = math.floor %b : f64
 ```
 """
-function floor(
-    operand::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function floor(operand::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "math.floor",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.floor", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -775,31 +639,20 @@ The semantics of the operation correspond to those of the `llvm.fma`
 particular case of lowering to LLVM, this is guaranteed to lower
 to the `llvm.fma.*` intrinsic.
 """
-function fma(
-    a::Value,
-    b::Value,
-    c::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function fma(a::Value, b::Value, c::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[a, b, c]
+    operands = Value[a, b, c, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "math.fma",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.fma", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -823,25 +676,19 @@ must have the same type.
 %a = math.ipowi %b, %c : i32
 ```
 """
-function ipowi(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function ipowi(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "math.ipowi",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.ipowi", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -859,29 +706,20 @@ the same type.
 %y = math.log10 %x : f64
 ```
 """
-function log10(
-    operand::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function log10(operand::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "math.log10",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.log10", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -901,29 +739,20 @@ log1p(x) := log(1 + x)
 %y = math.log1p %x : f64
 ```
 """
-function log1p(
-    operand::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function log1p(operand::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "math.log1p",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.log1p", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -941,29 +770,20 @@ the same type.
 %y = math.log2 %x : f64
 ```
 """
-function log2(
-    operand::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function log2(operand::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "math.log2",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.log2", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -981,29 +801,20 @@ the same type.
 %y = math.log %x : f64
 ```
 """
-function log(
-    operand::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function log(operand::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "math.log",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.log", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1027,30 +838,20 @@ must have the same type.
 %a = math.powf %b, %c : f64
 ```
 """
-function powf(
-    lhs::Value,
-    rhs::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function powf(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "math.powf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.powf", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1077,29 +878,20 @@ rounding direction.
 %a = math.roundeven %b : f64
 ```
 """
-function roundeven(
-    operand::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function roundeven(operand::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "math.roundeven",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.roundeven", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1126,29 +918,20 @@ rounding direction.
 %a = math.round %b : f64
 ```
 """
-function round(
-    operand::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function round(operand::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "math.round",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.round", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1166,29 +949,20 @@ one result of the same type. It has no standard attributes.
 %a = math.rsqrt %b : f64
 ```
 """
-function rsqrt(
-    operand::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function rsqrt(operand::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "math.rsqrt",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.rsqrt", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1212,29 +986,20 @@ result of the same type.  It has no standard attributes.
 %a = math.sin %b : f64
 ```
 """
-function sin(
-    operand::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function sin(operand::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "math.sin",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.sin", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1252,29 +1017,20 @@ the same type. It has no standard attributes.
 %a = math.sqrt %b : f64
 ```
 """
-function sqrt(
-    operand::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function sqrt(operand::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "math.sqrt",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.sqrt", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1292,29 +1048,20 @@ result of the same type. It has no standard attributes.
 %a = math.tan %b : f64
 ```
 """
-function tan(
-    operand::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function tan(operand::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "math.tan",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.tan", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1332,29 +1079,20 @@ result of the same type. It has no standard attributes.
 %a = math.tanh %b : f64
 ```
 """
-function tanh(
-    operand::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function tanh(operand::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "math.tanh",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.tanh", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1380,29 +1118,20 @@ than the operand, regardless of the current rounding direction.
 %a = math.trunc %b : f64
 ```
 """
-function trunc(
-    operand::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function trunc(operand::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "math.trunc",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.trunc", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 

--- a/src/Dialects/16/MemRef.jl
+++ b/src/Dialects/16/MemRef.jl
@@ -1,8 +1,8 @@
 module memref
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `assume_alignment`
@@ -16,20 +16,16 @@ optimization only, and the optimization is best-effort.
 """
 function assume_alignment(memref::Value; alignment, location=Location())
     results = IR.Type[]
-    operands = Value[memref,]
+    operands = Value[memref, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("alignment", alignment),]
-
-    return IR.create_operation(
-        "memref.assume_alignment",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("alignment", alignment), ]
+    
+    IR.create_operation(
+        "memref.assume_alignment", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -50,30 +46,19 @@ result represents the latest value that was stored.
 %x = memref.atomic_rmw \"addf\" %value, %I[%i] : (f32, memref<10xf32>) -> f32
 ```
 """
-function atomic_rmw(
-    value::Value,
-    memref::Value,
-    indices::Vector{Value};
-    result=nothing::Union{Nothing,IR.Type},
-    kind,
-    location=Location(),
-)
+function atomic_rmw(value::Value, memref::Value, indices::Vector{Value}; result=nothing::Union{Nothing, IR.Type}, kind, location=Location())
     results = IR.Type[]
-    operands = Value[value, memref, indices...]
+    operands = Value[value, memref, indices..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("kind", kind),]
+    attributes = NamedAttribute[namedattribute("kind", kind), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "memref.atomic_rmw",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "memref.atomic_rmw", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -85,20 +70,16 @@ GenericAtomicRMWOp region.
 """
 function atomic_yield(result::Value; location=Location())
     results = IR.Type[]
-    operands = Value[result,]
+    operands = Value[result, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "memref.atomic_yield",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "memref.atomic_yield", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -118,20 +99,16 @@ Otherwise, the result is undefined. They may have different layouts.
 """
 function copy(source::Value, target::Value; location=Location())
     results = IR.Type[]
-    operands = Value[source, target]
+    operands = Value[source, target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "memref.copy",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "memref.copy", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -159,28 +136,18 @@ body of `GenericAtomicRMWOp`.
 }
 ```
 """
-function generic_atomic_rmw(
-    memref::Value,
-    indices::Vector{Value};
-    result::IR.Type,
-    atomic_body::Region,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[memref, indices...]
-    owned_regions = Region[atomic_body,]
+function generic_atomic_rmw(memref::Value, indices::Vector{Value}; result::IR.Type, atomic_body::Region, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[memref, indices..., ]
+    owned_regions = Region[atomic_body, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "memref.generic_atomic_rmw",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "memref.generic_atomic_rmw", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -222,28 +189,18 @@ techniques. This is possible because of the
 [restrictions on dimensions and symbols](Affine.md/#restrictions-on-dimensions-and-symbols)
 in these contexts.
 """
-function load(
-    memref::Value,
-    indices::Vector{Value};
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[memref, indices...]
+function load(memref::Value, indices::Vector{Value}; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[memref, indices..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "memref.load",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "memref.load", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -288,30 +245,20 @@ boundary.
   memref<8x64xf32, affine_map<(d0, d1)[s0] -> ((d0 + s0), d1)>, 1>
 ```
 """
-function alloc(
-    dynamicSizes::Vector{Value},
-    symbolOperands::Vector{Value};
-    memref::IR.Type,
-    alignment=nothing,
-    location=Location(),
-)
-    results = IR.Type[memref,]
-    operands = Value[dynamicSizes..., symbolOperands...]
+function alloc(dynamicSizes::Vector{Value}, symbolOperands::Vector{Value}; memref::IR.Type, alignment=nothing, location=Location())
+    results = IR.Type[memref, ]
+    operands = Value[dynamicSizes..., symbolOperands..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(dynamicSizes), length(symbolOperands)]))
+    push!(attributes, operandsegmentsizes([length(dynamicSizes), length(symbolOperands), ]))
     !isnothing(alignment) && push!(attributes, namedattribute("alignment", alignment))
-
-    return IR.create_operation(
-        "memref.alloc",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "memref.alloc", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -352,30 +299,20 @@ specified, guarantees alignment at least to that boundary. If not specified,
 an alignment on any convenient boundary compatible with the type will be
 chosen.
 """
-function alloca(
-    dynamicSizes::Vector{Value},
-    symbolOperands::Vector{Value};
-    memref::IR.Type,
-    alignment=nothing,
-    location=Location(),
-)
-    results = IR.Type[memref,]
-    operands = Value[dynamicSizes..., symbolOperands...]
+function alloca(dynamicSizes::Vector{Value}, symbolOperands::Vector{Value}; memref::IR.Type, alignment=nothing, location=Location())
+    results = IR.Type[memref, ]
+    operands = Value[dynamicSizes..., symbolOperands..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(dynamicSizes), length(symbolOperands)]))
+    push!(attributes, operandsegmentsizes([length(dynamicSizes), length(symbolOperands), ]))
     !isnothing(alignment) && push!(attributes, namedattribute("alignment", alignment))
-
-    return IR.create_operation(
-        "memref.alloca",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "memref.alloca", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -413,22 +350,18 @@ operation:
 If `memref.alloca_scope` returns no value, the `memref.alloca_scope.return ` can
 be left out, and will be inserted implicitly.
 """
-function alloca_scope(; results::Vector{IR.Type}, bodyRegion::Region, location=Location())
-    results = IR.Type[results...,]
+function alloca_scope(; results_::Vector{IR.Type}, bodyRegion::Region, location=Location())
+    results = IR.Type[results_..., ]
     operands = Value[]
-    owned_regions = Region[bodyRegion,]
+    owned_regions = Region[bodyRegion, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "memref.alloca_scope",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "memref.alloca_scope", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -444,22 +377,18 @@ to indicate which values are going to be returned. For example:
 memref.alloca_scope.return %value
 ```
 """
-function alloca_scope_return(results::Vector{Value}; location=Location())
+function alloca_scope_return(results_::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[results...,]
+    operands = Value[results_..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "memref.alloca_scope.return",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "memref.alloca_scope.return", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -520,21 +449,17 @@ Erase rank information.
 ```
 """
 function cast(source::Value; dest::IR.Type, location=Location())
-    results = IR.Type[dest,]
-    operands = Value[source,]
+    results = IR.Type[dest, ]
+    operands = Value[source, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "memref.cast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "memref.cast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -582,21 +507,17 @@ Note: This op currently assumes that the inner strides are of the
 source/result layout map are the faster-varying ones.
 """
 function collapse_shape(src::Value; result::IR.Type, reassociation, location=Location())
-    results = IR.Type[result,]
-    operands = Value[src,]
+    results = IR.Type[result, ]
+    operands = Value[src, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("reassociation", reassociation),]
-
-    return IR.create_operation(
-        "memref.collapse_shape",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("reassociation", reassociation), ]
+    
+    IR.create_operation(
+        "memref.collapse_shape", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -617,20 +538,16 @@ memref.dealloc %0 : memref<8x64xf32,  affine_map<(d0, d1) -> (d0, d1), 1>>
 """
 function dealloc(memref::Value; location=Location())
     results = IR.Type[]
-    operands = Value[memref,]
+    operands = Value[memref, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "memref.dealloc",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "memref.dealloc", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -659,25 +576,19 @@ The specified memref type is that of the first operand.
 %y = \"memref.dim\"(%A, %c1) : (memref<4 x ? x f32>, index) -> index
 ```
 """
-function dim(
-    source::Value, index::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function dim(source::Value, index::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[source, index]
+    operands = Value[source, index, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "memref.dim",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "memref.dim", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -728,22 +639,18 @@ TODO: add additional operands to allow source and destination striding, and
 multiple stride levels.
 TODO: Consider replacing src/dst memref indices with view memrefs.
 """
-function dma_start(operands::Vector{Value}; location=Location())
+function dma_start(operands_::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[operands...,]
+    operands = Value[operands_..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "memref.dma_start",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "memref.dma_start", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -767,24 +674,18 @@ number of elements associated with the DMA operation.
  dma_wait %tag[%index], %num_elements : memref<1 x i32, affine_map<(d0) -> (d0)>, 2>
  ```
 """
-function dma_wait(
-    tagMemRef::Value, tagIndices::Vector{Value}, numElements::Value; location=Location()
-)
+function dma_wait(tagMemRef::Value, tagIndices::Vector{Value}, numElements::Value; location=Location())
     results = IR.Type[]
-    operands = Value[tagMemRef, tagIndices..., numElements]
+    operands = Value[tagMemRef, tagIndices..., numElements, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "memref.dma_wait",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "memref.dma_wait", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -831,21 +732,17 @@ Note: This op currently assumes that the inner strides are of the
 source/result layout map are the faster-varying ones.
 """
 function expand_shape(src::Value; result::IR.Type, reassociation, location=Location())
-    results = IR.Type[result,]
-    operands = Value[src,]
+    results = IR.Type[result, ]
+    operands = Value[src, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("reassociation", reassociation),]
-
-    return IR.create_operation(
-        "memref.expand_shape",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("reassociation", reassociation), ]
+    
+    IR.create_operation(
+        "memref.expand_shape", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -871,25 +768,19 @@ as a pointer is explicitly discouraged.
   call @foo(%2) : (!llvm.ptr<f32>) ->()
 ```
 """
-function extract_aligned_pointer_as_index(
-    source::Value; aligned_pointer=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function extract_aligned_pointer_as_index(source::Value; aligned_pointer=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[source,]
+    operands = Value[source, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(aligned_pointer) && push!(results, aligned_pointer)
-
-    return IR.create_operation(
-        "memref.extract_aligned_pointer_as_index",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "memref.extract_aligned_pointer_as_index", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -937,16 +828,9 @@ This makes lowering more progressive and brings the following benefits:
     : memref<f32> to memref<?x?xf32, offset: ?, strides: [?, ?]>
 ```
 """
-function extract_strided_metadata(
-    source::Value;
-    base_buffer=nothing::Union{Nothing,IR.Type},
-    offset=nothing::Union{Nothing,IR.Type},
-    sizes=nothing::Union{Nothing,Vector{IR.Type}},
-    strides=nothing::Union{Nothing,Vector{IR.Type}},
-    location=Location(),
-)
+function extract_strided_metadata(source::Value; base_buffer=nothing::Union{Nothing, IR.Type}, offset=nothing::Union{Nothing, IR.Type}, sizes=nothing::Union{Nothing, Vector{IR.Type}}, strides=nothing::Union{Nothing, Vector{IR.Type}}, location=Location())
     results = IR.Type[]
-    operands = Value[source,]
+    operands = Value[source, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
@@ -954,16 +838,12 @@ function extract_strided_metadata(
     !isnothing(offset) && push!(results, offset)
     !isnothing(sizes) && push!(results, sizes...)
     !isnothing(strides) && push!(results, strides...)
-
-    return IR.create_operation(
-        "memref.extract_strided_metadata",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "memref.extract_strided_metadata", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -982,21 +862,17 @@ undefined.
 ```
 """
 function get_global(; result::IR.Type, name, location=Location())
-    results = IR.Type[result,]
+    results = IR.Type[result, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("name", name),]
-
-    return IR.create_operation(
-        "memref.get_global",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("name", name), ]
+    
+    IR.create_operation(
+        "memref.get_global", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1038,38 +914,22 @@ memref.global @z : memref<3xf16> = uninitialized
 memref.global constant @c : memref<2xi32> = dense<1, 4>
 ```
 """
-function global_(;
-    sym_name,
-    sym_visibility=nothing,
-    type,
-    initial_value=nothing,
-    constant=nothing,
-    alignment=nothing,
-    location=Location(),
-)
+function global_(; sym_name, sym_visibility=nothing, type, initial_value=nothing, constant=nothing, alignment=nothing, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("sym_name", sym_name), namedattribute("type", type)
-    ]
-    !isnothing(sym_visibility) &&
-        push!(attributes, namedattribute("sym_visibility", sym_visibility))
-    !isnothing(initial_value) &&
-        push!(attributes, namedattribute("initial_value", initial_value))
+    attributes = NamedAttribute[namedattribute("sym_name", sym_name), namedattribute("type", type), ]
+    !isnothing(sym_visibility) && push!(attributes, namedattribute("sym_visibility", sym_visibility))
+    !isnothing(initial_value) && push!(attributes, namedattribute("initial_value", initial_value))
     !isnothing(constant) && push!(attributes, namedattribute("constant", constant))
     !isnothing(alignment) && push!(attributes, namedattribute("alignment", alignment))
-
-    return IR.create_operation(
-        "memref.global",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "memref.global", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1091,33 +951,18 @@ in cache). The cache type specifier is either \'data\' or \'instr\'
 and specifies whether the prefetch is performed on data cache or on
 instruction cache.
 """
-function prefetch(
-    memref::Value,
-    indices::Vector{Value};
-    isWrite,
-    localityHint,
-    isDataCache,
-    location=Location(),
-)
+function prefetch(memref::Value, indices::Vector{Value}; isWrite, localityHint, isDataCache, location=Location())
     results = IR.Type[]
-    operands = Value[memref, indices...]
+    operands = Value[memref, indices..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("isWrite", isWrite),
-        namedattribute("localityHint", localityHint),
-        namedattribute("isDataCache", isDataCache),
-    ]
-
-    return IR.create_operation(
-        "memref.prefetch",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("isWrite", isWrite), namedattribute("localityHint", localityHint), namedattribute("isDataCache", isDataCache), ]
+    
+    IR.create_operation(
+        "memref.prefetch", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1133,23 +978,19 @@ The `memref.rank` operation takes a memref operand and returns its rank.
 %1 = memref.rank %arg1 : memref<?x?xf32>
 ```
 """
-function rank(memref::Value; result_0=nothing::Union{Nothing,IR.Type}, location=Location())
+function rank(memref::Value; result_0=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[memref,]
+    operands = Value[memref, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result_0) && push!(results, result_0)
-
-    return IR.create_operation(
-        "memref.rank",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "memref.rank", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1211,30 +1052,20 @@ behavior.
 %5 = memref.load %old[%index]   // undefined behavior
 ```
 """
-function realloc(
-    source::Value,
-    dynamicResultSize=nothing::Union{Nothing,Value};
-    result_0::IR.Type,
-    alignment=nothing,
-    location=Location(),
-)
-    results = IR.Type[result_0,]
-    operands = Value[source,]
+function realloc(source::Value, dynamicResultSize=nothing::Union{Nothing, Value}; result_0::IR.Type, alignment=nothing, location=Location())
+    results = IR.Type[result_0, ]
+    operands = Value[source, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(dynamicResultSize) && push!(operands, dynamicResultSize)
     !isnothing(alignment) && push!(attributes, namedattribute("alignment", alignment))
-
-    return IR.create_operation(
-        "memref.realloc",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "memref.realloc", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1276,40 +1107,19 @@ means that `%dst`\'s descriptor will be:
 %dst.strides = %strides
 ```
 """
-function reinterpret_cast(
-    source::Value,
-    offsets::Vector{Value},
-    sizes::Vector{Value},
-    strides::Vector{Value};
-    result::IR.Type,
-    static_offsets,
-    static_sizes,
-    static_strides,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[source, offsets..., sizes..., strides...]
+function reinterpret_cast(source::Value, offsets::Vector{Value}, sizes::Vector{Value}, strides::Vector{Value}; result::IR.Type, static_offsets, static_sizes, static_strides, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[source, offsets..., sizes..., strides..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("static_offsets", static_offsets),
-        namedattribute("static_sizes", static_sizes),
-        namedattribute("static_strides", static_strides),
-    ]
-    push!(
-        attributes,
-        operandsegmentsizes([1, length(offsets), length(sizes), length(strides)]),
-    )
-
-    return IR.create_operation(
-        "memref.reinterpret_cast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("static_offsets", static_offsets), namedattribute("static_sizes", static_sizes), namedattribute("static_strides", static_strides), ]
+    push!(attributes, operandsegmentsizes([1, length(offsets), length(sizes), length(strides), ]))
+    
+    IR.create_operation(
+        "memref.reinterpret_cast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1349,21 +1159,17 @@ Result type is unranked.
 ```
 """
 function reshape(source::Value, shape::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[source, shape]
+    results = IR.Type[result, ]
+    operands = Value[source, shape, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "memref.reshape",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "memref.reshape", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1399,20 +1205,16 @@ in these contexts.
 """
 function store(value::Value, memref::Value, indices::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[value, memref, indices...]
+    operands = Value[value, memref, indices..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "memref.store",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "memref.store", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1430,21 +1232,17 @@ transformation.
 ```
 """
 function transpose(in::Value; result_0::IR.Type, permutation, location=Location())
-    results = IR.Type[result_0,]
-    operands = Value[in,]
+    results = IR.Type[result_0, ]
+    operands = Value[in, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("permutation", permutation),]
-
-    return IR.create_operation(
-        "memref.transpose",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("permutation", permutation), ]
+    
+    IR.create_operation(
+        "memref.transpose", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1486,28 +1284,18 @@ For now, a \"view\" op:
   memref<2048xi8> to memref<?x4x?xf32>
 ```
 """
-function view(
-    source::Value,
-    byte_shift::Value,
-    sizes::Vector{Value};
-    result_0::IR.Type,
-    location=Location(),
-)
-    results = IR.Type[result_0,]
-    operands = Value[source, byte_shift, sizes...]
+function view(source::Value, byte_shift::Value, sizes::Vector{Value}; result_0::IR.Type, location=Location())
+    results = IR.Type[result_0, ]
+    operands = Value[source, byte_shift, sizes..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "memref.view",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "memref.view", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1645,40 +1433,19 @@ Example 5:
   memref<8x16x4xf32> to memref<6x3xf32, strided<[4, 1], offset: 210>>
 ```
 """
-function subview(
-    source::Value,
-    offsets::Vector{Value},
-    sizes::Vector{Value},
-    strides::Vector{Value};
-    result::IR.Type,
-    static_offsets,
-    static_sizes,
-    static_strides,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[source, offsets..., sizes..., strides...]
+function subview(source::Value, offsets::Vector{Value}, sizes::Vector{Value}, strides::Vector{Value}; result::IR.Type, static_offsets, static_sizes, static_strides, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[source, offsets..., sizes..., strides..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("static_offsets", static_offsets),
-        namedattribute("static_sizes", static_sizes),
-        namedattribute("static_strides", static_strides),
-    ]
-    push!(
-        attributes,
-        operandsegmentsizes([1, length(offsets), length(sizes), length(strides)]),
-    )
-
-    return IR.create_operation(
-        "memref.subview",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("static_offsets", static_offsets), namedattribute("static_sizes", static_sizes), namedattribute("static_strides", static_strides), ]
+    push!(attributes, operandsegmentsizes([1, length(offsets), length(sizes), length(strides), ]))
+    
+    IR.create_operation(
+        "memref.subview", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1699,20 +1466,16 @@ memref.tensor_store %8, %10 : memref<4x?xf32, #layout, memspace0>
 """
 function tensor_store(tensor::Value, memref::Value; location=Location())
     results = IR.Type[]
-    operands = Value[tensor, memref]
+    operands = Value[tensor, memref, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "memref.tensor_store",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "memref.tensor_store", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/16/OpenMP.jl
+++ b/src/Dialects/16/OpenMP.jl
@@ -1,8 +1,8 @@
 module omp
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `atomic_capture`
@@ -37,27 +37,20 @@ The region has the following allowed forms:
   }
 ```
 """
-function atomic_capture(;
-    hint_val=nothing, memory_order_val=nothing, region::Region, location=Location()
-)
+function atomic_capture(; hint_val=nothing, memory_order_val=nothing, region::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[region,]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(hint_val) && push!(attributes, namedattribute("hint_val", hint_val))
-    !isnothing(memory_order_val) &&
-        push!(attributes, namedattribute("memory_order_val", memory_order_val))
-
-    return IR.create_operation(
-        "omp.atomic.capture",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(memory_order_val) && push!(attributes, namedattribute("memory_order_val", memory_order_val))
+    
+    IR.create_operation(
+        "omp.atomic.capture", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -76,27 +69,20 @@ optimization.
 `memory_order` indicates the memory ordering behavior of the construct. It
 can be one of `seq_cst`, `acquire` or `relaxed`.
 """
-function atomic_read(
-    x::Value, v::Value; hint_val=nothing, memory_order_val=nothing, location=Location()
-)
+function atomic_read(x::Value, v::Value; hint_val=nothing, memory_order_val=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[x, v]
+    operands = Value[x, v, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(hint_val) && push!(attributes, namedattribute("hint_val", hint_val))
-    !isnothing(memory_order_val) &&
-        push!(attributes, namedattribute("memory_order_val", memory_order_val))
-
-    return IR.create_operation(
-        "omp.atomic.read",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(memory_order_val) && push!(attributes, namedattribute("memory_order_val", memory_order_val))
+    
+    IR.create_operation(
+        "omp.atomic.read", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -130,31 +116,20 @@ the core update operation is directly translated like regular operations by
 the host dialect. The front-end must handle semantic checks for allowed
 operations.
 """
-function atomic_update(
-    x::Value;
-    hint_val=nothing,
-    memory_order_val=nothing,
-    region::Region,
-    location=Location(),
-)
+function atomic_update(x::Value; hint_val=nothing, memory_order_val=nothing, region::Region, location=Location())
     results = IR.Type[]
-    operands = Value[x,]
-    owned_regions = Region[region,]
+    operands = Value[x, ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(hint_val) && push!(attributes, namedattribute("hint_val", hint_val))
-    !isnothing(memory_order_val) &&
-        push!(attributes, namedattribute("memory_order_val", memory_order_val))
-
-    return IR.create_operation(
-        "omp.atomic.update",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(memory_order_val) && push!(attributes, namedattribute("memory_order_val", memory_order_val))
+    
+    IR.create_operation(
+        "omp.atomic.update", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -175,31 +150,20 @@ optimization.
 `memory_order` indicates the memory ordering behavior of the construct. It
 can be one of `seq_cst`, `release` or `relaxed`.
 """
-function atomic_write(
-    address::Value,
-    value::Value;
-    hint_val=nothing,
-    memory_order_val=nothing,
-    location=Location(),
-)
+function atomic_write(address::Value, value::Value; hint_val=nothing, memory_order_val=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[address, value]
+    operands = Value[address, value, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(hint_val) && push!(attributes, namedattribute("hint_val", hint_val))
-    !isnothing(memory_order_val) &&
-        push!(attributes, namedattribute("memory_order_val", memory_order_val))
-
-    return IR.create_operation(
-        "omp.atomic.write",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(memory_order_val) && push!(attributes, namedattribute("memory_order_val", memory_order_val))
+    
+    IR.create_operation(
+        "omp.atomic.write", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -215,16 +179,12 @@ function barrier(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "omp.barrier",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "omp.barrier", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -234,29 +194,19 @@ end
 The cancel construct activates cancellation of the innermost enclosing
 region of the type specified.
 """
-function cancel(
-    if_expr=nothing::Union{Nothing,Value};
-    cancellation_construct_type_val,
-    location=Location(),
-)
+function cancel(if_expr=nothing::Union{Nothing, Value}; cancellation_construct_type_val, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute(
-        "cancellation_construct_type_val", cancellation_construct_type_val
-    ),]
+    attributes = NamedAttribute[namedattribute("cancellation_construct_type_val", cancellation_construct_type_val), ]
     !isnothing(if_expr) && push!(operands, if_expr)
-
-    return IR.create_operation(
-        "omp.cancel",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "omp.cancel", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -272,19 +222,13 @@ function cancellationpoint(; cancellation_construct_type_val, location=Location(
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute(
-        "cancellation_construct_type_val", cancellation_construct_type_val
-    ),]
-
-    return IR.create_operation(
-        "omp.cancellationpoint",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("cancellation_construct_type_val", cancellation_construct_type_val), ]
+    
+    IR.create_operation(
+        "omp.cancellationpoint", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -300,18 +244,14 @@ function critical_declare(; sym_name, hint_val=nothing, location=Location())
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("sym_name", sym_name),]
+    attributes = NamedAttribute[namedattribute("sym_name", sym_name), ]
     !isnothing(hint_val) && push!(attributes, namedattribute("hint_val", hint_val))
-
-    return IR.create_operation(
-        "omp.critical.declare",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "omp.critical.declare", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -324,20 +264,16 @@ block (region) to be executed by only a single thread at a time.
 function critical(; name=nothing, region::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[region,]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(name) && push!(attributes, namedattribute("name", name))
-
-    return IR.create_operation(
-        "omp.critical",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "omp.critical", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -351,20 +287,16 @@ specified or implied.
 """
 function flush(varList::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[varList...,]
+    operands = Value[varList..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "omp.flush",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "omp.flush", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -377,19 +309,15 @@ the master thread of the team.
 function master(; region::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[region,]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "omp.master",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "omp.master", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -411,31 +339,20 @@ the index of the element of \"vec\" for the DEPEND(SINK: vec) clause. It
 contains the operands in multiple \"vec\" when multiple DEPEND(SINK: vec)
 clauses exist in one ORDERED directive.
 """
-function ordered(
-    depend_vec_vars::Vector{Value};
-    depend_type_val=nothing,
-    num_loops_val=nothing,
-    location=Location(),
-)
+function ordered(depend_vec_vars::Vector{Value}; depend_type_val=nothing, num_loops_val=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[depend_vec_vars...,]
+    operands = Value[depend_vec_vars..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(depend_type_val) &&
-        push!(attributes, namedattribute("depend_type_val", depend_type_val))
-    !isnothing(num_loops_val) &&
-        push!(attributes, namedattribute("num_loops_val", num_loops_val))
-
-    return IR.create_operation(
-        "omp.ordered",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(depend_type_val) && push!(attributes, namedattribute("depend_type_val", depend_type_val))
+    !isnothing(num_loops_val) && push!(attributes, namedattribute("num_loops_val", num_loops_val))
+    
+    IR.create_operation(
+        "omp.ordered", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -453,20 +370,16 @@ specified.
 function ordered_region(; simd=nothing, region::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[region,]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(simd) && push!(attributes, namedattribute("simd", simd))
-
-    return IR.create_operation(
-        "omp.ordered_region",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "omp.ordered_region", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -502,51 +415,23 @@ threads complete.
 The optional \$proc_bind_val attribute controls the thread affinity for the execution
 of the parallel region.
 """
-function parallel(
-    if_expr_var=nothing::Union{Nothing,Value};
-    num_threads_var=nothing::Union{Nothing,Value},
-    allocate_vars::Vector{Value},
-    allocators_vars::Vector{Value},
-    reduction_vars::Vector{Value},
-    reductions=nothing,
-    proc_bind_val=nothing,
-    region::Region,
-    location=Location(),
-)
+function parallel(if_expr_var=nothing::Union{Nothing, Value}; num_threads_var=nothing::Union{Nothing, Value}, allocate_vars::Vector{Value}, allocators_vars::Vector{Value}, reduction_vars::Vector{Value}, reductions=nothing, proc_bind_val=nothing, region::Region, location=Location())
     results = IR.Type[]
-    operands = Value[allocate_vars..., allocators_vars..., reduction_vars...]
-    owned_regions = Region[region,]
+    operands = Value[allocate_vars..., allocators_vars..., reduction_vars..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(if_expr_var) && push!(operands, if_expr_var)
     !isnothing(num_threads_var) && push!(operands, num_threads_var)
-    push!(
-        attributes,
-        operandsegmentsizes([
-            if (if_expr_var == nothing)
-                0
-            elseif 1(num_threads_var == nothing)
-                0
-            else
-                1length(allocate_vars)
-            end,
-            length(allocators_vars),
-            length(reduction_vars),
-        ]),
-    )
+    push!(attributes, operandsegmentsizes([isnothing(if_expr_var) ? 0 : 1, isnothing(num_threads_var) ? 0 : 1, length(allocate_vars), length(allocators_vars), length(reduction_vars), ]))
     !isnothing(reductions) && push!(attributes, namedattribute("reductions", reductions))
-    !isnothing(proc_bind_val) &&
-        push!(attributes, namedattribute("proc_bind_val", proc_bind_val))
-
-    return IR.create_operation(
-        "omp.parallel",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(proc_bind_val) && push!(attributes, namedattribute("proc_bind_val", proc_bind_val))
+    
+    IR.create_operation(
+        "omp.parallel", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -575,31 +460,18 @@ element and accumulator types.
 For initializer and reduction regions, the operand to `omp.yield` must
 match the parent operation\'s results.
 """
-function reduction_declare(;
-    sym_name,
-    type,
-    initializerRegion::Region,
-    reductionRegion::Region,
-    atomicReductionRegion::Region,
-    location=Location(),
-)
+function reduction_declare(; sym_name, type, initializerRegion::Region, reductionRegion::Region, atomicReductionRegion::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[initializerRegion, reductionRegion, atomicReductionRegion]
+    owned_regions = Region[initializerRegion, reductionRegion, atomicReductionRegion, ]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("sym_name", sym_name), namedattribute("type", type)
-    ]
-
-    return IR.create_operation(
-        "omp.reduction.declare",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("sym_name", sym_name), namedattribute("type", type), ]
+    
+    IR.create_operation(
+        "omp.reduction.declare", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -613,20 +485,16 @@ updated immediately.
 """
 function reduction(operand::Value, accumulator::Value; location=Location())
     results = IR.Type[]
-    operands = Value[operand, accumulator]
+    operands = Value[operand, accumulator, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "omp.reduction",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "omp.reduction", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -640,19 +508,15 @@ sections construct. A section op should always be surrounded by an
 function section(; region::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[region,]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "omp.section",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "omp.section", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -683,38 +547,21 @@ that specify the memory allocator to be used to obtain storage for private value
 The `nowait` attribute, when present, signifies that there should be no
 implicit barrier at the end of the construct.
 """
-function sections(
-    reduction_vars::Vector{Value},
-    allocate_vars::Vector{Value},
-    allocators_vars::Vector{Value};
-    reductions=nothing,
-    nowait=nothing,
-    region::Region,
-    location=Location(),
-)
+function sections(reduction_vars::Vector{Value}, allocate_vars::Vector{Value}, allocators_vars::Vector{Value}; reductions=nothing, nowait=nothing, region::Region, location=Location())
     results = IR.Type[]
-    operands = Value[reduction_vars..., allocate_vars..., allocators_vars...]
-    owned_regions = Region[region,]
+    operands = Value[reduction_vars..., allocate_vars..., allocators_vars..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(
-        attributes,
-        operandsegmentsizes([
-            length(reduction_vars), length(allocate_vars), length(allocators_vars)
-        ]),
-    )
+    push!(attributes, operandsegmentsizes([length(reduction_vars), length(allocate_vars), length(allocators_vars), ]))
     !isnothing(reductions) && push!(attributes, namedattribute("reductions", reductions))
     !isnothing(nowait) && push!(attributes, namedattribute("nowait", nowait))
-
-    return IR.create_operation(
-        "omp.sections",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "omp.sections", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -763,55 +610,25 @@ for (%i1, %i2) : index = (%c0, %c0) to (%c10, %c10) step (%c1, %c1) {
 }
 ```
 """
-function simdloop(
-    lowerBound::Vector{Value},
-    upperBound::Vector{Value},
-    step::Vector{Value},
-    aligned_vars::Vector{Value},
-    if_expr=nothing::Union{Nothing,Value};
-    nontemporal_vars::Vector{Value},
-    alignment_values=nothing,
-    order_val=nothing,
-    simdlen=nothing,
-    safelen=nothing,
-    inclusive=nothing,
-    region::Region,
-    location=Location(),
-)
+function simdloop(lowerBound::Vector{Value}, upperBound::Vector{Value}, step::Vector{Value}, aligned_vars::Vector{Value}, if_expr=nothing::Union{Nothing, Value}; nontemporal_vars::Vector{Value}, alignment_values=nothing, order_val=nothing, simdlen=nothing, safelen=nothing, inclusive=nothing, region::Region, location=Location())
     results = IR.Type[]
-    operands = Value[
-        lowerBound..., upperBound..., step..., aligned_vars..., nontemporal_vars...
-    ]
-    owned_regions = Region[region,]
+    operands = Value[lowerBound..., upperBound..., step..., aligned_vars..., nontemporal_vars..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(if_expr) && push!(operands, if_expr)
-    push!(
-        attributes,
-        operandsegmentsizes([
-            length(lowerBound),
-            length(upperBound),
-            length(step),
-            length(aligned_vars),
-            (if_expr == nothing) ? 0 : 1length(nontemporal_vars),
-        ]),
-    )
-    !isnothing(alignment_values) &&
-        push!(attributes, namedattribute("alignment_values", alignment_values))
+    push!(attributes, operandsegmentsizes([length(lowerBound), length(upperBound), length(step), length(aligned_vars), isnothing(if_expr) ? 0 : 1, length(nontemporal_vars), ]))
+    !isnothing(alignment_values) && push!(attributes, namedattribute("alignment_values", alignment_values))
     !isnothing(order_val) && push!(attributes, namedattribute("order_val", order_val))
     !isnothing(simdlen) && push!(attributes, namedattribute("simdlen", simdlen))
     !isnothing(safelen) && push!(attributes, namedattribute("safelen", safelen))
     !isnothing(inclusive) && push!(attributes, namedattribute("inclusive", inclusive))
-
-    return IR.create_operation(
-        "omp.simdloop",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "omp.simdloop", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -824,30 +641,20 @@ master thread), in the context of its implicit task. The other threads
 in the team, which do not execute the block, wait at an implicit barrier
 at the end of the single construct unless a nowait clause is specified.
 """
-function single(
-    allocate_vars::Vector{Value},
-    allocators_vars::Vector{Value};
-    nowait=nothing,
-    region::Region,
-    location=Location(),
-)
+function single(allocate_vars::Vector{Value}, allocators_vars::Vector{Value}; nowait=nothing, region::Region, location=Location())
     results = IR.Type[]
-    operands = Value[allocate_vars..., allocators_vars...]
-    owned_regions = Region[region,]
+    operands = Value[allocate_vars..., allocators_vars..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(allocate_vars), length(allocators_vars)]))
+    push!(attributes, operandsegmentsizes([length(allocate_vars), length(allocators_vars), ]))
     !isnothing(nowait) && push!(attributes, namedattribute("nowait", nowait))
-
-    return IR.create_operation(
-        "omp.single",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "omp.single", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -871,44 +678,23 @@ even if the target task is not yet completed.
 
 TODO:  map, is_device_ptr, depend, defaultmap, in_reduction
 """
-function target(
-    if_expr=nothing::Union{Nothing,Value};
-    device=nothing::Union{Nothing,Value},
-    thread_limit=nothing::Union{Nothing,Value},
-    nowait=nothing,
-    region::Region,
-    location=Location(),
-)
+function target(if_expr=nothing::Union{Nothing, Value}; device=nothing::Union{Nothing, Value}, thread_limit=nothing::Union{Nothing, Value}, nowait=nothing, region::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[region,]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(if_expr) && push!(operands, if_expr)
     !isnothing(device) && push!(operands, device)
     !isnothing(thread_limit) && push!(operands, thread_limit)
-    push!(attributes, operandsegmentsizes([
-        if (if_expr == nothing)
-            0
-        elseif 1(device == nothing)
-            0
-        elseif 1(thread_limit == nothing)
-            0
-        else
-            1
-        end,
-    ]))
+    push!(attributes, operandsegmentsizes([isnothing(if_expr) ? 0 : 1, isnothing(device) ? 0 : 1, isnothing(thread_limit) ? 0 : 1, ]))
     !isnothing(nowait) && push!(attributes, namedattribute("nowait", nowait))
-
-    return IR.create_operation(
-        "omp.target",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "omp.target", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -943,47 +729,21 @@ The \$map_types specifies the types and modifiers for the map clause.
 
 TODO:  depend clause and map_type_modifier values iterator and mapper.
 """
-function target_data(
-    if_expr=nothing::Union{Nothing,Value};
-    device=nothing::Union{Nothing,Value},
-    use_device_ptr::Vector{Value},
-    use_device_addr::Vector{Value},
-    map_operands::Vector{Value},
-    map_types,
-    region::Region,
-    location=Location(),
-)
+function target_data(if_expr=nothing::Union{Nothing, Value}; device=nothing::Union{Nothing, Value}, use_device_ptr::Vector{Value}, use_device_addr::Vector{Value}, map_operands::Vector{Value}, map_types, region::Region, location=Location())
     results = IR.Type[]
-    operands = Value[use_device_ptr..., use_device_addr..., map_operands...]
-    owned_regions = Region[region,]
+    operands = Value[use_device_ptr..., use_device_addr..., map_operands..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("map_types", map_types),]
+    attributes = NamedAttribute[namedattribute("map_types", map_types), ]
     !isnothing(if_expr) && push!(operands, if_expr)
     !isnothing(device) && push!(operands, device)
-    push!(
-        attributes,
-        operandsegmentsizes([
-            if (if_expr == nothing)
-                0
-            elseif 1(device == nothing)
-                0
-            else
-                1length(use_device_ptr)
-            end,
-            length(use_device_addr),
-            length(map_operands),
-        ]),
-    )
-
-    return IR.create_operation(
-        "omp.target_data",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([isnothing(if_expr) ? 0 : 1, isnothing(device) ? 0 : 1, length(use_device_ptr), length(use_device_addr), length(map_operands), ]))
+    
+    IR.create_operation(
+        "omp.target_data", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1011,41 +771,22 @@ The \$map_types specifies the types and modifiers for the map clause.
 
 TODO:  depend clause and map_type_modifier values iterator and mapper.
 """
-function target_enter_data(
-    if_expr=nothing::Union{Nothing,Value};
-    device=nothing::Union{Nothing,Value},
-    map_operands::Vector{Value},
-    nowait=nothing,
-    map_types,
-    location=Location(),
-)
+function target_enter_data(if_expr=nothing::Union{Nothing, Value}; device=nothing::Union{Nothing, Value}, map_operands::Vector{Value}, nowait=nothing, map_types, location=Location())
     results = IR.Type[]
-    operands = Value[map_operands...,]
+    operands = Value[map_operands..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("map_types", map_types),]
+    attributes = NamedAttribute[namedattribute("map_types", map_types), ]
     !isnothing(if_expr) && push!(operands, if_expr)
     !isnothing(device) && push!(operands, device)
-    push!(attributes, operandsegmentsizes([
-        if (if_expr == nothing)
-            0
-        elseif 1(device == nothing)
-            0
-        else
-            1length(map_operands)
-        end,
-    ]))
+    push!(attributes, operandsegmentsizes([isnothing(if_expr) ? 0 : 1, isnothing(device) ? 0 : 1, length(map_operands), ]))
     !isnothing(nowait) && push!(attributes, namedattribute("nowait", nowait))
-
-    return IR.create_operation(
-        "omp.target_enter_data",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "omp.target_enter_data", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1073,41 +814,22 @@ The \$map_types specifies the types and modifiers for the map clause.
 
 TODO:  depend clause and map_type_modifier values iterator and mapper.
 """
-function target_exit_data(
-    if_expr=nothing::Union{Nothing,Value};
-    device=nothing::Union{Nothing,Value},
-    map_operands::Vector{Value},
-    nowait=nothing,
-    map_types,
-    location=Location(),
-)
+function target_exit_data(if_expr=nothing::Union{Nothing, Value}; device=nothing::Union{Nothing, Value}, map_operands::Vector{Value}, nowait=nothing, map_types, location=Location())
     results = IR.Type[]
-    operands = Value[map_operands...,]
+    operands = Value[map_operands..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("map_types", map_types),]
+    attributes = NamedAttribute[namedattribute("map_types", map_types), ]
     !isnothing(if_expr) && push!(operands, if_expr)
     !isnothing(device) && push!(operands, device)
-    push!(attributes, operandsegmentsizes([
-        if (if_expr == nothing)
-            0
-        elseif 1(device == nothing)
-            0
-        else
-            1length(map_operands)
-        end,
-    ]))
+    push!(attributes, operandsegmentsizes([isnothing(if_expr) ? 0 : 1, isnothing(device) ? 0 : 1, length(map_operands), ]))
     !isnothing(nowait) && push!(attributes, namedattribute("nowait", nowait))
-
-    return IR.create_operation(
-        "omp.target_exit_data",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "omp.target_exit_data", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1135,37 +857,20 @@ The `allocators_vars` and `allocate_vars` arguments are a variadic list of
 values that specify the memory allocator to be used to obtain storage for
 private values.
 """
-function taskgroup(
-    task_reduction_vars::Vector{Value},
-    allocate_vars::Vector{Value},
-    allocators_vars::Vector{Value};
-    task_reductions=nothing,
-    region::Region,
-    location=Location(),
-)
+function taskgroup(task_reduction_vars::Vector{Value}, allocate_vars::Vector{Value}, allocators_vars::Vector{Value}; task_reductions=nothing, region::Region, location=Location())
     results = IR.Type[]
-    operands = Value[task_reduction_vars..., allocate_vars..., allocators_vars...]
-    owned_regions = Region[region,]
+    operands = Value[task_reduction_vars..., allocate_vars..., allocators_vars..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(
-        attributes,
-        operandsegmentsizes([
-            length(task_reduction_vars), length(allocate_vars), length(allocators_vars)
-        ]),
-    )
-    !isnothing(task_reductions) &&
-        push!(attributes, namedattribute("task_reductions", task_reductions))
-
-    return IR.create_operation(
-        "omp.taskgroup",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(task_reduction_vars), length(allocate_vars), length(allocators_vars), ]))
+    !isnothing(task_reductions) && push!(attributes, namedattribute("task_reductions", task_reductions))
+    
+    IR.create_operation(
+        "omp.taskgroup", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1267,39 +972,10 @@ construct. Thus, the taskloop construct creates an implicit taskgroup
 region. If the `nogroup` clause is present, no implicit taskgroup region is
 created.
 """
-function taskloop(
-    lowerBound::Vector{Value},
-    upperBound::Vector{Value},
-    step::Vector{Value},
-    if_expr=nothing::Union{Nothing,Value};
-    final_expr=nothing::Union{Nothing,Value},
-    in_reduction_vars::Vector{Value},
-    reduction_vars::Vector{Value},
-    priority=nothing::Union{Nothing,Value},
-    allocate_vars::Vector{Value},
-    allocators_vars::Vector{Value},
-    grain_size=nothing::Union{Nothing,Value},
-    num_tasks=nothing::Union{Nothing,Value},
-    inclusive=nothing,
-    untied=nothing,
-    mergeable=nothing,
-    in_reductions=nothing,
-    reductions=nothing,
-    nogroup=nothing,
-    region::Region,
-    location=Location(),
-)
+function taskloop(lowerBound::Vector{Value}, upperBound::Vector{Value}, step::Vector{Value}, if_expr=nothing::Union{Nothing, Value}; final_expr=nothing::Union{Nothing, Value}, in_reduction_vars::Vector{Value}, reduction_vars::Vector{Value}, priority=nothing::Union{Nothing, Value}, allocate_vars::Vector{Value}, allocators_vars::Vector{Value}, grain_size=nothing::Union{Nothing, Value}, num_tasks=nothing::Union{Nothing, Value}, inclusive=nothing, untied=nothing, mergeable=nothing, in_reductions=nothing, reductions=nothing, nogroup=nothing, region::Region, location=Location())
     results = IR.Type[]
-    operands = Value[
-        lowerBound...,
-        upperBound...,
-        step...,
-        in_reduction_vars...,
-        reduction_vars...,
-        allocate_vars...,
-        allocators_vars...,
-    ]
-    owned_regions = Region[region,]
+    operands = Value[lowerBound..., upperBound..., step..., in_reduction_vars..., reduction_vars..., allocate_vars..., allocators_vars..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(if_expr) && push!(operands, if_expr)
@@ -1307,48 +983,19 @@ function taskloop(
     !isnothing(priority) && push!(operands, priority)
     !isnothing(grain_size) && push!(operands, grain_size)
     !isnothing(num_tasks) && push!(operands, num_tasks)
-    push!(
-        attributes,
-        operandsegmentsizes([
-            length(lowerBound),
-            length(upperBound),
-            length(step),
-            if (if_expr == nothing)
-                0
-            elseif 1(final_expr == nothing)
-                0
-            else
-                1length(in_reduction_vars)
-            end,
-            length(reduction_vars),
-            (priority == nothing) ? 0 : 1length(allocate_vars),
-            length(allocators_vars),
-            if (grain_size == nothing)
-                0
-            elseif 1(num_tasks == nothing)
-                0
-            else
-                1
-            end,
-        ]),
-    )
+    push!(attributes, operandsegmentsizes([length(lowerBound), length(upperBound), length(step), isnothing(if_expr) ? 0 : 1, isnothing(final_expr) ? 0 : 1, length(in_reduction_vars), length(reduction_vars), isnothing(priority) ? 0 : 1, length(allocate_vars), length(allocators_vars), isnothing(grain_size) ? 0 : 1, isnothing(num_tasks) ? 0 : 1, ]))
     !isnothing(inclusive) && push!(attributes, namedattribute("inclusive", inclusive))
     !isnothing(untied) && push!(attributes, namedattribute("untied", untied))
     !isnothing(mergeable) && push!(attributes, namedattribute("mergeable", mergeable))
-    !isnothing(in_reductions) &&
-        push!(attributes, namedattribute("in_reductions", in_reductions))
+    !isnothing(in_reductions) && push!(attributes, namedattribute("in_reductions", in_reductions))
     !isnothing(reductions) && push!(attributes, namedattribute("reductions", reductions))
     !isnothing(nogroup) && push!(attributes, namedattribute("nogroup", nogroup))
-
-    return IR.create_operation(
-        "omp.taskloop",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "omp.taskloop", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1394,55 +1041,25 @@ The `allocators_vars` and `allocate_vars` arguments are a variadic list of
 values that specify the memory allocator to be used to obtain storage for
 private values.
 """
-function task(
-    if_expr=nothing::Union{Nothing,Value};
-    final_expr=nothing::Union{Nothing,Value},
-    in_reduction_vars::Vector{Value},
-    priority=nothing::Union{Nothing,Value},
-    allocate_vars::Vector{Value},
-    allocators_vars::Vector{Value},
-    untied=nothing,
-    mergeable=nothing,
-    in_reductions=nothing,
-    region::Region,
-    location=Location(),
-)
+function task(if_expr=nothing::Union{Nothing, Value}; final_expr=nothing::Union{Nothing, Value}, in_reduction_vars::Vector{Value}, priority=nothing::Union{Nothing, Value}, allocate_vars::Vector{Value}, allocators_vars::Vector{Value}, untied=nothing, mergeable=nothing, in_reductions=nothing, region::Region, location=Location())
     results = IR.Type[]
-    operands = Value[in_reduction_vars..., allocate_vars..., allocators_vars...]
-    owned_regions = Region[region,]
+    operands = Value[in_reduction_vars..., allocate_vars..., allocators_vars..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(if_expr) && push!(operands, if_expr)
     !isnothing(final_expr) && push!(operands, final_expr)
     !isnothing(priority) && push!(operands, priority)
-    push!(
-        attributes,
-        operandsegmentsizes([
-            if (if_expr == nothing)
-                0
-            elseif 1(final_expr == nothing)
-                0
-            else
-                1length(in_reduction_vars)
-            end,
-            (priority == nothing) ? 0 : 1length(allocate_vars),
-            length(allocators_vars),
-        ]),
-    )
+    push!(attributes, operandsegmentsizes([isnothing(if_expr) ? 0 : 1, isnothing(final_expr) ? 0 : 1, length(in_reduction_vars), isnothing(priority) ? 0 : 1, length(allocate_vars), length(allocators_vars), ]))
     !isnothing(untied) && push!(attributes, namedattribute("untied", untied))
     !isnothing(mergeable) && push!(attributes, namedattribute("mergeable", mergeable))
-    !isnothing(in_reductions) &&
-        push!(attributes, namedattribute("in_reductions", in_reductions))
-
-    return IR.create_operation(
-        "omp.task",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(in_reductions) && push!(attributes, namedattribute("in_reductions", in_reductions))
+    
+    IR.create_operation(
+        "omp.task", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1458,16 +1075,12 @@ function taskwait(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "omp.taskwait",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "omp.taskwait", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1483,16 +1096,12 @@ function taskyield(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "omp.taskyield",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "omp.taskyield", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1510,16 +1119,12 @@ function terminator(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "omp.terminator",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "omp.terminator", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1542,21 +1147,17 @@ The `sym_addr` refers to the address of the symbol, which is a pointer to
 the original variable.
 """
 function threadprivate(sym_addr::Value; tls_addr::IR.Type, location=Location())
-    results = IR.Type[tls_addr,]
-    operands = Value[sym_addr,]
+    results = IR.Type[tls_addr, ]
+    operands = Value[sym_addr, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "omp.threadprivate",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "omp.threadprivate", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1621,71 +1222,28 @@ The optional `order` attribute specifies which order the iterations of the
 associate loops are executed in. Currently the only option for this
 attribute is \"concurrent\".
 """
-function wsloop(
-    lowerBound::Vector{Value},
-    upperBound::Vector{Value},
-    step::Vector{Value},
-    linear_vars::Vector{Value},
-    linear_step_vars::Vector{Value},
-    reduction_vars::Vector{Value},
-    schedule_chunk_var=nothing::Union{Nothing,Value};
-    reductions=nothing,
-    schedule_val=nothing,
-    schedule_modifier=nothing,
-    simd_modifier=nothing,
-    nowait=nothing,
-    ordered_val=nothing,
-    order_val=nothing,
-    inclusive=nothing,
-    region::Region,
-    location=Location(),
-)
+function wsloop(lowerBound::Vector{Value}, upperBound::Vector{Value}, step::Vector{Value}, linear_vars::Vector{Value}, linear_step_vars::Vector{Value}, reduction_vars::Vector{Value}, schedule_chunk_var=nothing::Union{Nothing, Value}; reductions=nothing, schedule_val=nothing, schedule_modifier=nothing, simd_modifier=nothing, nowait=nothing, ordered_val=nothing, order_val=nothing, inclusive=nothing, region::Region, location=Location())
     results = IR.Type[]
-    operands = Value[
-        lowerBound...,
-        upperBound...,
-        step...,
-        linear_vars...,
-        linear_step_vars...,
-        reduction_vars...,
-    ]
-    owned_regions = Region[region,]
+    operands = Value[lowerBound..., upperBound..., step..., linear_vars..., linear_step_vars..., reduction_vars..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(schedule_chunk_var) && push!(operands, schedule_chunk_var)
-    push!(
-        attributes,
-        operandsegmentsizes([
-            length(lowerBound),
-            length(upperBound),
-            length(step),
-            length(linear_vars),
-            length(linear_step_vars),
-            length(reduction_vars),
-            (schedule_chunk_var == nothing) ? 0 : 1,
-        ]),
-    )
+    push!(attributes, operandsegmentsizes([length(lowerBound), length(upperBound), length(step), length(linear_vars), length(linear_step_vars), length(reduction_vars), isnothing(schedule_chunk_var) ? 0 : 1, ]))
     !isnothing(reductions) && push!(attributes, namedattribute("reductions", reductions))
-    !isnothing(schedule_val) &&
-        push!(attributes, namedattribute("schedule_val", schedule_val))
-    !isnothing(schedule_modifier) &&
-        push!(attributes, namedattribute("schedule_modifier", schedule_modifier))
-    !isnothing(simd_modifier) &&
-        push!(attributes, namedattribute("simd_modifier", simd_modifier))
+    !isnothing(schedule_val) && push!(attributes, namedattribute("schedule_val", schedule_val))
+    !isnothing(schedule_modifier) && push!(attributes, namedattribute("schedule_modifier", schedule_modifier))
+    !isnothing(simd_modifier) && push!(attributes, namedattribute("simd_modifier", simd_modifier))
     !isnothing(nowait) && push!(attributes, namedattribute("nowait", nowait))
     !isnothing(ordered_val) && push!(attributes, namedattribute("ordered_val", ordered_val))
     !isnothing(order_val) && push!(attributes, namedattribute("order_val", order_val))
     !isnothing(inclusive) && push!(attributes, namedattribute("inclusive", inclusive))
-
-    return IR.create_operation(
-        "omp.wsloop",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "omp.wsloop", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1696,22 +1254,18 @@ end
 terminates the region. The semantics of how the values are yielded is
 defined by the parent operation.
 """
-function yield(results::Vector{Value}; location=Location())
+function yield(results_::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[results...,]
+    operands = Value[results_..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "omp.yield",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "omp.yield", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/16/PDL.jl
+++ b/src/Dialects/16/PDL.jl
@@ -1,8 +1,8 @@
 module pdl
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `apply_native_constraint`
@@ -20,20 +20,16 @@ pdl.apply_native_constraint \"myConstraint\"(%input, %attr, %op : !pdl.value, !p
 """
 function apply_native_constraint(args::Vector{Value}; name, location=Location())
     results = IR.Type[]
-    operands = Value[args...,]
+    operands = Value[args..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("name", name),]
-
-    return IR.create_operation(
-        "pdl.apply_native_constraint",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("name", name), ]
+    
+    IR.create_operation(
+        "pdl.apply_native_constraint", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -65,24 +61,18 @@ void registerNativeRewrite(PDLPatternModule &pdlModule) {
 }
 ```
 """
-function apply_native_rewrite(
-    args::Vector{Value}; results::Vector{IR.Type}, name, location=Location()
-)
-    results = IR.Type[results...,]
-    operands = Value[args...,]
+function apply_native_rewrite(args::Vector{Value}; results_::Vector{IR.Type}, name, location=Location())
+    results = IR.Type[results_..., ]
+    operands = Value[args..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("name", name),]
-
-    return IR.create_operation(
-        "pdl.apply_native_rewrite",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("name", name), ]
+    
+    IR.create_operation(
+        "pdl.apply_native_rewrite", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -111,29 +101,20 @@ defined within a `pdl.rewrite` region, the constant value must be specified.
 %attr = pdl.attribute = \"hello\"
 ```
 """
-function attribute(
-    valueType=nothing::Union{Nothing,Value};
-    attr::IR.Type,
-    value=nothing,
-    location=Location(),
-)
-    results = IR.Type[attr,]
+function attribute(valueType=nothing::Union{Nothing, Value}; attr::IR.Type, value=nothing, location=Location())
+    results = IR.Type[attr, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(valueType) && push!(operands, valueType)
     !isnothing(value) && push!(attributes, namedattribute("value", value))
-
-    return IR.create_operation(
-        "pdl.attribute",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl.attribute", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -152,20 +133,16 @@ pdl.erase %root
 """
 function erase(opValue::Value; location=Location())
     results = IR.Type[]
-    operands = Value[opValue,]
+    operands = Value[opValue, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "pdl.erase",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl.erase", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -190,30 +167,24 @@ may partially constrain an operand by specifying an expected value type
 %operand = pdl.operand : %type
 ```
 """
-function operand(
-    valueType=nothing::Union{Nothing,Value}; value::IR.Type, location=Location()
-)
-    results = IR.Type[value,]
+function operand(valueType=nothing::Union{Nothing, Value}; value::IR.Type, location=Location())
+    results = IR.Type[value, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(valueType) && push!(operands, valueType)
-
-    return IR.create_operation(
-        "pdl.operand",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl.operand", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
 """
-`operands`
+`operands_`
 
 `pdl.operands` operations capture external operand range edges into an
 operation node that originate from operations or block arguments not
@@ -233,25 +204,19 @@ operands by specifying expected value types (via `pdl.types` operations).
 %typed_operands = pdl.operands : %types
 ```
 """
-function operands(
-    valueType=nothing::Union{Nothing,Value}; value::IR.Type, location=Location()
-)
-    results = IR.Type[value,]
+function operands_(valueType=nothing::Union{Nothing, Value}; value::IR.Type, location=Location())
+    results = IR.Type[value, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(valueType) && push!(operands, valueType)
-
-    return IR.create_operation(
-        "pdl.operands",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl.operands", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -352,37 +317,20 @@ def MyOp {
 %op = pdl.operation \"foo.op\" -> (%result, %otherResults : !pdl.type, !pdl.range<type>)
 ```
 """
-function operation(
-    operandValues::Vector{Value},
-    attributeValues::Vector{Value},
-    typeValues::Vector{Value};
-    op::IR.Type,
-    opName=nothing,
-    attributeValueNames,
-    location=Location(),
-)
-    results = IR.Type[op,]
-    operands = Value[operandValues..., attributeValues..., typeValues...]
+function operation(operandValues::Vector{Value}, attributeValues::Vector{Value}, typeValues::Vector{Value}; op::IR.Type, opName=nothing, attributeValueNames, location=Location())
+    results = IR.Type[op, ]
+    operands = Value[operandValues..., attributeValues..., typeValues..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("attributeValueNames", attributeValueNames),]
-    push!(
-        attributes,
-        operandsegmentsizes([
-            length(operandValues), length(attributeValues), length(typeValues)
-        ]),
-    )
+    attributes = NamedAttribute[namedattribute("attributeValueNames", attributeValueNames), ]
+    push!(attributes, operandsegmentsizes([length(operandValues), length(attributeValues), length(typeValues), ]))
     !isnothing(opName) && push!(attributes, namedattribute("opName", opName))
-
-    return IR.create_operation(
-        "pdl.operation",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl.operation", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -413,20 +361,16 @@ pdl.pattern : benefit(1) {
 function pattern(; benefit, sym_name=nothing, bodyRegion::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[bodyRegion,]
+    owned_regions = Region[bodyRegion, ]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("benefit", benefit),]
+    attributes = NamedAttribute[namedattribute("benefit", benefit), ]
     !isnothing(sym_name) && push!(attributes, namedattribute("sym_name", sym_name))
-
-    return IR.create_operation(
-        "pdl.pattern",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl.pattern", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -458,21 +402,17 @@ there are multiple sub ranges used for construction, we won\'t be able
 to determine their sizes during constraint time.
 """
 function range(arguments::Vector{Value}; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[arguments...,]
+    results = IR.Type[result, ]
+    operands = Value[arguments..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "pdl.range",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl.range", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -501,32 +441,20 @@ pdl.replace %root with (%vals : !pdl.range<value>)
 pdl.replace %root with %otherOp
 ```
 """
-function replace(
-    opValue::Value,
-    replOperation=nothing::Union{Nothing,Value};
-    replValues::Vector{Value},
-    location=Location(),
-)
+function replace(opValue::Value, replOperation=nothing::Union{Nothing, Value}; replValues::Vector{Value}, location=Location())
     results = IR.Type[]
-    operands = Value[opValue, replValues...]
+    operands = Value[opValue, replValues..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(replOperation) && push!(operands, replOperation)
-    push!(
-        attributes,
-        operandsegmentsizes([1, (replOperation == nothing) ? 0 : 1length(replValues)]),
-    )
-
-    return IR.create_operation(
-        "pdl.replace",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([1, isnothing(replOperation) ? 0 : 1, length(replValues), ]))
+    
+    IR.create_operation(
+        "pdl.replace", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -553,26 +481,22 @@ as defined by the ODS definition of the operation.
 ```
 """
 function result(parent::Value; val::IR.Type, index, location=Location())
-    results = IR.Type[val,]
-    operands = Value[parent,]
+    results = IR.Type[val, ]
+    operands = Value[parent, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("index", index),]
-
-    return IR.create_operation(
-        "pdl.result",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("index", index), ]
+    
+    IR.create_operation(
+        "pdl.result", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
 """
-`results`
+`results_`
 
 `pdl.results` operations extract a result group from an operation within a
 pattern or rewrite region. If an index is provided, this operation extracts
@@ -600,23 +524,19 @@ operation.
 %results = pdl.results 1 of %operation -> !pdl.value
 ```
 """
-function results(parent::Value; val::IR.Type, index=nothing, location=Location())
-    results = IR.Type[val,]
-    operands = Value[parent,]
+function results_(parent::Value; val::IR.Type, index=nothing, location=Location())
+    results = IR.Type[val, ]
+    operands = Value[parent, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(index) && push!(attributes, namedattribute("index", index))
-
-    return IR.create_operation(
-        "pdl.results",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl.results", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -659,31 +579,21 @@ pdl.rewrite {
 }
 ```
 """
-function rewrite(
-    root=nothing::Union{Nothing,Value};
-    externalArgs::Vector{Value},
-    name=nothing,
-    bodyRegion::Region,
-    location=Location(),
-)
+function rewrite(root=nothing::Union{Nothing, Value}; externalArgs::Vector{Value}, name=nothing, bodyRegion::Region, location=Location())
     results = IR.Type[]
-    operands = Value[externalArgs...,]
-    owned_regions = Region[bodyRegion,]
+    operands = Value[externalArgs..., ]
+    owned_regions = Region[bodyRegion, ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(root) && push!(operands, root)
-    push!(attributes, operandsegmentsizes([(root == nothing) ? 0 : 1length(externalArgs)]))
+    push!(attributes, operandsegmentsizes([isnothing(root) ? 0 : 1, length(externalArgs), ]))
     !isnothing(name) && push!(attributes, namedattribute("name", name))
-
-    return IR.create_operation(
-        "pdl.rewrite",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl.rewrite", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -706,23 +616,18 @@ partially constrain the result by specifying a constant `Type`.
 ```
 """
 function type(; result::IR.Type, constantType=nothing, location=Location())
-    results = IR.Type[result,]
+    results = IR.Type[result, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(constantType) &&
-        push!(attributes, namedattribute("constantType", constantType))
-
-    return IR.create_operation(
-        "pdl.type",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(constantType) && push!(attributes, namedattribute("constantType", constantType))
+    
+    IR.create_operation(
+        "pdl.type", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -745,23 +650,18 @@ an array of `Type`s.
 ```
 """
 function types(; result::IR.Type, constantTypes=nothing, location=Location())
-    results = IR.Type[result,]
+    results = IR.Type[result, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(constantTypes) &&
-        push!(attributes, namedattribute("constantTypes", constantTypes))
-
-    return IR.create_operation(
-        "pdl.types",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(constantTypes) && push!(attributes, namedattribute("constantTypes", constantTypes))
+    
+    IR.create_operation(
+        "pdl.types", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/16/PDLInterp.jl
+++ b/src/Dialects/16/PDLInterp.jl
@@ -1,8 +1,8 @@
 module pdl_interp
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `apply_constraint`
@@ -20,24 +20,18 @@ otherwise the false destination is taken.
 pdl_interp.apply_constraint \"myConstraint\"(%input, %attr, %op : !pdl.value, !pdl.attribute, !pdl.operation) -> ^matchDest, ^failureDest
 ```
 """
-function apply_constraint(
-    args::Vector{Value}; name, trueDest::Block, falseDest::Block, location=Location()
-)
+function apply_constraint(args::Vector{Value}; name, trueDest::Block, falseDest::Block, location=Location())
     results = IR.Type[]
-    operands = Value[args...,]
+    operands = Value[args..., ]
     owned_regions = Region[]
-    successors = Block[trueDest, falseDest]
-    attributes = NamedAttribute[namedattribute("name", name),]
-
-    return IR.create_operation(
-        "pdl_interp.apply_constraint",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    successors = Block[trueDest, falseDest, ]
+    attributes = NamedAttribute[namedattribute("name", name), ]
+    
+    IR.create_operation(
+        "pdl_interp.apply_constraint", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -63,24 +57,18 @@ pdl_interp.apply_rewrite \"rewriter\"(%root : !pdl.operation)
 pdl_interp.apply_rewrite \"rewriter\"(%root : !pdl.operation, %value : !pdl.value)
 ```
 """
-function apply_rewrite(
-    args::Vector{Value}; results::Vector{IR.Type}, name, location=Location()
-)
-    results = IR.Type[results...,]
-    operands = Value[args...,]
+function apply_rewrite(args::Vector{Value}; results_::Vector{IR.Type}, name, location=Location())
+    results = IR.Type[results_..., ]
+    operands = Value[args..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("name", name),]
-
-    return IR.create_operation(
-        "pdl_interp.apply_rewrite",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("name", name), ]
+    
+    IR.create_operation(
+        "pdl_interp.apply_rewrite", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -97,24 +85,18 @@ otherwise the false destination is taken.
 pdl_interp.are_equal %result1, %result2 : !pdl.value -> ^matchDest, ^failureDest
 ```
 """
-function are_equal(
-    lhs::Value, rhs::Value; trueDest::Block, falseDest::Block, location=Location()
-)
+function are_equal(lhs::Value, rhs::Value; trueDest::Block, falseDest::Block, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
-    successors = Block[trueDest, falseDest]
+    successors = Block[trueDest, falseDest, ]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "pdl_interp.are_equal",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl_interp.are_equal", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -135,18 +117,14 @@ function branch(; dest::Block, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
-    successors = Block[dest,]
+    successors = Block[dest, ]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "pdl_interp.branch",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl_interp.branch", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -163,24 +141,18 @@ true destination, otherwise the false destination is taken.
 pdl_interp.check_attribute %attr is 10 -> ^matchDest, ^failureDest
 ```
 """
-function check_attribute(
-    attribute::Value; constantValue, trueDest::Block, falseDest::Block, location=Location()
-)
+function check_attribute(attribute::Value; constantValue, trueDest::Block, falseDest::Block, location=Location())
     results = IR.Type[]
-    operands = Value[attribute,]
+    operands = Value[attribute, ]
     owned_regions = Region[]
-    successors = Block[trueDest, falseDest]
-    attributes = NamedAttribute[namedattribute("constantValue", constantValue),]
-
-    return IR.create_operation(
-        "pdl_interp.check_attribute",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    successors = Block[trueDest, falseDest, ]
+    attributes = NamedAttribute[namedattribute("constantValue", constantValue), ]
+    
+    IR.create_operation(
+        "pdl_interp.check_attribute", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -203,31 +175,19 @@ pdl_interp.check_operand_count of %op is 2 -> ^matchDest, ^failureDest
 pdl_interp.check_operand_count of %op is at_least 2 -> ^matchDest, ^failureDest
 ```
 """
-function check_operand_count(
-    inputOp::Value;
-    count,
-    compareAtLeast=nothing,
-    trueDest::Block,
-    falseDest::Block,
-    location=Location(),
-)
+function check_operand_count(inputOp::Value; count, compareAtLeast=nothing, trueDest::Block, falseDest::Block, location=Location())
     results = IR.Type[]
-    operands = Value[inputOp,]
+    operands = Value[inputOp, ]
     owned_regions = Region[]
-    successors = Block[trueDest, falseDest]
-    attributes = NamedAttribute[namedattribute("count", count),]
-    !isnothing(compareAtLeast) &&
-        push!(attributes, namedattribute("compareAtLeast", compareAtLeast))
-
-    return IR.create_operation(
-        "pdl_interp.check_operand_count",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    successors = Block[trueDest, falseDest, ]
+    attributes = NamedAttribute[namedattribute("count", count), ]
+    !isnothing(compareAtLeast) && push!(attributes, namedattribute("compareAtLeast", compareAtLeast))
+    
+    IR.create_operation(
+        "pdl_interp.check_operand_count", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -244,24 +204,18 @@ destination, otherwise the false destination is taken.
 pdl_interp.check_operation_name of %op is \"foo.op\" -> ^matchDest, ^failureDest
 ```
 """
-function check_operation_name(
-    inputOp::Value; name, trueDest::Block, falseDest::Block, location=Location()
-)
+function check_operation_name(inputOp::Value; name, trueDest::Block, falseDest::Block, location=Location())
     results = IR.Type[]
-    operands = Value[inputOp,]
+    operands = Value[inputOp, ]
     owned_regions = Region[]
-    successors = Block[trueDest, falseDest]
-    attributes = NamedAttribute[namedattribute("name", name),]
-
-    return IR.create_operation(
-        "pdl_interp.check_operation_name",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    successors = Block[trueDest, falseDest, ]
+    attributes = NamedAttribute[namedattribute("name", name), ]
+    
+    IR.create_operation(
+        "pdl_interp.check_operation_name", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -284,31 +238,19 @@ pdl_interp.check_result_count of %op is 2 -> ^matchDest, ^failureDest
 pdl_interp.check_result_count of %op is at_least 2 -> ^matchDest, ^failureDest
 ```
 """
-function check_result_count(
-    inputOp::Value;
-    count,
-    compareAtLeast=nothing,
-    trueDest::Block,
-    falseDest::Block,
-    location=Location(),
-)
+function check_result_count(inputOp::Value; count, compareAtLeast=nothing, trueDest::Block, falseDest::Block, location=Location())
     results = IR.Type[]
-    operands = Value[inputOp,]
+    operands = Value[inputOp, ]
     owned_regions = Region[]
-    successors = Block[trueDest, falseDest]
-    attributes = NamedAttribute[namedattribute("count", count),]
-    !isnothing(compareAtLeast) &&
-        push!(attributes, namedattribute("compareAtLeast", compareAtLeast))
-
-    return IR.create_operation(
-        "pdl_interp.check_result_count",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    successors = Block[trueDest, falseDest, ]
+    attributes = NamedAttribute[namedattribute("count", count), ]
+    !isnothing(compareAtLeast) && push!(attributes, namedattribute("compareAtLeast", compareAtLeast))
+    
+    IR.create_operation(
+        "pdl_interp.check_result_count", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -325,24 +267,18 @@ the false destination is taken.
 pdl_interp.check_type %type is i32 -> ^matchDest, ^failureDest
 ```
 """
-function check_type(
-    value::Value; type, trueDest::Block, falseDest::Block, location=Location()
-)
+function check_type(value::Value; type, trueDest::Block, falseDest::Block, location=Location())
     results = IR.Type[]
-    operands = Value[value,]
+    operands = Value[value, ]
     owned_regions = Region[]
-    successors = Block[trueDest, falseDest]
-    attributes = NamedAttribute[namedattribute("type", type),]
-
-    return IR.create_operation(
-        "pdl_interp.check_type",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    successors = Block[trueDest, falseDest, ]
+    attributes = NamedAttribute[namedattribute("type", type), ]
+    
+    IR.create_operation(
+        "pdl_interp.check_type", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -359,24 +295,18 @@ to the true destination, otherwise the false destination is taken.
 pdl_interp.check_types %type are [i32, i64] -> ^matchDest, ^failureDest
 ```
 """
-function check_types(
-    value::Value; types, trueDest::Block, falseDest::Block, location=Location()
-)
+function check_types(value::Value; types, trueDest::Block, falseDest::Block, location=Location())
     results = IR.Type[]
-    operands = Value[value,]
+    operands = Value[value, ]
     owned_regions = Region[]
-    successors = Block[trueDest, falseDest]
-    attributes = NamedAttribute[namedattribute("types", types),]
-
-    return IR.create_operation(
-        "pdl_interp.check_types",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    successors = Block[trueDest, falseDest, ]
+    attributes = NamedAttribute[namedattribute("types", types), ]
+    
+    IR.create_operation(
+        "pdl_interp.check_types", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -399,16 +329,12 @@ function continue_(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "pdl_interp.continue",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl_interp.continue", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -425,21 +351,17 @@ interpreter for a specific constant attribute value.
 ```
 """
 function create_attribute(; attribute::IR.Type, value, location=Location())
-    results = IR.Type[attribute,]
+    results = IR.Type[attribute, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("value", value),]
-
-    return IR.create_operation(
-        "pdl_interp.create_attribute",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("value", value), ]
+    
+    IR.create_operation(
+        "pdl_interp.create_attribute", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -462,42 +384,20 @@ to this operation.
 %op = pdl_interp.create_operation \"foo.op\"(%arg0 : !pdl.value) {\"attrA\" = %attr0} -> <inferred>
 ```
 """
-function create_operation(
-    inputOperands::Vector{Value},
-    inputAttributes::Vector{Value},
-    inputResultTypes::Vector{Value};
-    resultOp::IR.Type,
-    name,
-    inputAttributeNames,
-    inferredResultTypes=nothing,
-    location=Location(),
-)
-    results = IR.Type[resultOp,]
-    operands = Value[inputOperands..., inputAttributes..., inputResultTypes...]
+function create_operation(inputOperands::Vector{Value}, inputAttributes::Vector{Value}, inputResultTypes::Vector{Value}; resultOp::IR.Type, name, inputAttributeNames, inferredResultTypes=nothing, location=Location())
+    results = IR.Type[resultOp, ]
+    operands = Value[inputOperands..., inputAttributes..., inputResultTypes..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("name", name),
-        namedattribute("inputAttributeNames", inputAttributeNames),
-    ]
-    push!(
-        attributes,
-        operandsegmentsizes([
-            length(inputOperands), length(inputAttributes), length(inputResultTypes)
-        ]),
-    )
-    !isnothing(inferredResultTypes) &&
-        push!(attributes, namedattribute("inferredResultTypes", inferredResultTypes))
-
-    return IR.create_operation(
-        "pdl_interp.create_operation",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("name", name), namedattribute("inputAttributeNames", inputAttributeNames), ]
+    push!(attributes, operandsegmentsizes([length(inputOperands), length(inputAttributes), length(inputResultTypes), ]))
+    !isnothing(inferredResultTypes) && push!(attributes, namedattribute("inferredResultTypes", inferredResultTypes))
+    
+    IR.create_operation(
+        "pdl_interp.create_operation", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -523,21 +423,17 @@ or `!pdl.range<value>` entities.
 ```
 """
 function create_range(arguments::Vector{Value}; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[arguments...,]
+    results = IR.Type[result, ]
+    operands = Value[arguments..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "pdl_interp.create_range",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl_interp.create_range", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -554,21 +450,17 @@ pdl_interp.create_type i64
 ```
 """
 function create_type(; result::IR.Type, value, location=Location())
-    results = IR.Type[result,]
+    results = IR.Type[result, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("value", value),]
-
-    return IR.create_operation(
-        "pdl_interp.create_type",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("value", value), ]
+    
+    IR.create_operation(
+        "pdl_interp.create_type", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -585,21 +477,17 @@ pdl_interp.create_types [i64, i64]
 ```
 """
 function create_types(; result::IR.Type, value, location=Location())
-    results = IR.Type[result,]
+    results = IR.Type[result, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("value", value),]
-
-    return IR.create_operation(
-        "pdl_interp.create_types",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("value", value), ]
+    
+    IR.create_operation(
+        "pdl_interp.create_types", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -618,20 +506,16 @@ pdl_interp.erase %root
 """
 function erase(inputOp::Value; location=Location())
     results = IR.Type[]
-    operands = Value[inputOp,]
+    operands = Value[inputOp, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "pdl_interp.erase",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl_interp.erase", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -649,21 +533,17 @@ at the specified index. If the index is out of range, returns null.
 ```
 """
 function extract(range::Value; result::IR.Type, index, location=Location())
-    results = IR.Type[result,]
-    operands = Value[range,]
+    results = IR.Type[result, ]
+    operands = Value[range, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("index", index),]
-
-    return IR.create_operation(
-        "pdl_interp.extract",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("index", index), ]
+    
+    IR.create_operation(
+        "pdl_interp.extract", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -685,16 +565,12 @@ function finalize(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "pdl_interp.finalize",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl_interp.finalize", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -719,20 +595,16 @@ pdl_interp.foreach %op : !pdl.operation in %ops {
 """
 function foreach(values::Value; region::Region, successor::Block, location=Location())
     results = IR.Type[]
-    operands = Value[values,]
-    owned_regions = Region[region,]
-    successors = Block[successor,]
+    operands = Value[values, ]
+    owned_regions = Region[region, ]
+    successors = Block[successor, ]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "pdl_interp.foreach",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl_interp.foreach", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -754,33 +626,20 @@ pdl_interp.func @rewriter(%root: !pdl.operation) {
 }
 ```
 """
-function func(;
-    sym_name,
-    function_type,
-    arg_attrs=nothing,
-    res_attrs=nothing,
-    body::Region,
-    location=Location(),
-)
+function func(; sym_name, function_type, arg_attrs=nothing, res_attrs=nothing, body::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[body,]
+    owned_regions = Region[body, ]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("sym_name", sym_name), namedattribute("function_type", function_type)
-    ]
+    attributes = NamedAttribute[namedattribute("sym_name", sym_name), namedattribute("function_type", function_type), ]
     !isnothing(arg_attrs) && push!(attributes, namedattribute("arg_attrs", arg_attrs))
     !isnothing(res_attrs) && push!(attributes, namedattribute("res_attrs", res_attrs))
-
-    return IR.create_operation(
-        "pdl_interp.func",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl_interp.func", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -798,21 +657,17 @@ returned.
 ```
 """
 function get_attribute(inputOp::Value; attribute::IR.Type, name, location=Location())
-    results = IR.Type[attribute,]
-    operands = Value[inputOp,]
+    results = IR.Type[attribute, ]
+    operands = Value[inputOp, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("name", name),]
-
-    return IR.create_operation(
-        "pdl_interp.get_attribute",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("name", name), ]
+    
+    IR.create_operation(
+        "pdl_interp.get_attribute", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -829,21 +684,17 @@ specific attribute.
 ```
 """
 function get_attribute_type(value::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[value,]
+    results = IR.Type[result, ]
+    operands = Value[value, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "pdl_interp.get_attribute_type",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl_interp.get_attribute_type", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -862,21 +713,17 @@ or range of operand results, null is returned.
 ```
 """
 function get_defining_op(value::Value; inputOp::IR.Type, location=Location())
-    results = IR.Type[inputOp,]
-    operands = Value[value,]
+    results = IR.Type[inputOp, ]
+    operands = Value[value, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "pdl_interp.get_defining_op",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl_interp.get_defining_op", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -894,21 +741,17 @@ null value is returned.
 ```
 """
 function get_operand(inputOp::Value; value::IR.Type, index, location=Location())
-    results = IR.Type[value,]
-    operands = Value[inputOp,]
+    results = IR.Type[value, ]
+    operands = Value[inputOp, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("index", index),]
-
-    return IR.create_operation(
-        "pdl_interp.get_operand",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("index", index), ]
+    
+    IR.create_operation(
+        "pdl_interp.get_operand", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -936,22 +779,18 @@ the returned operand group corresponds to all operands of the operation.
 ```
 """
 function get_operands(inputOp::Value; value::IR.Type, index=nothing, location=Location())
-    results = IR.Type[value,]
-    operands = Value[inputOp,]
+    results = IR.Type[value, ]
+    operands = Value[inputOp, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(index) && push!(attributes, namedattribute("index", index))
-
-    return IR.create_operation(
-        "pdl_interp.get_operands",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl_interp.get_operands", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -969,21 +808,17 @@ null value is returned.
 ```
 """
 function get_result(inputOp::Value; value::IR.Type, index, location=Location())
-    results = IR.Type[value,]
-    operands = Value[inputOp,]
+    results = IR.Type[value, ]
+    operands = Value[inputOp, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("index", index),]
-
-    return IR.create_operation(
-        "pdl_interp.get_result",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("index", index), ]
+    
+    IR.create_operation(
+        "pdl_interp.get_result", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1011,22 +846,18 @@ the returned operand group corresponds to all results of the operation.
 ```
 """
 function get_results(inputOp::Value; value::IR.Type, index=nothing, location=Location())
-    results = IR.Type[value,]
-    operands = Value[inputOp,]
+    results = IR.Type[value, ]
+    operands = Value[inputOp, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(index) && push!(attributes, namedattribute("index", index))
-
-    return IR.create_operation(
-        "pdl_interp.get_results",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl_interp.get_results", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1048,21 +879,17 @@ similarly to ResultRange::getUsers.
 ```
 """
 function get_users(value::Value; operations::IR.Type, location=Location())
-    results = IR.Type[operations,]
-    operands = Value[value,]
+    results = IR.Type[operations, ]
+    operands = Value[value, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "pdl_interp.get_users",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl_interp.get_users", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1083,21 +910,17 @@ value or range thereof.
 ```
 """
 function get_value_type(value::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[value,]
+    results = IR.Type[result, ]
+    operands = Value[value, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "pdl_interp.get_value_type",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl_interp.get_value_type", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1117,20 +940,16 @@ pdl_interp.is_not_null %value : !pdl.value -> ^matchDest, ^failureDest
 """
 function is_not_null(value::Value; trueDest::Block, falseDest::Block, location=Location())
     results = IR.Type[]
-    operands = Value[value,]
+    operands = Value[value, ]
     owned_regions = Region[]
-    successors = Block[trueDest, falseDest]
+    successors = Block[trueDest, falseDest, ]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "pdl_interp.is_not_null",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl_interp.is_not_null", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1149,37 +968,21 @@ rewriter.
 pdl_interp.record_match @rewriters::myRewriter(%root : !pdl.operation) : benefit(1), loc([%root, %op1]), root(\"foo.op\") -> ^nextDest
 ```
 """
-function record_match(
-    inputs::Vector{Value},
-    matchedOps::Vector{Value};
-    rewriter,
-    rootKind=nothing,
-    generatedOps=nothing,
-    benefit,
-    dest::Block,
-    location=Location(),
-)
+function record_match(inputs::Vector{Value}, matchedOps::Vector{Value}; rewriter, rootKind=nothing, generatedOps=nothing, benefit, dest::Block, location=Location())
     results = IR.Type[]
-    operands = Value[inputs..., matchedOps...]
+    operands = Value[inputs..., matchedOps..., ]
     owned_regions = Region[]
-    successors = Block[dest,]
-    attributes = NamedAttribute[
-        namedattribute("rewriter", rewriter), namedattribute("benefit", benefit)
-    ]
-    push!(attributes, operandsegmentsizes([length(inputs), length(matchedOps)]))
+    successors = Block[dest, ]
+    attributes = NamedAttribute[namedattribute("rewriter", rewriter), namedattribute("benefit", benefit), ]
+    push!(attributes, operandsegmentsizes([length(inputs), length(matchedOps), ]))
     !isnothing(rootKind) && push!(attributes, namedattribute("rootKind", rootKind))
-    !isnothing(generatedOps) &&
-        push!(attributes, namedattribute("generatedOps", generatedOps))
-
-    return IR.create_operation(
-        "pdl_interp.record_match",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(generatedOps) && push!(attributes, namedattribute("generatedOps", generatedOps))
+    
+    IR.create_operation(
+        "pdl_interp.record_match", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1200,20 +1003,16 @@ pdl_interp.replace %root with (%val0, %val1 : !pdl.type, !pdl.type)
 """
 function replace(inputOp::Value, replValues::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[inputOp, replValues...]
+    operands = Value[inputOp, replValues..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "pdl_interp.replace",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl_interp.replace", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1231,28 +1030,18 @@ the default destination is taken.
 pdl_interp.switch_attribute %attr to [10, true](^10Dest, ^trueDest) -> ^defaultDest
 ```
 """
-function switch_attribute(
-    attribute::Value;
-    caseValues,
-    defaultDest::Block,
-    cases::Vector{Block},
-    location=Location(),
-)
+function switch_attribute(attribute::Value; caseValues, defaultDest::Block, cases::Vector{Block}, location=Location())
     results = IR.Type[]
-    operands = Value[attribute,]
+    operands = Value[attribute, ]
     owned_regions = Region[]
-    successors = Block[defaultDest, cases...]
-    attributes = NamedAttribute[namedattribute("caseValues", caseValues),]
-
-    return IR.create_operation(
-        "pdl_interp.switch_attribute",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    successors = Block[defaultDest, cases..., ]
+    attributes = NamedAttribute[namedattribute("caseValues", caseValues), ]
+    
+    IR.create_operation(
+        "pdl_interp.switch_attribute", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1270,28 +1059,18 @@ otherwise the default destination is taken.
 pdl_interp.switch_operand_count of %op to [10, 2] -> ^10Dest, ^2Dest, ^defaultDest
 ```
 """
-function switch_operand_count(
-    inputOp::Value;
-    caseValues,
-    defaultDest::Block,
-    cases::Vector{Block},
-    location=Location(),
-)
+function switch_operand_count(inputOp::Value; caseValues, defaultDest::Block, cases::Vector{Block}, location=Location())
     results = IR.Type[]
-    operands = Value[inputOp,]
+    operands = Value[inputOp, ]
     owned_regions = Region[]
-    successors = Block[defaultDest, cases...]
-    attributes = NamedAttribute[namedattribute("caseValues", caseValues),]
-
-    return IR.create_operation(
-        "pdl_interp.switch_operand_count",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    successors = Block[defaultDest, cases..., ]
+    attributes = NamedAttribute[namedattribute("caseValues", caseValues), ]
+    
+    IR.create_operation(
+        "pdl_interp.switch_operand_count", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1309,28 +1088,18 @@ the default destination is taken.
 pdl_interp.switch_operation_name of %op to [\"foo.op\", \"bar.op\"](^fooDest, ^barDest) -> ^defaultDest
 ```
 """
-function switch_operation_name(
-    inputOp::Value;
-    caseValues,
-    defaultDest::Block,
-    cases::Vector{Block},
-    location=Location(),
-)
+function switch_operation_name(inputOp::Value; caseValues, defaultDest::Block, cases::Vector{Block}, location=Location())
     results = IR.Type[]
-    operands = Value[inputOp,]
+    operands = Value[inputOp, ]
     owned_regions = Region[]
-    successors = Block[defaultDest, cases...]
-    attributes = NamedAttribute[namedattribute("caseValues", caseValues),]
-
-    return IR.create_operation(
-        "pdl_interp.switch_operation_name",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    successors = Block[defaultDest, cases..., ]
+    attributes = NamedAttribute[namedattribute("caseValues", caseValues), ]
+    
+    IR.create_operation(
+        "pdl_interp.switch_operation_name", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1348,28 +1117,18 @@ otherwise the default destination is taken.
 pdl_interp.switch_result_count of %op to [0, 2](^0Dest, ^2Dest) -> ^defaultDest
 ```
 """
-function switch_result_count(
-    inputOp::Value;
-    caseValues,
-    defaultDest::Block,
-    cases::Vector{Block},
-    location=Location(),
-)
+function switch_result_count(inputOp::Value; caseValues, defaultDest::Block, cases::Vector{Block}, location=Location())
     results = IR.Type[]
-    operands = Value[inputOp,]
+    operands = Value[inputOp, ]
     owned_regions = Region[]
-    successors = Block[defaultDest, cases...]
-    attributes = NamedAttribute[namedattribute("caseValues", caseValues),]
-
-    return IR.create_operation(
-        "pdl_interp.switch_result_count",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    successors = Block[defaultDest, cases..., ]
+    attributes = NamedAttribute[namedattribute("caseValues", caseValues), ]
+    
+    IR.create_operation(
+        "pdl_interp.switch_result_count", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1387,24 +1146,18 @@ is taken.
 pdl_interp.switch_type %type to [i32, i64] -> ^i32Dest, ^i64Dest, ^defaultDest
 ```
 """
-function switch_type(
-    value::Value; caseValues, defaultDest::Block, cases::Vector{Block}, location=Location()
-)
+function switch_type(value::Value; caseValues, defaultDest::Block, cases::Vector{Block}, location=Location())
     results = IR.Type[]
-    operands = Value[value,]
+    operands = Value[value, ]
     owned_regions = Region[]
-    successors = Block[defaultDest, cases...]
-    attributes = NamedAttribute[namedattribute("caseValues", caseValues),]
-
-    return IR.create_operation(
-        "pdl_interp.switch_type",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    successors = Block[defaultDest, cases..., ]
+    attributes = NamedAttribute[namedattribute("caseValues", caseValues), ]
+    
+    IR.create_operation(
+        "pdl_interp.switch_type", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1422,24 +1175,18 @@ destination is taken.
 pdl_interp.switch_types %type is [[i32], [i64, i64]] -> ^i32Dest, ^i64Dest, ^defaultDest
 ```
 """
-function switch_types(
-    value::Value; caseValues, defaultDest::Block, cases::Vector{Block}, location=Location()
-)
+function switch_types(value::Value; caseValues, defaultDest::Block, cases::Vector{Block}, location=Location())
     results = IR.Type[]
-    operands = Value[value,]
+    operands = Value[value, ]
     owned_regions = Region[]
-    successors = Block[defaultDest, cases...]
-    attributes = NamedAttribute[namedattribute("caseValues", caseValues),]
-
-    return IR.create_operation(
-        "pdl_interp.switch_types",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    successors = Block[defaultDest, cases..., ]
+    attributes = NamedAttribute[namedattribute("caseValues", caseValues), ]
+    
+    IR.create_operation(
+        "pdl_interp.switch_types", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/16/Quant.jl
+++ b/src/Dialects/16/Quant.jl
@@ -1,29 +1,25 @@
 module quant
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `dcast`
 
 """
 function dcast(arg::Value; result_0::IR.Type, location=Location())
-    results = IR.Type[result_0,]
-    operands = Value[arg,]
+    results = IR.Type[result_0, ]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "quant.dcast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "quant.dcast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -32,21 +28,17 @@ end
 
 """
 function qcast(arg::Value; result_0::IR.Type, location=Location())
-    results = IR.Type[result_0,]
-    operands = Value[arg,]
+    results = IR.Type[result_0, ]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "quant.qcast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "quant.qcast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -55,21 +47,17 @@ end
 
 """
 function scast(arg::Value; result_0::IR.Type, location=Location())
-    results = IR.Type[result_0,]
-    operands = Value[arg,]
+    results = IR.Type[result_0, ]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "quant.scast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "quant.scast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/16/SCF.jl
+++ b/src/Dialects/16/SCF.jl
@@ -1,8 +1,8 @@
 module scf
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `condition`
@@ -14,20 +14,16 @@ to the entry block of the region. Otherwise, the loop terminates.
 """
 function condition(condition::Value, args::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[condition, args...]
+    operands = Value[condition, args..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "scf.condition",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "scf.condition", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -73,21 +69,17 @@ affine.for %i = 0 to 100 {
 ```
 """
 function execute_region(; result_0::Vector{IR.Type}, region::Region, location=Location())
-    results = IR.Type[result_0...,]
+    results = IR.Type[result_0..., ]
     operands = Value[]
-    owned_regions = Region[region,]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "scf.execute_region",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "scf.execute_region", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -180,30 +172,18 @@ func.func @conditional_reduce(%buffer: memref<1024xf32>, %lb: index,
 }
 ```
 """
-function for_(
-    lowerBound::Value,
-    upperBound::Value,
-    step::Value,
-    initArgs::Vector{Value};
-    results::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[results...,]
-    operands = Value[lowerBound, upperBound, step, initArgs...]
-    owned_regions = Region[region,]
+function for_(lowerBound::Value, upperBound::Value, step::Value, initArgs::Vector{Value}; results_::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[results_..., ]
+    operands = Value[lowerBound, upperBound, step, initArgs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "scf.for",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "scf.for", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -332,31 +312,20 @@ Example with privatized tensors:
 }
 ```
 """
-function foreach_thread(
-    num_threads::Vector{Value},
-    outputs::Vector{Value};
-    results::Vector{IR.Type},
-    mapping=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[results...,]
-    operands = Value[num_threads..., outputs...]
-    owned_regions = Region[region,]
+function foreach_thread(num_threads::Vector{Value}, outputs::Vector{Value}; results_::Vector{IR.Type}, mapping=nothing, region::Region, location=Location())
+    results = IR.Type[results_..., ]
+    operands = Value[num_threads..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(num_threads), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(num_threads), length(outputs), ]))
     !isnothing(mapping) && push!(attributes, namedattribute("mapping", mapping))
-
-    return IR.create_operation(
-        "scf.foreach_thread",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "scf.foreach_thread", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -406,28 +375,18 @@ scf.if %b  {
 }
 ```
 """
-function if_(
-    condition::Value;
-    results::Vector{IR.Type},
-    thenRegion::Region,
-    elseRegion::Region,
-    location=Location(),
-)
-    results = IR.Type[results...,]
-    operands = Value[condition,]
-    owned_regions = Region[thenRegion, elseRegion]
+function if_(condition::Value; results_::Vector{IR.Type}, thenRegion::Region, elseRegion::Region, location=Location())
+    results = IR.Type[results_..., ]
+    operands = Value[condition, ]
+    owned_regions = Region[thenRegion, elseRegion, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "scf.if",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "scf.if", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -462,29 +421,18 @@ default {
 }
 ```
 """
-function index_switch(
-    arg::Value;
-    results::Vector{IR.Type},
-    cases,
-    defaultRegion::Region,
-    caseRegions::Vector{Region},
-    location=Location(),
-)
-    results = IR.Type[results...,]
-    operands = Value[arg,]
-    owned_regions = Region[defaultRegion, caseRegions...]
+function index_switch(arg::Value; results_::Vector{IR.Type}, cases, defaultRegion::Region, caseRegions::Vector{Region}, location=Location())
+    results = IR.Type[results_..., ]
+    operands = Value[arg, ]
+    owned_regions = Region[defaultRegion, caseRegions..., ]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("cases", cases),]
-
-    return IR.create_operation(
-        "scf.index_switch",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("cases", cases), ]
+    
+    IR.create_operation(
+        "scf.index_switch", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -534,36 +482,19 @@ scf.parallel (%iv) = (%lb) to (%ub) step (%step) init (%init) -> f32 {
 }
 ```
 """
-function parallel(
-    lowerBound::Vector{Value},
-    upperBound::Vector{Value},
-    step::Vector{Value},
-    initVals::Vector{Value};
-    results::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[results...,]
-    operands = Value[lowerBound..., upperBound..., step..., initVals...]
-    owned_regions = Region[region,]
+function parallel(lowerBound::Vector{Value}, upperBound::Vector{Value}, step::Vector{Value}, initVals::Vector{Value}; results_::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[results_..., ]
+    operands = Value[lowerBound..., upperBound..., step..., initVals..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(
-        attributes,
-        operandsegmentsizes([
-            length(lowerBound), length(upperBound), length(step), length(initVals)
-        ]),
-    )
-
-    return IR.create_operation(
-        "scf.parallel",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(lowerBound), length(upperBound), length(step), length(initVals), ]))
+    
+    IR.create_operation(
+        "scf.parallel", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -581,19 +512,15 @@ The result number corresponds to the position of the op in the terminator.
 function foreach_thread_perform_concurrently(; region::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[region,]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "scf.foreach_thread.perform_concurrently",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "scf.foreach_thread.perform_concurrently", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -635,20 +562,16 @@ scf.reduce(%operand) : f32 {
 """
 function reduce(operand::Value; reductionOperator::Region, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
-    owned_regions = Region[reductionOperator,]
+    operands = Value[operand, ]
+    owned_regions = Region[reductionOperator, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "scf.reduce",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "scf.reduce", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -665,20 +588,16 @@ scf.reduce.return %res : f32
 """
 function reduce_return(result::Value; location=Location())
     results = IR.Type[]
-    operands = Value[result,]
+    operands = Value[result, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "scf.reduce.return",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "scf.reduce.return", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -796,28 +715,18 @@ assignment-list ::= assignment | assignment `,` assignment-list
 assignment ::= ssa-value `=` ssa-value
 ```
 """
-function while_(
-    inits::Vector{Value};
-    results::Vector{IR.Type},
-    before::Region,
-    after::Region,
-    location=Location(),
-)
-    results = IR.Type[results...,]
-    operands = Value[inits...,]
-    owned_regions = Region[before, after]
+function while_(inits::Vector{Value}; results_::Vector{IR.Type}, before::Region, after::Region, location=Location())
+    results = IR.Type[results_..., ]
+    operands = Value[inits..., ]
+    owned_regions = Region[before, after, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "scf.while",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "scf.while", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -834,22 +743,18 @@ left out in the custom syntax and the builders will insert one implicitly.
 Otherwise, it has to be present in the syntax to indicate which values are
 yielded.
 """
-function yield(results::Vector{Value}; location=Location())
+function yield(results_::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[results...,]
+    operands = Value[results_..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "scf.yield",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "scf.yield", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/16/SPIRV.jl
+++ b/src/Dialects/16/SPIRV.jl
@@ -1,8 +1,8 @@
 module spirv
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `AccessChain`
@@ -46,24 +46,18 @@ access-chain-op ::= ssa-id `=` `spirv.AccessChain` ssa-use
 %3 = spirv.Load \"Function\" %2 [\"Volatile\"] : !spirv.array<4xf32>
 ```
 """
-function AccessChain(
-    base_ptr::Value, indices::Vector{Value}; component_ptr::IR.Type, location=Location()
-)
-    results = IR.Type[component_ptr,]
-    operands = Value[base_ptr, indices...]
+function AccessChain(base_ptr::Value, indices::Vector{Value}; component_ptr::IR.Type, location=Location())
+    results = IR.Type[component_ptr, ]
+    operands = Value[base_ptr, indices..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.AccessChain",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.AccessChain", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -92,21 +86,17 @@ spv-address-of-op ::= ssa-id `=` `spirv.mlir.addressof` symbol-ref-id
 ```
 """
 function mlir_addressof(; pointer::IR.Type, variable, location=Location())
-    results = IR.Type[pointer,]
+    results = IR.Type[pointer, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("variable", variable),]
-
-    return IR.create_operation(
-        "spirv.mlir.addressof",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("variable", variable), ]
+    
+    IR.create_operation(
+        "spirv.mlir.addressof", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -147,31 +137,18 @@ atomic-and-op ::=
                    !spirv.ptr<i32, StorageBuffer>
 ```
 """
-function AtomicAnd(
-    pointer::Value,
-    value::Value;
-    result::IR.Type,
-    memory_scope,
-    semantics,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[pointer, value]
+function AtomicAnd(pointer::Value, value::Value; result::IR.Type, memory_scope, semantics, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[pointer, value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics)
-    ]
-
-    return IR.create_operation(
-        "spirv.AtomicAnd",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics), ]
+    
+    IR.create_operation(
+        "spirv.AtomicAnd", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -221,35 +198,18 @@ atomic-compare-exchange-op ::=
                                 : !spirv.ptr<i32, WorkGroup>
 ```
 """
-function AtomicCompareExchange(
-    pointer::Value,
-    value::Value,
-    comparator::Value;
-    result::IR.Type,
-    memory_scope,
-    equal_semantics,
-    unequal_semantics,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[pointer, value, comparator]
+function AtomicCompareExchange(pointer::Value, value::Value, comparator::Value; result::IR.Type, memory_scope, equal_semantics, unequal_semantics, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[pointer, value, comparator, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("memory_scope", memory_scope),
-        namedattribute("equal_semantics", equal_semantics),
-        namedattribute("unequal_semantics", unequal_semantics),
-    ]
-
-    return IR.create_operation(
-        "spirv.AtomicCompareExchange",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("equal_semantics", equal_semantics), namedattribute("unequal_semantics", unequal_semantics), ]
+    
+    IR.create_operation(
+        "spirv.AtomicCompareExchange", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -277,35 +237,18 @@ atomic-compare-exchange-weak-op ::=
                                    : !spirv.ptr<i32, WorkGroup>
 ```
 """
-function AtomicCompareExchangeWeak(
-    pointer::Value,
-    value::Value,
-    comparator::Value;
-    result::IR.Type,
-    memory_scope,
-    equal_semantics,
-    unequal_semantics,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[pointer, value, comparator]
+function AtomicCompareExchangeWeak(pointer::Value, value::Value, comparator::Value; result::IR.Type, memory_scope, equal_semantics, unequal_semantics, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[pointer, value, comparator, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("memory_scope", memory_scope),
-        namedattribute("equal_semantics", equal_semantics),
-        namedattribute("unequal_semantics", unequal_semantics),
-    ]
-
-    return IR.create_operation(
-        "spirv.AtomicCompareExchangeWeak",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("equal_semantics", equal_semantics), namedattribute("unequal_semantics", unequal_semantics), ]
+    
+    IR.create_operation(
+        "spirv.AtomicCompareExchangeWeak", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -342,31 +285,18 @@ atomic-exchange-op ::=
                         : !spirv.ptr<i32, WorkGroup>
 ```
 """
-function AtomicExchange(
-    pointer::Value,
-    value::Value;
-    result::IR.Type,
-    memory_scope,
-    semantics,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[pointer, value]
+function AtomicExchange(pointer::Value, value::Value; result::IR.Type, memory_scope, semantics, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[pointer, value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics)
-    ]
-
-    return IR.create_operation(
-        "spirv.AtomicExchange",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics), ]
+    
+    IR.create_operation(
+        "spirv.AtomicExchange", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -403,31 +333,18 @@ atomic-iadd-op ::=
                     !spirv.ptr<i32, StorageBuffer>
 ```
 """
-function AtomicIAdd(
-    pointer::Value,
-    value::Value;
-    result::IR.Type,
-    memory_scope,
-    semantics,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[pointer, value]
+function AtomicIAdd(pointer::Value, value::Value; result::IR.Type, memory_scope, semantics, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[pointer, value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics)
-    ]
-
-    return IR.create_operation(
-        "spirv.AtomicIAdd",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics), ]
+    
+    IR.create_operation(
+        "spirv.AtomicIAdd", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -463,26 +380,18 @@ atomic-idecrement-op ::=
                           !spirv.ptr<i32, StorageBuffer>
 ```
 """
-function AtomicIDecrement(
-    pointer::Value; result::IR.Type, memory_scope, semantics, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[pointer,]
+function AtomicIDecrement(pointer::Value; result::IR.Type, memory_scope, semantics, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[pointer, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics)
-    ]
-
-    return IR.create_operation(
-        "spirv.AtomicIDecrement",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics), ]
+    
+    IR.create_operation(
+        "spirv.AtomicIDecrement", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -517,26 +426,18 @@ atomic-iincrement-op ::=
                          !spirv.ptr<i32, StorageBuffer>
 ```
 """
-function AtomicIIncrement(
-    pointer::Value; result::IR.Type, memory_scope, semantics, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[pointer,]
+function AtomicIIncrement(pointer::Value; result::IR.Type, memory_scope, semantics, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[pointer, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics)
-    ]
-
-    return IR.create_operation(
-        "spirv.AtomicIIncrement",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics), ]
+    
+    IR.create_operation(
+        "spirv.AtomicIIncrement", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -574,31 +475,18 @@ atomic-isub-op ::=
                     !spirv.ptr<i32, StorageBuffer>
 ```
 """
-function AtomicISub(
-    pointer::Value,
-    value::Value;
-    result::IR.Type,
-    memory_scope,
-    semantics,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[pointer, value]
+function AtomicISub(pointer::Value, value::Value; result::IR.Type, memory_scope, semantics, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[pointer, value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics)
-    ]
-
-    return IR.create_operation(
-        "spirv.AtomicISub",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics), ]
+    
+    IR.create_operation(
+        "spirv.AtomicISub", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -635,31 +523,18 @@ atomic-or-op ::=
                   !spirv.ptr<i32, StorageBuffer>
 ```
 """
-function AtomicOr(
-    pointer::Value,
-    value::Value;
-    result::IR.Type,
-    memory_scope,
-    semantics,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[pointer, value]
+function AtomicOr(pointer::Value, value::Value; result::IR.Type, memory_scope, semantics, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[pointer, value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics)
-    ]
-
-    return IR.create_operation(
-        "spirv.AtomicOr",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics), ]
+    
+    IR.create_operation(
+        "spirv.AtomicOr", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -697,31 +572,18 @@ atomic-smax-op ::=
                     !spirv.ptr<i32, StorageBuffer>
 ```
 """
-function AtomicSMax(
-    pointer::Value,
-    value::Value;
-    result::IR.Type,
-    memory_scope,
-    semantics,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[pointer, value]
+function AtomicSMax(pointer::Value, value::Value; result::IR.Type, memory_scope, semantics, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[pointer, value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics)
-    ]
-
-    return IR.create_operation(
-        "spirv.AtomicSMax",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics), ]
+    
+    IR.create_operation(
+        "spirv.AtomicSMax", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -759,31 +621,18 @@ atomic-smin-op ::=
                     !spirv.ptr<i32, StorageBuffer>
 ```
 """
-function AtomicSMin(
-    pointer::Value,
-    value::Value;
-    result::IR.Type,
-    memory_scope,
-    semantics,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[pointer, value]
+function AtomicSMin(pointer::Value, value::Value; result::IR.Type, memory_scope, semantics, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[pointer, value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics)
-    ]
-
-    return IR.create_operation(
-        "spirv.AtomicSMin",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics), ]
+    
+    IR.create_operation(
+        "spirv.AtomicSMin", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -821,31 +670,18 @@ atomic-umax-op ::=
                     !spirv.ptr<i32, StorageBuffer>
 ```
 """
-function AtomicUMax(
-    pointer::Value,
-    value::Value;
-    result::IR.Type,
-    memory_scope,
-    semantics,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[pointer, value]
+function AtomicUMax(pointer::Value, value::Value; result::IR.Type, memory_scope, semantics, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[pointer, value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics)
-    ]
-
-    return IR.create_operation(
-        "spirv.AtomicUMax",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics), ]
+    
+    IR.create_operation(
+        "spirv.AtomicUMax", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -883,31 +719,18 @@ atomic-umin-op ::=
                     !spirv.ptr<i32, StorageBuffer>
 ```
 """
-function AtomicUMin(
-    pointer::Value,
-    value::Value;
-    result::IR.Type,
-    memory_scope,
-    semantics,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[pointer, value]
+function AtomicUMin(pointer::Value, value::Value; result::IR.Type, memory_scope, semantics, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[pointer, value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics)
-    ]
-
-    return IR.create_operation(
-        "spirv.AtomicUMin",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics), ]
+    
+    IR.create_operation(
+        "spirv.AtomicUMin", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -945,31 +768,18 @@ atomic-xor-op ::=
                    !spirv.ptr<i32, StorageBuffer>
 ```
 """
-function AtomicXor(
-    pointer::Value,
-    value::Value;
-    result::IR.Type,
-    memory_scope,
-    semantics,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[pointer, value]
+function AtomicXor(pointer::Value, value::Value; result::IR.Type, memory_scope, semantics, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[pointer, value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics)
-    ]
-
-    return IR.create_operation(
-        "spirv.AtomicXor",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics), ]
+    
+    IR.create_operation(
+        "spirv.AtomicXor", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1005,25 +815,19 @@ Results are computed per component.
     %3 = spirv.BitCount %1: vector<4xi32>
     ```
 """
-function BitCount(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function BitCount(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.BitCount",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.BitCount", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1069,30 +873,19 @@ The type of Base and Insert must be the same as Result Type.
     %0 = spirv.BitFieldInsert %base, %insert, %offset, %count : vector<3xi32>, i8, i8
     ```
 """
-function BitFieldInsert(
-    base::Value,
-    insert::Value,
-    offset::Value,
-    count::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function BitFieldInsert(base::Value, insert::Value, offset::Value, count::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[base, insert, offset, count]
+    operands = Value[base, insert, offset, count, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.BitFieldInsert",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.BitFieldInsert", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1138,29 +931,19 @@ The type of Base must be the same as Result Type.
     %0 = spirv.BitFieldSExtract %base, %offset, %count : vector<3xi32>, i8, i8
     ```
 """
-function BitFieldSExtract(
-    base::Value,
-    offset::Value,
-    count::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function BitFieldSExtract(base::Value, offset::Value, count::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[base, offset, count]
+    operands = Value[base, offset, count, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.BitFieldSExtract",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.BitFieldSExtract", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1188,29 +971,19 @@ bitfield-extract-u-op ::= ssa-id `=` `spirv.BitFieldUExtract` ssa-use
 %0 = spirv.BitFieldUExtract %base, %offset, %count : vector<3xi32>, i8, i8
 ```
 """
-function BitFieldUExtract(
-    base::Value,
-    offset::Value,
-    count::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function BitFieldUExtract(base::Value, offset::Value, count::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[base, offset, count]
+    operands = Value[base, offset, count, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.BitFieldUExtract",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.BitFieldUExtract", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1242,25 +1015,19 @@ The type of Base must be the same as Result Type.
     %3 = spirv.BitReverse %1 : vector<4xi32>
     ```
 """
-function BitReverse(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function BitReverse(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.BitReverse",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.BitReverse", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1304,21 +1071,17 @@ bitcast-op ::= ssa-id `=` `spirv.Bitcast` ssa-use
 ```
 """
 function Bitcast(operand::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand,]
+    results = IR.Type[result, ]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.Bitcast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.Bitcast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1348,28 +1111,19 @@ Results are computed per component, and within each component, per bit.
     %2 = spirv.BitwiseAnd %0, %1 : vector<4xi32>
     ```
 """
-function BitwiseAnd(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function BitwiseAnd(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand1, operand2]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.BitwiseAnd",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.BitwiseAnd", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1399,28 +1153,19 @@ Results are computed per component, and within each component, per bit.
     %2 = spirv.BitwiseOr %0, %1 : vector<4xi32>
     ```
 """
-function BitwiseOr(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function BitwiseOr(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand1, operand2]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.BitwiseOr",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.BitwiseOr", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1450,28 +1195,19 @@ Results are computed per component, and within each component, per bit.
     %2 = spirv.BitwiseXor %0, %1 : vector<4xi32>
     ```
 """
-function BitwiseXor(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function BitwiseXor(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand1, operand2]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.BitwiseXor",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.BitwiseXor", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1509,36 +1245,20 @@ spirv.BranchConditional %condition, ^true_branch, ^false_branch
 spirv.BranchConditional %condition, ^true_branch(%0: i32), ^false_branch(%1: i32)
 ```
 """
-function BranchConditional(
-    condition::Value,
-    trueTargetOperands::Vector{Value},
-    falseTargetOperands::Vector{Value};
-    branch_weights=nothing,
-    trueTarget::Block,
-    falseTarget::Block,
-    location=Location(),
-)
+function BranchConditional(condition::Value, trueTargetOperands::Vector{Value}, falseTargetOperands::Vector{Value}; branch_weights=nothing, trueTarget::Block, falseTarget::Block, location=Location())
     results = IR.Type[]
-    operands = Value[condition, trueTargetOperands..., falseTargetOperands...]
+    operands = Value[condition, trueTargetOperands..., falseTargetOperands..., ]
     owned_regions = Region[]
-    successors = Block[trueTarget, falseTarget]
+    successors = Block[trueTarget, falseTarget, ]
     attributes = NamedAttribute[]
-    push!(
-        attributes,
-        operandsegmentsizes([1, length(trueTargetOperands), length(falseTargetOperands)]),
-    )
-    !isnothing(branch_weights) &&
-        push!(attributes, namedattribute("branch_weights", branch_weights))
-
-    return IR.create_operation(
-        "spirv.BranchConditional",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([1, length(trueTargetOperands), length(falseTargetOperands), ]))
+    !isnothing(branch_weights) && push!(attributes, namedattribute("branch_weights", branch_weights))
+    
+    IR.create_operation(
+        "spirv.BranchConditional", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1564,20 +1284,16 @@ spirv.Branch ^target(%0, %1: i32, f32)
 """
 function Branch(targetOperands::Vector{Value}; target::Block, location=Location())
     results = IR.Type[]
-    operands = Value[targetOperands...,]
+    operands = Value[targetOperands..., ]
     owned_regions = Region[]
-    successors = Block[target,]
+    successors = Block[target, ]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.Branch",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.Branch", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1606,25 +1322,19 @@ ceil-op ::= ssa-id `=` `spirv.CL.ceil` ssa-use `:`
 %3 = spirv.CL.ceil %1 : vector<3xf16>
 ```
 """
-function CL_ceil(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function CL_ceil(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.CL.ceil",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.CL.ceil", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1653,23 +1363,19 @@ cos-op ::= ssa-id `=` `spirv.CL.cos` ssa-use `:`
 %3 = spirv.CL.cos %1 : vector<3xf16>
 ```
 """
-function CL_cos(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function CL_cos(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.CL.cos",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.CL.cos", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1698,23 +1404,19 @@ erf-op ::= ssa-id `=` `spirv.CL.erf` ssa-use `:`
 %3 = spirv.CL.erf %1 : vector<3xf16>
 ```
 """
-function CL_erf(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function CL_erf(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.CL.erf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.CL.erf", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1743,23 +1445,19 @@ exp-op ::= ssa-id `=` `spirv.CL.exp` ssa-use `:`
 %3 = spirv.CL.exp %1 : vector<3xf16>
 ```
 """
-function CL_exp(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function CL_exp(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.CL.exp",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.CL.exp", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1788,25 +1486,19 @@ abs-op ::= ssa-id `=` `spirv.CL.fabs` ssa-use `:`
 %3 = spirv.CL.fabs %1 : vector<3xf16>
 ```
 """
-function CL_fabs(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function CL_fabs(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.CL.fabs",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.CL.fabs", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1836,25 +1528,19 @@ fmax-op ::= ssa-id `=` `spirv.CL.fmax` ssa-use `:`
 %3 = spirv.CL.fmax %0, %1 : vector<3xf16>
 ```
 """
-function CL_fmax(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function CL_fmax(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.CL.fmax",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.CL.fmax", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1883,25 +1569,19 @@ fmin-op ::= ssa-id `=` `spirv.CL.fmin` ssa-use `:`
 %3 = spirv.CL.fmin %0, %1 : vector<3xf16>
 ```
 """
-function CL_fmin(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function CL_fmin(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.CL.fmin",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.CL.fmin", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1930,25 +1610,19 @@ floor-op ::= ssa-id `=` `spirv.CL.floor` ssa-use `:`
 %3 = spirv.CL.ceifloorl %1 : vector<3xf16>
 ```
 """
-function CL_floor(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function CL_floor(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.CL.floor",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.CL.floor", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1975,29 +1649,19 @@ fma-op ::= ssa-id `=` `spirv.CL.fma` ssa-use, ssa-use, ssa-use `:`
 %1 = spirv.CL.fma %a, %b, %c : vector<3xf16>
 ```
 """
-function CL_fma(
-    x::Value,
-    y::Value,
-    z::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function CL_fma(x::Value, y::Value, z::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[x, y, z]
+    operands = Value[x, y, z, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.CL.fma",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.CL.fma", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -2026,23 +1690,19 @@ log-op ::= ssa-id `=` `spirv.CL.log` ssa-use `:`
 %3 = spirv.CL.log %1 : vector<3xf16>
 ```
 """
-function CL_log(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function CL_log(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.CL.log",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.CL.log", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -2072,25 +1732,19 @@ pow-op ::= ssa-id `=` `spirv.CL.pow` ssa-use `:`
 %3 = spirv.CL.pow %0, %1 : vector<3xf16>
 ```
 """
-function CL_pow(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function CL_pow(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.CL.pow",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.CL.pow", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -2119,25 +1773,19 @@ rint-op ::= ssa-id `=` `spirv.CL.rint` ssa-use `:`
 %1 = spirv.CL.rint %1 : vector<3xf16>
 ```
 """
-function CL_rint(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function CL_rint(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.CL.rint",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.CL.rint", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -2165,25 +1813,19 @@ round-op ::= ssa-id `=` `spirv.CL.round` ssa-use `:`
 %3 = spirv.CL.round %0 : vector<3xf16>
 ```
 """
-function CL_round(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function CL_round(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.CL.round",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.CL.round", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -2212,25 +1854,19 @@ rsqrt-op ::= ssa-id `=` `spirv.CL.rsqrt` ssa-use `:`
 %3 = spirv.CL.rsqrt %1 : vector<3xf16>
 ```
 """
-function CL_rsqrt(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function CL_rsqrt(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.CL.rsqrt",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.CL.rsqrt", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -2259,25 +1895,19 @@ abs-op ::= ssa-id `=` `spirv.CL.s_abs` ssa-use `:`
 %3 = spirv.CL.s_abs %1 : vector<3xi16>
 ```
 """
-function CL_s_abs(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function CL_s_abs(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.CL.s_abs",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.CL.s_abs", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -2303,25 +1933,19 @@ smax-op ::= ssa-id `=` `spirv.CL.s_max` ssa-use `:`
 %3 = spirv.CL.s_max %0, %1 : vector<3xi16>
 ```
 """
-function CL_s_max(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function CL_s_max(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.CL.s_max",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.CL.s_max", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -2347,25 +1971,19 @@ smin-op ::= ssa-id `=` `spirv.CL.s_min` ssa-use `:`
 %3 = spirv.CL.s_min %0, %1 : vector<3xi16>
 ```
 """
-function CL_s_min(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function CL_s_min(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.CL.s_min",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.CL.s_min", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -2394,23 +2012,19 @@ sin-op ::= ssa-id `=` `spirv.CL.sin` ssa-use `:`
 %3 = spirv.CL.sin %1 : vector<3xf16>
 ```
 """
-function CL_sin(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function CL_sin(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.CL.sin",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.CL.sin", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -2439,25 +2053,19 @@ sqrt-op ::= ssa-id `=` `spirv.CL.sqrt` ssa-use `:`
 %3 = spirv.CL.sqrt %1 : vector<3xf16>
 ```
 """
-function CL_sqrt(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function CL_sqrt(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.CL.sqrt",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.CL.sqrt", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -2486,25 +2094,19 @@ tanh-op ::= ssa-id `=` `spirv.CL.tanh` ssa-use `:`
 %3 = spirv.CL.tanh %1 : vector<3xf16>
 ```
 """
-function CL_tanh(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function CL_tanh(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.CL.tanh",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.CL.tanh", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -2530,25 +2132,19 @@ umax-op ::= ssa-id `=` `spirv.CL.u_max` ssa-use `:`
 %3 = spirv.CL.u_max %0, %1 : vector<3xi16>
 ```
 """
-function CL_u_max(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function CL_u_max(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.CL.u_max",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.CL.u_max", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -2574,25 +2170,19 @@ umin-op ::= ssa-id `=` `spirv.CL.u_min` ssa-use `:`
 %3 = spirv.CL.u_min %0, %1 : vector<3xi16>
 ```
 """
-function CL_u_min(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function CL_u_min(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.CL.u_min",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.CL.u_min", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -2630,24 +2220,18 @@ composite-construct-op ::= ssa-id `=` `spirv.CompositeConstruct`
 %0 = spirv.CompositeConstruct %1, %2, %3 : vector<3xf32>
 ```
 """
-function CompositeConstruct(
-    constituents::Vector{Value}; result::IR.Type, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[constituents...,]
+function CompositeConstruct(constituents::Vector{Value}; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[constituents..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.CompositeConstruct",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.CompositeConstruct", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2680,24 +2264,18 @@ composite-extract-op ::= ssa-id `=` `spirv.CompositeExtract` ssa-use
 %2 = spirv.CompositeExtract %1[1 : i32] : !spirv.array<4x!spirv.array<4xf32>>
 ```
 """
-function CompositeExtract(
-    composite::Value; component::IR.Type, indices, location=Location()
-)
-    results = IR.Type[component,]
-    operands = Value[composite,]
+function CompositeExtract(composite::Value; component::IR.Type, indices, location=Location())
+    results = IR.Type[component, ]
+    operands = Value[composite, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("indices", indices),]
-
-    return IR.create_operation(
-        "spirv.CompositeExtract",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("indices", indices), ]
+    
+    IR.create_operation(
+        "spirv.CompositeExtract", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2730,24 +2308,18 @@ composite-insert-op ::= ssa-id `=` `spirv.CompositeInsert` ssa-use, ssa-use
 %0 = spirv.CompositeInsert %object, %composite[1 : i32] : f32 into !spirv.array<4xf32>
 ```
 """
-function CompositeInsert(
-    object::Value, composite::Value; result::IR.Type, indices, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[object, composite]
+function CompositeInsert(object::Value, composite::Value; result::IR.Type, indices, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[object, composite, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("indices", indices),]
-
-    return IR.create_operation(
-        "spirv.CompositeInsert",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("indices", indices), ]
+    
+    IR.create_operation(
+        "spirv.CompositeInsert", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2787,21 +2359,17 @@ spirv.Constant-op ::= ssa-id `=` `spirv.Constant` attribute-value
 TODO: support constant structs
 """
 function Constant(; constant::IR.Type, value, location=Location())
-    results = IR.Type[constant,]
+    results = IR.Type[constant, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("value", value),]
-
-    return IR.create_operation(
-        "spirv.Constant",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("value", value), ]
+    
+    IR.create_operation(
+        "spirv.Constant", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2851,28 +2419,18 @@ spirv.ControlBarrier \"Workgroup\", \"Device\", \"Acquire|UniformMemory\"
 
 ```
 """
-function ControlBarrier(;
-    execution_scope, memory_scope, memory_semantics, location=Location()
-)
+function ControlBarrier(; execution_scope, memory_scope, memory_semantics, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("execution_scope", execution_scope),
-        namedattribute("memory_scope", memory_scope),
-        namedattribute("memory_semantics", memory_semantics),
-    ]
-
-    return IR.create_operation(
-        "spirv.ControlBarrier",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("memory_scope", memory_scope), namedattribute("memory_semantics", memory_semantics), ]
+    
+    IR.create_operation(
+        "spirv.ControlBarrier", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2901,21 +2459,17 @@ convert-f-to-s-op ::= ssa-id `=` `spirv.ConvertFToSOp` ssa-use
 ```
 """
 function ConvertFToS(operand::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand,]
+    results = IR.Type[result, ]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.ConvertFToS",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.ConvertFToS", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2945,21 +2499,17 @@ convert-f-to-u-op ::= ssa-id `=` `spirv.ConvertFToUOp` ssa-use
 ```
 """
 function ConvertFToU(operand::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand,]
+    results = IR.Type[result, ]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.ConvertFToU",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.ConvertFToU", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2988,21 +2538,17 @@ convert-s-to-f-op ::= ssa-id `=` `spirv.ConvertSToFOp` ssa-use
 ```
 """
 function ConvertSToF(operand::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand,]
+    results = IR.Type[result, ]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.ConvertSToF",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.ConvertSToF", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -3031,21 +2577,17 @@ convert-u-to-f-op ::= ssa-id `=` `spirv.ConvertUToFOp` ssa-use
 ```
 """
 function ConvertUToF(operand::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand,]
+    results = IR.Type[result, ]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.ConvertUToF",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.ConvertUToF", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -3078,37 +2620,22 @@ copy-memory-op ::= `spirv.CopyMemory ` storage-class ssa-use
 spirv.CopyMemory \"Function\" %0, \"Function\" %1 : f32
 ```
 """
-function CopyMemory(
-    target::Value,
-    source::Value;
-    memory_access=nothing,
-    alignment=nothing,
-    source_memory_access=nothing,
-    source_alignment=nothing,
-    location=Location(),
-)
+function CopyMemory(target::Value, source::Value; memory_access=nothing, alignment=nothing, source_memory_access=nothing, source_alignment=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[target, source]
+    operands = Value[target, source, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(memory_access) &&
-        push!(attributes, namedattribute("memory_access", memory_access))
+    !isnothing(memory_access) && push!(attributes, namedattribute("memory_access", memory_access))
     !isnothing(alignment) && push!(attributes, namedattribute("alignment", alignment))
-    !isnothing(source_memory_access) &&
-        push!(attributes, namedattribute("source_memory_access", source_memory_access))
-    !isnothing(source_alignment) &&
-        push!(attributes, namedattribute("source_alignment", source_alignment))
-
-    return IR.create_operation(
-        "spirv.CopyMemory",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(source_memory_access) && push!(attributes, namedattribute("source_memory_access", source_memory_access))
+    !isnothing(source_alignment) && push!(attributes, namedattribute("source_alignment", source_alignment))
+    
+    IR.create_operation(
+        "spirv.CopyMemory", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -3150,31 +2677,18 @@ atomic-fadd-op ::=
                        !spirv.ptr<f32, StorageBuffer>
 ```
 """
-function EXT_AtomicFAdd(
-    pointer::Value,
-    value::Value;
-    result::IR.Type,
-    memory_scope,
-    semantics,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[pointer, value]
+function EXT_AtomicFAdd(pointer::Value, value::Value; result::IR.Type, memory_scope, semantics, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[pointer, value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics)
-    ]
-
-    return IR.create_operation(
-        "spirv.EXT.AtomicFAdd",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics), ]
+    
+    IR.create_operation(
+        "spirv.EXT.AtomicFAdd", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -3224,21 +2738,13 @@ function EntryPoint(; execution_model, fn, interface, location=Location())
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("execution_model", execution_model),
-        namedattribute("fn", fn),
-        namedattribute("interface", interface),
-    ]
-
-    return IR.create_operation(
-        "spirv.EntryPoint",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("execution_model", execution_model), namedattribute("fn", fn), namedattribute("interface", interface), ]
+    
+    IR.create_operation(
+        "spirv.EntryPoint", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -3276,21 +2782,13 @@ function ExecutionMode(; fn, execution_mode, values, location=Location())
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("fn", fn),
-        namedattribute("execution_mode", execution_mode),
-        namedattribute("values", values),
-    ]
-
-    return IR.create_operation(
-        "spirv.ExecutionMode",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("fn", fn), namedattribute("execution_mode", execution_mode), namedattribute("values", values), ]
+    
+    IR.create_operation(
+        "spirv.ExecutionMode", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -3318,28 +2816,19 @@ fadd-op ::= ssa-id `=` `spirv.FAdd` ssa-use, ssa-use
 %5 = spirv.FAdd %2, %3 : vector<4xf32>
 ```
 """
-function FAdd(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function FAdd(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand1, operand2]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.FAdd",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.FAdd", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -3369,21 +2858,17 @@ f-convert-op ::= ssa-id `=` `spirv.FConvertOp` ssa-use
 ```
 """
 function FConvert(operand::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand,]
+    results = IR.Type[result, ]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.FConvert",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.FConvert", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -3413,28 +2898,19 @@ fdiv-op ::= ssa-id `=` `spirv.FDiv` ssa-use, ssa-use
 %5 = spirv.FDiv %2, %3 : vector<4xf32>
 ```
 """
-function FDiv(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function FDiv(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand1, operand2]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.FDiv",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.FDiv", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -3465,28 +2941,19 @@ fmod-op ::= ssa-id `=` `spirv.FMod` ssa-use, ssa-use
 %5 = spirv.FMod %2, %3 : vector<4xf32>
 ```
 """
-function FMod(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function FMod(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand1, operand2]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.FMod",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.FMod", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -3516,28 +2983,19 @@ fmul-op ::= `spirv.FMul` ssa-use, ssa-use
 %5 = spirv.FMul %2, %3 : vector<4xf32>
 ```
 """
-function FMul(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function FMul(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand1, operand2]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.FMul",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.FMul", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -3565,25 +3023,19 @@ fmul-op ::= `spirv.FNegate` ssa-use `:` float-scalar-vector-type
 %3 = spirv.FNegate %2 : vector<4xf32>
 ```
 """
-function FNegate(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function FNegate(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.FNegate",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.FNegate", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -3613,28 +3065,18 @@ fordequal-op ::= ssa-id `=` `spirv.FOrdEqual` ssa-use, ssa-use
 %5 = spirv.FOrdEqual %2, %3 : vector<4xf32>
 ```
 """
-function FOrdEqual(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[operand1, operand2]
+function FOrdEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.FOrdEqual",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "spirv.FOrdEqual", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -3664,28 +3106,18 @@ fordgte-op ::= ssa-id `=` `spirv.FOrdGreaterThanEqual` ssa-use, ssa-use
 %5 = spirv.FOrdGreaterThanEqual %2, %3 : vector<4xf32>
 ```
 """
-function FOrdGreaterThanEqual(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[operand1, operand2]
+function FOrdGreaterThanEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.FOrdGreaterThanEqual",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "spirv.FOrdGreaterThanEqual", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -3715,28 +3147,18 @@ fordgt-op ::= ssa-id `=` `spirv.FOrdGreaterThan` ssa-use, ssa-use
 %5 = spirv.FOrdGreaterThan %2, %3 : vector<4xf32>
 ```
 """
-function FOrdGreaterThan(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[operand1, operand2]
+function FOrdGreaterThan(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.FOrdGreaterThan",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "spirv.FOrdGreaterThan", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -3766,28 +3188,18 @@ fordlte-op ::= ssa-id `=` `spirv.FOrdLessThanEqual` ssa-use, ssa-use
 %5 = spirv.FOrdLessThanEqual %2, %3 : vector<4xf32>
 ```
 """
-function FOrdLessThanEqual(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[operand1, operand2]
+function FOrdLessThanEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.FOrdLessThanEqual",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "spirv.FOrdLessThanEqual", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -3817,28 +3229,18 @@ fordlt-op ::= ssa-id `=` `spirv.FOrdLessThan` ssa-use, ssa-use
 %5 = spirv.FOrdLessThan %2, %3 : vector<4xf32>
 ```
 """
-function FOrdLessThan(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[operand1, operand2]
+function FOrdLessThan(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.FOrdLessThan",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "spirv.FOrdLessThan", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -3868,28 +3270,18 @@ fordneq-op ::= ssa-id `=` `spirv.FOrdNotEqual` ssa-use, ssa-use
 %5 = spirv.FOrdNotEqual %2, %3 : vector<4xf32>
 ```
 """
-function FOrdNotEqual(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[operand1, operand2]
+function FOrdNotEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.FOrdNotEqual",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "spirv.FOrdNotEqual", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -3921,28 +3313,19 @@ frem-op ::= ssa-id `=` `spirv.FRemOp` ssa-use, ssa-use
 %5 = spirv.FRemOp %2, %3 : vector<4xf32>
 ```
 """
-function FRem(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function FRem(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand1, operand2]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.FRem",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.FRem", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -3971,28 +3354,19 @@ fsub-op ::= ssa-id `=` `spirv.FRemOp` ssa-use, ssa-use
 %5 = spirv.FRemOp %2, %3 : vector<4xf32>
 ```
 """
-function FSub(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function FSub(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand1, operand2]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.FSub",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.FSub", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -4022,28 +3396,18 @@ funordequal-op ::= ssa-id `=` `spirv.FUnordEqual` ssa-use, ssa-use
 %5 = spirv.FUnordEqual %2, %3 : vector<4xf32>
 ```
 """
-function FUnordEqual(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[operand1, operand2]
+function FUnordEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.FUnordEqual",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "spirv.FUnordEqual", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -4073,28 +3437,18 @@ funordgte-op ::= ssa-id `=` `spirv.FUnordGreaterThanEqual` ssa-use, ssa-use
 %5 = spirv.FUnordGreaterThanEqual %2, %3 : vector<4xf32>
 ```
 """
-function FUnordGreaterThanEqual(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[operand1, operand2]
+function FUnordGreaterThanEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.FUnordGreaterThanEqual",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "spirv.FUnordGreaterThanEqual", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -4124,28 +3478,18 @@ funordgt-op ::= ssa-id `=` `spirv.FUnordGreaterThan` ssa-use, ssa-use
 %5 = spirv.FUnordGreaterThan %2, %3 : vector<4xf32>
 ```
 """
-function FUnordGreaterThan(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[operand1, operand2]
+function FUnordGreaterThan(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.FUnordGreaterThan",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "spirv.FUnordGreaterThan", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -4175,28 +3519,18 @@ funordlte-op ::= ssa-id `=` `spirv.FUnordLessThanEqual` ssa-use, ssa-use
 %5 = spirv.FUnordLessThanEqual %2, %3 : vector<4xf32>
 ```
 """
-function FUnordLessThanEqual(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[operand1, operand2]
+function FUnordLessThanEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.FUnordLessThanEqual",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "spirv.FUnordLessThanEqual", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -4226,28 +3560,18 @@ funordlt-op ::= ssa-id `=` `spirv.FUnordLessThan` ssa-use, ssa-use
 %5 = spirv.FUnordLessThan %2, %3 : vector<4xf32>
 ```
 """
-function FUnordLessThan(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[operand1, operand2]
+function FUnordLessThan(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.FUnordLessThan",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "spirv.FUnordLessThan", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -4277,28 +3601,18 @@ funordneq-op ::= ssa-id `=` `spirv.FUnordNotEqual` ssa-use, ssa-use
 %5 = spirv.FUnordNotEqual %2, %3 : vector<4xf32>
 ```
 """
-function FUnordNotEqual(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[operand1, operand2]
+function FUnordNotEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.FUnordNotEqual",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "spirv.FUnordNotEqual", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -4331,36 +3645,20 @@ spirv.func @foo() -> () \"None\" { ... }
 spirv.func @bar() -> () \"Inline|Pure\" { ... }
 ```
 """
-function func(;
-    function_type,
-    arg_attrs=nothing,
-    res_attrs=nothing,
-    sym_name,
-    function_control,
-    body::Region,
-    location=Location(),
-)
+function func(; function_type, arg_attrs=nothing, res_attrs=nothing, sym_name, function_control, body::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[body,]
+    owned_regions = Region[body, ]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("function_type", function_type),
-        namedattribute("sym_name", sym_name),
-        namedattribute("function_control", function_control),
-    ]
+    attributes = NamedAttribute[namedattribute("function_type", function_type), namedattribute("sym_name", sym_name), namedattribute("function_control", function_control), ]
     !isnothing(arg_attrs) && push!(attributes, namedattribute("arg_attrs", arg_attrs))
     !isnothing(res_attrs) && push!(attributes, namedattribute("res_attrs", res_attrs))
-
-    return IR.create_operation(
-        "spirv.func",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.func", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -4394,28 +3692,19 @@ spirv.FunctionCall @f_void(%arg0) : (i32) ->  ()
 %0 = spirv.FunctionCall @f_iadd(%arg0, %arg1) : (i32, i32) -> i32
 ```
 """
-function FunctionCall(
-    arguments::Vector{Value};
-    return_value=nothing::Union{Nothing,IR.Type},
-    callee,
-    location=Location(),
-)
+function FunctionCall(arguments::Vector{Value}; return_value=nothing::Union{Nothing, IR.Type}, callee, location=Location())
     results = IR.Type[]
-    operands = Value[arguments...,]
+    operands = Value[arguments..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("callee", callee),]
+    attributes = NamedAttribute[namedattribute("callee", callee), ]
     !isnothing(return_value) && push!(results, return_value)
-
-    return IR.create_operation(
-        "spirv.FunctionCall",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.FunctionCall", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -4448,25 +3737,19 @@ acos-op ::= ssa-id `=` `spirv.GL.Acos` ssa-use `:`
 %3 = spirv.GL.Acos %1 : vector<3xf16>
 ```
 """
-function GL_Acos(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_Acos(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GL.Acos",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.Acos", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -4499,25 +3782,19 @@ asin-op ::= ssa-id `=` `spirv.GL.Asin` ssa-use `:`
 %3 = spirv.GL.Asin %1 : vector<3xf16>
 ```
 """
-function GL_Asin(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_Asin(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GL.Asin",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.Asin", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -4550,25 +3827,19 @@ atan-op ::= ssa-id `=` `spirv.GL.Atan` ssa-use `:`
 %3 = spirv.GL.Atan %1 : vector<3xf16>
 ```
 """
-function GL_Atan(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_Atan(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GL.Atan",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.Atan", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -4598,25 +3869,19 @@ ceil-op ::= ssa-id `=` `spirv.GL.Ceil` ssa-use `:`
 %3 = spirv.GL.Ceil %1 : vector<3xf16>
 ```
 """
-function GL_Ceil(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_Ceil(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GL.Ceil",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.Ceil", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -4647,23 +3912,19 @@ cos-op ::= ssa-id `=` `spirv.GL.Cos` ssa-use `:`
 %3 = spirv.GL.Cos %1 : vector<3xf16>
 ```
 """
-function GL_Cos(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function GL_Cos(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GL.Cos",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.Cos", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -4694,25 +3955,19 @@ cosh-op ::= ssa-id `=` `spirv.GL.Cosh` ssa-use `:`
 %3 = spirv.GL.Cosh %1 : vector<3xf16>
 ```
 """
-function GL_Cosh(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_Cosh(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GL.Cosh",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.Cosh", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -4743,23 +3998,19 @@ exp-op ::= ssa-id `=` `spirv.GL.Exp` ssa-use `:`
 %3 = spirv.GL.Exp %1 : vector<3xf16>
 ```
 """
-function GL_Exp(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function GL_Exp(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GL.Exp",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.Exp", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -4788,25 +4039,19 @@ abs-op ::= ssa-id `=` `spirv.GL.FAbs` ssa-use `:`
 %3 = spirv.GL.FAbs %1 : vector<3xf16>
 ```
 """
-function GL_FAbs(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_FAbs(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GL.FAbs",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.FAbs", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -4836,21 +4081,17 @@ fclamp-op ::= ssa-id `=` `spirv.GL.FClamp` ssa-use, ssa-use, ssa-use `:`
 ```
 """
 function GL_FClamp(x::Value, y::Value, z::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[x, y, z]
+    results = IR.Type[result, ]
+    operands = Value[x, y, z, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.GL.FClamp",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.FClamp", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -4880,25 +4121,19 @@ fmax-op ::= ssa-id `=` `spirv.GL.FMax` ssa-use `:`
 %3 = spirv.GL.FMax %0, %1 : vector<3xf16>
 ```
 """
-function GL_FMax(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_FMax(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GL.FMax",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.FMax", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -4928,25 +4163,19 @@ fmin-op ::= ssa-id `=` `spirv.GL.FMin` ssa-use `:`
 %3 = spirv.GL.FMin %0, %1 : vector<3xf16>
 ```
 """
-function GL_FMin(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_FMin(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GL.FMin",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.FMin", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -4968,29 +4197,19 @@ Result Type and the type of all operands must be the same type. Results are comp
 %0 = spirv.GL.FMix %x : vector<4xf32>, %y : vector<4xf32>, %a : vector<4xf32> -> vector<4xf32>
 ```
 """
-function GL_FMix(
-    x::Value,
-    y::Value,
-    a::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function GL_FMix(x::Value, y::Value, a::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[x, y, a]
+    operands = Value[x, y, a, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GL.FMix",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.FMix", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -5019,25 +4238,19 @@ sign-op ::= ssa-id `=` `spirv.GL.FSign` ssa-use `:`
 %3 = spirv.GL.FSign %1 : vector<3xf16>
 ```
 """
-function GL_FSign(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_FSign(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GL.FSign",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.FSign", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -5054,25 +4267,19 @@ computed per component.
 
 This instruction is currently limited to 32-bit width components.
 """
-function GL_FindUMsb(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_FindUMsb(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GL.FindUMsb",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.FindUMsb", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -5102,25 +4309,19 @@ floor-op ::= ssa-id `=` `spirv.GL.Floor` ssa-use `:`
 %3 = spirv.GL.Floor %1 : vector<3xf16>
 ```
 """
-function GL_Floor(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_Floor(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GL.Floor",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.Floor", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -5160,21 +4361,17 @@ fma-op ::= ssa-id `=` `spirv.GL.Fma` ssa-use, ssa-use, ssa-use `:`
 ```
 """
 function GL_Fma(x::Value, y::Value, z::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[x, y, z]
+    results = IR.Type[result, ]
+    operands = Value[x, y, z, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.GL.Fma",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.Fma", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -5217,21 +4414,17 @@ frexpstruct-op ::= ssa-id `=` `spirv.GL.FrexpStruct` ssa-use `:`
 ```
 """
 function GL_FrexpStruct(operand::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand,]
+    results = IR.Type[result, ]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.GL.FrexpStruct",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.FrexpStruct", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -5260,25 +4453,19 @@ rsqrt-op ::= ssa-id `=` `spirv.GL.InverseSqrt` ssa-use `:`
 %3 = spirv.GL.InverseSqrt %1 : vector<3xf16>
 ```
 """
-function GL_InverseSqrt(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_InverseSqrt(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GL.InverseSqrt",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.InverseSqrt", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -5316,25 +4503,19 @@ component.
 %y = spirv.GL.Ldexp %x : vector<3xf32>, %exp : vector<3xi32> -> vector<3xf32>
 ```
 """
-function GL_Ldexp(
-    x::Value, exp::Value; y=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_Ldexp(x::Value, exp::Value; y=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[x, exp]
+    operands = Value[x, exp, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(y) && push!(results, y)
-
-    return IR.create_operation(
-        "spirv.GL.Ldexp",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.Ldexp", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -5366,23 +4547,19 @@ log-op ::= ssa-id `=` `spirv.GL.Log` ssa-use `:`
 %3 = spirv.GL.Log %1 : vector<3xf16>
 ```
 """
-function GL_Log(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function GL_Log(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GL.Log",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.Log", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -5415,25 +4592,19 @@ pow-op ::= ssa-id `=` `spirv.GL.Pow` ssa-use `:`
 %3 = spirv.GL.Pow %0, %1 : vector<3xf16>
 ```
 """
-function GL_Pow(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_Pow(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GL.Pow",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.Pow", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -5464,25 +4635,19 @@ round-even-op ::= ssa-id `=` `spirv.GL.RoundEven` ssa-use `:`
 %3 = spirv.GL.RoundEven %1 : vector<3xf16>
 ```
 """
-function GL_RoundEven(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_RoundEven(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GL.RoundEven",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.RoundEven", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -5514,25 +4679,19 @@ round-op ::= ssa-id `=` `spirv.GL.Round` ssa-use `:`
 %3 = spirv.GL.Round %1 : vector<3xf16>
 ```
 """
-function GL_Round(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_Round(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GL.Round",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.Round", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -5560,25 +4719,19 @@ abs-op ::= ssa-id `=` `spirv.GL.SAbs` ssa-use `:`
 %3 = spirv.GL.SAbs %1 : vector<3xi16>
 ```
 """
-function GL_SAbs(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_SAbs(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GL.SAbs",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.SAbs", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -5607,21 +4760,17 @@ uclamp-op ::= ssa-id `=` `spirv.GL.UClamp` ssa-use, ssa-use, ssa-use `:`
 ```
 """
 function GL_SClamp(x::Value, y::Value, z::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[x, y, z]
+    results = IR.Type[result, ]
+    operands = Value[x, y, z, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.GL.SClamp",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.SClamp", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -5650,25 +4799,19 @@ smax-op ::= ssa-id `=` `spirv.GL.SMax` ssa-use `:`
 %3 = spirv.GL.SMax %0, %1 : vector<3xi16>
 ```
 """
-function GL_SMax(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_SMax(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GL.SMax",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.SMax", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -5697,25 +4840,19 @@ smin-op ::= ssa-id `=` `spirv.GL.SMin` ssa-use `:`
 %3 = spirv.GL.SMin %0, %1 : vector<3xi16>
 ```
 """
-function GL_SMin(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_SMin(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GL.SMin",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.SMin", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -5743,25 +4880,19 @@ sign-op ::= ssa-id `=` `spirv.GL.SSign` ssa-use `:`
 %3 = spirv.GL.SSign %1 : vector<3xi16>
 ```
 """
-function GL_SSign(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_SSign(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GL.SSign",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.SSign", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -5792,23 +4923,19 @@ sin-op ::= ssa-id `=` `spirv.GL.Sin` ssa-use `:`
 %3 = spirv.GL.Sin %1 : vector<3xf16>
 ```
 """
-function GL_Sin(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function GL_Sin(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GL.Sin",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.Sin", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -5839,25 +4966,19 @@ sinh-op ::= ssa-id `=` `spirv.GL.Sinh` ssa-use `:`
 %3 = spirv.GL.Sinh %1 : vector<3xf16>
 ```
 """
-function GL_Sinh(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_Sinh(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GL.Sinh",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.Sinh", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -5886,25 +5007,19 @@ sqrt-op ::= ssa-id `=` `spirv.GL.Sqrt` ssa-use `:`
 %3 = spirv.GL.Sqrt %1 : vector<3xf16>
 ```
 """
-function GL_Sqrt(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_Sqrt(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GL.Sqrt",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.Sqrt", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -5935,23 +5050,19 @@ tan-op ::= ssa-id `=` `spirv.GL.Tan` ssa-use `:`
 %3 = spirv.GL.Tan %1 : vector<3xf16>
 ```
 """
-function GL_Tan(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function GL_Tan(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GL.Tan",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.Tan", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -5982,25 +5093,19 @@ tanh-op ::= ssa-id `=` `spirv.GL.Tanh` ssa-use `:`
 %3 = spirv.GL.Tanh %1 : vector<3xf16>
 ```
 """
-function GL_Tanh(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_Tanh(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GL.Tanh",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.Tanh", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -6029,21 +5134,17 @@ uclamp-op ::= ssa-id `=` `spirv.GL.UClamp` ssa-use, ssa-use, ssa-use `:`
 ```
 """
 function GL_UClamp(x::Value, y::Value, z::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[x, y, z]
+    results = IR.Type[result, ]
+    operands = Value[x, y, z, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.GL.UClamp",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.UClamp", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -6072,25 +5173,19 @@ smax-op ::= ssa-id `=` `spirv.GL.UMax` ssa-use `:`
 %3 = spirv.GL.UMax %0, %1 : vector<3xi16>
 ```
 """
-function GL_UMax(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_UMax(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GL.UMax",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.UMax", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -6119,25 +5214,19 @@ smin-op ::= ssa-id `=` `spirv.GL.UMin` ssa-use `:`
 %3 = spirv.GL.UMin %0, %1 : vector<3xi16>
 ```
 """
-function GL_UMin(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_UMin(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GL.UMin",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.UMin", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -6164,21 +5253,17 @@ Workgroup, CrossWorkgroup, or Function.
 ```
 """
 function GenericCastToPtrExplicit(pointer::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[pointer,]
+    results = IR.Type[result, ]
+    operands = Value[pointer, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.GenericCastToPtrExplicit",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GenericCastToPtrExplicit", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -6202,21 +5287,17 @@ Result Type and Pointer must point to the same type.
 ```
 """
 function GenericCastToPtr(pointer::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[pointer,]
+    results = IR.Type[result, ]
+    operands = Value[pointer, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.GenericCastToPtr",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GenericCastToPtr", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -6260,39 +5341,23 @@ spirv.GlobalVariable @var2 bind(1, 2) : !spirv.ptr<f32, Uniform>
 spirv.GlobalVariable @var3 built_in(\"GlobalInvocationId\") : !spirv.ptr<vector<3xi32>, Input>
 ```
 """
-function GlobalVariable(;
-    type,
-    sym_name,
-    initializer=nothing,
-    location_=nothing,
-    binding=nothing,
-    descriptor_set=nothing,
-    builtin=nothing,
-    location=Location(),
-)
+function GlobalVariable(; type, sym_name, initializer=nothing, location_=nothing, binding=nothing, descriptor_set=nothing, builtin=nothing, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("type", type), namedattribute("sym_name", sym_name)
-    ]
+    attributes = NamedAttribute[namedattribute("type", type), namedattribute("sym_name", sym_name), ]
     !isnothing(initializer) && push!(attributes, namedattribute("initializer", initializer))
     !isnothing(location) && push!(attributes, namedattribute("location", location_))
     !isnothing(binding) && push!(attributes, namedattribute("binding", binding))
-    !isnothing(descriptor_set) &&
-        push!(attributes, namedattribute("descriptor_set", descriptor_set))
+    !isnothing(descriptor_set) && push!(attributes, namedattribute("descriptor_set", descriptor_set))
     !isnothing(builtin) && push!(attributes, namedattribute("builtin", builtin))
-
-    return IR.create_operation(
-        "spirv.GlobalVariable",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GlobalVariable", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -6341,29 +5406,19 @@ group-broadcast-op ::= ssa-id `=` `spirv.GroupBroadcast` scope ssa_use,
   vector<4xf32>, vector<3xi32>
 ```
 """
-function GroupBroadcast(
-    value::Value,
-    localid::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    execution_scope,
-    location=Location(),
-)
+function GroupBroadcast(value::Value, localid::Value; result=nothing::Union{Nothing, IR.Type}, execution_scope, location=Location())
     results = IR.Type[]
-    operands = Value[value, localid]
+    operands = Value[value, localid, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope),]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GroupBroadcast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GroupBroadcast", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -6399,32 +5454,19 @@ op ::= ssa-id `=` `spirv.GroupFAdd` scope operation ssa-use
 %0 = spirv.GroupFAdd <Workgroup> <Reduce> %value : f32
 ```
 """
-function GroupFAdd(
-    x::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    execution_scope,
-    group_operation,
-    location=Location(),
-)
+function GroupFAdd(x::Value; result=nothing::Union{Nothing, IR.Type}, execution_scope, group_operation, location=Location())
     results = IR.Type[]
-    operands = Value[x,]
+    operands = Value[x, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("execution_scope", execution_scope),
-        namedattribute("group_operation", group_operation),
-    ]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GroupFAdd",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GroupFAdd", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -6460,32 +5502,19 @@ op ::= ssa-id `=` `spirv.GroupFMax` scope operation ssa-use
 %0 = spirv.GroupFMax <Workgroup> <Reduce> %value : f32
 ```
 """
-function GroupFMax(
-    x::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    execution_scope,
-    group_operation,
-    location=Location(),
-)
+function GroupFMax(x::Value; result=nothing::Union{Nothing, IR.Type}, execution_scope, group_operation, location=Location())
     results = IR.Type[]
-    operands = Value[x,]
+    operands = Value[x, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("execution_scope", execution_scope),
-        namedattribute("group_operation", group_operation),
-    ]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GroupFMax",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GroupFMax", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -6521,32 +5550,19 @@ op ::= ssa-id `=` `spirv.GroupFMin` scope operation ssa-use
 %0 = spirv.GroupFMin <Workgroup> <Reduce> %value : f32
 ```
 """
-function GroupFMin(
-    x::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    execution_scope,
-    group_operation,
-    location=Location(),
-)
+function GroupFMin(x::Value; result=nothing::Union{Nothing, IR.Type}, execution_scope, group_operation, location=Location())
     results = IR.Type[]
-    operands = Value[x,]
+    operands = Value[x, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("execution_scope", execution_scope),
-        namedattribute("group_operation", group_operation),
-    ]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GroupFMin",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GroupFMin", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -6583,32 +5599,19 @@ op ::= ssa-id `=` `spirv.KHR.GroupFMul` scope operation ssa-use
 %0 = spirv.KHR.GroupFMul <Workgroup> <Reduce> %value : f32
 ```
 """
-function KHR_GroupFMul(
-    x::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    execution_scope,
-    group_operation,
-    location=Location(),
-)
+function KHR_GroupFMul(x::Value; result=nothing::Union{Nothing, IR.Type}, execution_scope, group_operation, location=Location())
     results = IR.Type[]
-    operands = Value[x,]
+    operands = Value[x, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("execution_scope", execution_scope),
-        namedattribute("group_operation", group_operation),
-    ]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.KHR.GroupFMul",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.KHR.GroupFMul", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -6644,32 +5647,19 @@ op ::= ssa-id `=` `spirv.GroupIAdd` scope operation ssa-use
 %0 = spirv.GroupIAdd <Workgroup> <Reduce> %value : i32
 ```
 """
-function GroupIAdd(
-    x::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    execution_scope,
-    group_operation,
-    location=Location(),
-)
+function GroupIAdd(x::Value; result=nothing::Union{Nothing, IR.Type}, execution_scope, group_operation, location=Location())
     results = IR.Type[]
-    operands = Value[x,]
+    operands = Value[x, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("execution_scope", execution_scope),
-        namedattribute("group_operation", group_operation),
-    ]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GroupIAdd",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GroupIAdd", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -6706,32 +5696,19 @@ op ::= ssa-id `=` `spirv.KHR.GroupIMul` scope operation ssa-use
 %0 = spirv.KHR.GroupIMul <Workgroup> <Reduce> %value : i32
 ```
 """
-function KHR_GroupIMul(
-    x::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    execution_scope,
-    group_operation,
-    location=Location(),
-)
+function KHR_GroupIMul(x::Value; result=nothing::Union{Nothing, IR.Type}, execution_scope, group_operation, location=Location())
     results = IR.Type[]
-    operands = Value[x,]
+    operands = Value[x, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("execution_scope", execution_scope),
-        namedattribute("group_operation", group_operation),
-    ]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.KHR.GroupIMul",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.KHR.GroupIMul", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -6764,24 +5741,18 @@ non-uniform-ballot-op ::= ssa-id `=` `spirv.GroupNonUniformBallot` scope
 %0 = spirv.GroupNonUniformBallot \"SubGroup\" %predicate : vector<4xi32>
 ```
 """
-function GroupNonUniformBallot(
-    predicate::Value; result::IR.Type, execution_scope, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[predicate,]
+function GroupNonUniformBallot(predicate::Value; result::IR.Type, execution_scope, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[predicate, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope),]
-
-    return IR.create_operation(
-        "spirv.GroupNonUniformBallot",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), ]
+    
+    IR.create_operation(
+        "spirv.GroupNonUniformBallot", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -6826,29 +5797,19 @@ group-non-uniform-broadcast-op ::= ssa-id `=`
   vector<4xf32>, i32
 ```
 """
-function GroupNonUniformBroadcast(
-    value::Value,
-    id::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    execution_scope,
-    location=Location(),
-)
+function GroupNonUniformBroadcast(value::Value, id::Value; result=nothing::Union{Nothing, IR.Type}, execution_scope, location=Location())
     results = IR.Type[]
-    operands = Value[value, id]
+    operands = Value[value, id, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope),]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GroupNonUniformBroadcast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GroupNonUniformBroadcast", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -6873,25 +5834,19 @@ non-uniform-elect-op ::= ssa-id `=` `spirv.GroupNonUniformElect` scope
 %0 = spirv.GroupNonUniformElect : i1
 ```
 """
-function GroupNonUniformElect(;
-    result=nothing::Union{Nothing,IR.Type}, execution_scope, location=Location()
-)
+function GroupNonUniformElect(; result=nothing::Union{Nothing, IR.Type}, execution_scope, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope),]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GroupNonUniformElect",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GroupNonUniformElect", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -6937,33 +5892,19 @@ non-uniform-fadd-op ::= ssa-id `=` `spirv.GroupNonUniformFAdd` scope operation
 %1 = spirv.GroupNonUniformFAdd \"Subgroup\" \"ClusteredReduce\" %vector cluster_size(%four) : vector<4xf32>
 ```
 """
-function GroupNonUniformFAdd(
-    value::Value,
-    cluster_size=nothing::Union{Nothing,Value};
-    result::IR.Type,
-    execution_scope,
-    group_operation,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[value,]
+function GroupNonUniformFAdd(value::Value, cluster_size=nothing::Union{Nothing, Value}; result::IR.Type, execution_scope, group_operation, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("execution_scope", execution_scope),
-        namedattribute("group_operation", group_operation),
-    ]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
     !isnothing(cluster_size) && push!(operands, cluster_size)
-
-    return IR.create_operation(
-        "spirv.GroupNonUniformFAdd",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GroupNonUniformFAdd", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -7012,33 +5953,19 @@ non-uniform-fmax-op ::= ssa-id `=` `spirv.GroupNonUniformFMax` scope operation
 %1 = spirv.GroupNonUniformFMax \"Subgroup\" \"ClusteredReduce\" %vector cluster_size(%four) : vector<4xf32>
 ```
 """
-function GroupNonUniformFMax(
-    value::Value,
-    cluster_size=nothing::Union{Nothing,Value};
-    result::IR.Type,
-    execution_scope,
-    group_operation,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[value,]
+function GroupNonUniformFMax(value::Value, cluster_size=nothing::Union{Nothing, Value}; result::IR.Type, execution_scope, group_operation, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("execution_scope", execution_scope),
-        namedattribute("group_operation", group_operation),
-    ]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
     !isnothing(cluster_size) && push!(operands, cluster_size)
-
-    return IR.create_operation(
-        "spirv.GroupNonUniformFMax",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GroupNonUniformFMax", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -7087,33 +6014,19 @@ non-uniform-fmin-op ::= ssa-id `=` `spirv.GroupNonUniformFMin` scope operation
 %1 = spirv.GroupNonUniformFMin \"Subgroup\" \"ClusteredReduce\" %vector cluster_size(%four) : vector<4xf32>
 ```
 """
-function GroupNonUniformFMin(
-    value::Value,
-    cluster_size=nothing::Union{Nothing,Value};
-    result::IR.Type,
-    execution_scope,
-    group_operation,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[value,]
+function GroupNonUniformFMin(value::Value, cluster_size=nothing::Union{Nothing, Value}; result::IR.Type, execution_scope, group_operation, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("execution_scope", execution_scope),
-        namedattribute("group_operation", group_operation),
-    ]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
     !isnothing(cluster_size) && push!(operands, cluster_size)
-
-    return IR.create_operation(
-        "spirv.GroupNonUniformFMin",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GroupNonUniformFMin", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -7159,33 +6072,19 @@ non-uniform-fmul-op ::= ssa-id `=` `spirv.GroupNonUniformFMul` scope operation
 %1 = spirv.GroupNonUniformFMul \"Subgroup\" \"ClusteredReduce\" %vector cluster_size(%four) : vector<4xf32>
 ```
 """
-function GroupNonUniformFMul(
-    value::Value,
-    cluster_size=nothing::Union{Nothing,Value};
-    result::IR.Type,
-    execution_scope,
-    group_operation,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[value,]
+function GroupNonUniformFMul(value::Value, cluster_size=nothing::Union{Nothing, Value}; result::IR.Type, execution_scope, group_operation, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("execution_scope", execution_scope),
-        namedattribute("group_operation", group_operation),
-    ]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
     !isnothing(cluster_size) && push!(operands, cluster_size)
-
-    return IR.create_operation(
-        "spirv.GroupNonUniformFMul",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GroupNonUniformFMul", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -7229,33 +6128,19 @@ non-uniform-iadd-op ::= ssa-id `=` `spirv.GroupNonUniformIAdd` scope operation
 %1 = spirv.GroupNonUniformIAdd \"Subgroup\" \"ClusteredReduce\" %vector cluster_size(%four) : vector<4xi32>
 ```
 """
-function GroupNonUniformIAdd(
-    value::Value,
-    cluster_size=nothing::Union{Nothing,Value};
-    result::IR.Type,
-    execution_scope,
-    group_operation,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[value,]
+function GroupNonUniformIAdd(value::Value, cluster_size=nothing::Union{Nothing, Value}; result::IR.Type, execution_scope, group_operation, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("execution_scope", execution_scope),
-        namedattribute("group_operation", group_operation),
-    ]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
     !isnothing(cluster_size) && push!(operands, cluster_size)
-
-    return IR.create_operation(
-        "spirv.GroupNonUniformIAdd",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GroupNonUniformIAdd", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -7299,33 +6184,19 @@ non-uniform-imul-op ::= ssa-id `=` `spirv.GroupNonUniformIMul` scope operation
 %1 = spirv.GroupNonUniformIMul \"Subgroup\" \"ClusteredReduce\" %vector cluster_size(%four) : vector<4xi32>
 ```
 """
-function GroupNonUniformIMul(
-    value::Value,
-    cluster_size=nothing::Union{Nothing,Value};
-    result::IR.Type,
-    execution_scope,
-    group_operation,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[value,]
+function GroupNonUniformIMul(value::Value, cluster_size=nothing::Union{Nothing, Value}; result::IR.Type, execution_scope, group_operation, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("execution_scope", execution_scope),
-        namedattribute("group_operation", group_operation),
-    ]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
     !isnothing(cluster_size) && push!(operands, cluster_size)
-
-    return IR.create_operation(
-        "spirv.GroupNonUniformIMul",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GroupNonUniformIMul", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -7369,33 +6240,19 @@ non-uniform-smax-op ::= ssa-id `=` `spirv.GroupNonUniformSMax` scope operation
 %1 = spirv.GroupNonUniformSMax \"Subgroup\" \"ClusteredReduce\" %vector cluster_size(%four) : vector<4xi32>
 ```
 """
-function GroupNonUniformSMax(
-    value::Value,
-    cluster_size=nothing::Union{Nothing,Value};
-    result::IR.Type,
-    execution_scope,
-    group_operation,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[value,]
+function GroupNonUniformSMax(value::Value, cluster_size=nothing::Union{Nothing, Value}; result::IR.Type, execution_scope, group_operation, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("execution_scope", execution_scope),
-        namedattribute("group_operation", group_operation),
-    ]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
     !isnothing(cluster_size) && push!(operands, cluster_size)
-
-    return IR.create_operation(
-        "spirv.GroupNonUniformSMax",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GroupNonUniformSMax", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -7439,33 +6296,19 @@ non-uniform-smin-op ::= ssa-id `=` `spirv.GroupNonUniformSMin` scope operation
 %1 = spirv.GroupNonUniformSMin \"Subgroup\" \"ClusteredReduce\" %vector cluster_size(%four) : vector<4xi32>
 ```
 """
-function GroupNonUniformSMin(
-    value::Value,
-    cluster_size=nothing::Union{Nothing,Value};
-    result::IR.Type,
-    execution_scope,
-    group_operation,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[value,]
+function GroupNonUniformSMin(value::Value, cluster_size=nothing::Union{Nothing, Value}; result::IR.Type, execution_scope, group_operation, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("execution_scope", execution_scope),
-        namedattribute("group_operation", group_operation),
-    ]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
     !isnothing(cluster_size) && push!(operands, cluster_size)
-
-    return IR.create_operation(
-        "spirv.GroupNonUniformSMin",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GroupNonUniformSMin", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -7494,29 +6337,19 @@ invocation or greater than or equal to the size of the group.
 %0 = spirv.GroupNonUniformShuffleDown <Subgroup> %val, %delta : f32, i32
 ```
 """
-function GroupNonUniformShuffleDown(
-    value::Value,
-    delta::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    execution_scope,
-    location=Location(),
-)
+function GroupNonUniformShuffleDown(value::Value, delta::Value; result=nothing::Union{Nothing, IR.Type}, execution_scope, location=Location())
     results = IR.Type[]
-    operands = Value[value, delta]
+    operands = Value[value, delta, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope),]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GroupNonUniformShuffleDown",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GroupNonUniformShuffleDown", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -7543,29 +6376,19 @@ greater than or equal to the size of the group.
 %0 = spirv.GroupNonUniformShuffle <Subgroup> %val, %id : f32, i32
 ```
 """
-function GroupNonUniformShuffle(
-    value::Value,
-    id::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    execution_scope,
-    location=Location(),
-)
+function GroupNonUniformShuffle(value::Value, id::Value; result=nothing::Union{Nothing, IR.Type}, execution_scope, location=Location())
     results = IR.Type[]
-    operands = Value[value, id]
+    operands = Value[value, id, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope),]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GroupNonUniformShuffle",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GroupNonUniformShuffle", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -7593,29 +6416,19 @@ the selected lane is inactive.
 %0 = spirv.GroupNonUniformShuffleUp <Subgroup> %val, %delta : f32, i32
 ```
 """
-function GroupNonUniformShuffleUp(
-    value::Value,
-    delta::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    execution_scope,
-    location=Location(),
-)
+function GroupNonUniformShuffleUp(value::Value, delta::Value; result=nothing::Union{Nothing, IR.Type}, execution_scope, location=Location())
     results = IR.Type[]
-    operands = Value[value, delta]
+    operands = Value[value, delta, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope),]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GroupNonUniformShuffleUp",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GroupNonUniformShuffleUp", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -7643,29 +6456,19 @@ equal to the size of the group.
 %0 = spirv.GroupNonUniformShuffleXor <Subgroup> %val, %mask : f32, i32
 ```
 """
-function GroupNonUniformShuffleXor(
-    value::Value,
-    mask::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    execution_scope,
-    location=Location(),
-)
+function GroupNonUniformShuffleXor(value::Value, mask::Value; result=nothing::Union{Nothing, IR.Type}, execution_scope, location=Location())
     results = IR.Type[]
-    operands = Value[value, mask]
+    operands = Value[value, mask, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope),]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GroupNonUniformShuffleXor",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GroupNonUniformShuffleXor", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -7710,33 +6513,19 @@ non-uniform-umax-op ::= ssa-id `=` `spirv.GroupNonUniformUMax` scope operation
 %1 = spirv.GroupNonUniformUMax \"Subgroup\" \"ClusteredReduce\" %vector cluster_size(%four) : vector<4xi32>
 ```
 """
-function GroupNonUniformUMax(
-    value::Value,
-    cluster_size=nothing::Union{Nothing,Value};
-    result::IR.Type,
-    execution_scope,
-    group_operation,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[value,]
+function GroupNonUniformUMax(value::Value, cluster_size=nothing::Union{Nothing, Value}; result::IR.Type, execution_scope, group_operation, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("execution_scope", execution_scope),
-        namedattribute("group_operation", group_operation),
-    ]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
     !isnothing(cluster_size) && push!(operands, cluster_size)
-
-    return IR.create_operation(
-        "spirv.GroupNonUniformUMax",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GroupNonUniformUMax", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -7781,33 +6570,19 @@ non-uniform-umin-op ::= ssa-id `=` `spirv.GroupNonUniformUMin` scope operation
 %1 = spirv.GroupNonUniformUMin \"Subgroup\" \"ClusteredReduce\" %vector cluster_size(%four) : vector<4xi32>
 ```
 """
-function GroupNonUniformUMin(
-    value::Value,
-    cluster_size=nothing::Union{Nothing,Value};
-    result::IR.Type,
-    execution_scope,
-    group_operation,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[value,]
+function GroupNonUniformUMin(value::Value, cluster_size=nothing::Union{Nothing, Value}; result::IR.Type, execution_scope, group_operation, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("execution_scope", execution_scope),
-        namedattribute("group_operation", group_operation),
-    ]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
     !isnothing(cluster_size) && push!(operands, cluster_size)
-
-    return IR.create_operation(
-        "spirv.GroupNonUniformUMin",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GroupNonUniformUMin", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -7844,32 +6619,19 @@ op ::= ssa-id `=` `spirv.GroupSMax` scope operation ssa-use
 %0 = spirv.GroupSMax <Workgroup> <Reduce> %value : i32
 ```
 """
-function GroupSMax(
-    x::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    execution_scope,
-    group_operation,
-    location=Location(),
-)
+function GroupSMax(x::Value; result=nothing::Union{Nothing, IR.Type}, execution_scope, group_operation, location=Location())
     results = IR.Type[]
-    operands = Value[x,]
+    operands = Value[x, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("execution_scope", execution_scope),
-        namedattribute("group_operation", group_operation),
-    ]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GroupSMax",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GroupSMax", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -7906,32 +6668,19 @@ op ::= ssa-id `=` `spirv.GroupSMin` scope operation ssa-use
 %0 = spirv.GroupSMin <Workgroup> <Reduce> %value : i32
 ```
 """
-function GroupSMin(
-    x::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    execution_scope,
-    group_operation,
-    location=Location(),
-)
+function GroupSMin(x::Value; result=nothing::Union{Nothing, IR.Type}, execution_scope, group_operation, location=Location())
     results = IR.Type[]
-    operands = Value[x,]
+    operands = Value[x, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("execution_scope", execution_scope),
-        namedattribute("group_operation", group_operation),
-    ]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GroupSMin",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GroupSMin", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -7967,32 +6716,19 @@ op ::= ssa-id `=` `spirv.GroupUMax` scope operation ssa-use
 %0 = spirv.GroupUMax <Workgroup> <Reduce> %value : i32
 ```
 """
-function GroupUMax(
-    x::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    execution_scope,
-    group_operation,
-    location=Location(),
-)
+function GroupUMax(x::Value; result=nothing::Union{Nothing, IR.Type}, execution_scope, group_operation, location=Location())
     results = IR.Type[]
-    operands = Value[x,]
+    operands = Value[x, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("execution_scope", execution_scope),
-        namedattribute("group_operation", group_operation),
-    ]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GroupUMax",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GroupUMax", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -8029,32 +6765,19 @@ op ::= ssa-id `=` `spirv.GroupUMin` scope operation ssa-use
 %0 = spirv.GroupUMin <Workgroup> <Reduce> %value : i32
 ```
 """
-function GroupUMin(
-    x::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    execution_scope,
-    group_operation,
-    location=Location(),
-)
+function GroupUMin(x::Value; result=nothing::Union{Nothing, IR.Type}, execution_scope, group_operation, location=Location())
     results = IR.Type[]
-    operands = Value[x,]
+    operands = Value[x, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("execution_scope", execution_scope),
-        namedattribute("group_operation", group_operation),
-    ]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GroupUMin",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GroupUMin", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -8088,21 +6811,17 @@ the component width, and 0 otherwise.
 ```
 """
 function IAddCarry(operand1::Value, operand2::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand1, operand2]
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.IAddCarry",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.IAddCarry", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -8137,28 +6856,19 @@ iadd-op ::= ssa-id `=` `spirv.IAdd` ssa-use, ssa-use
 
 ```
 """
-function IAdd(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function IAdd(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand1, operand2]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.IAdd",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.IAdd", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -8188,28 +6898,18 @@ iequal-op ::= ssa-id `=` `spirv.IEqual` ssa-use, ssa-use
 
 ```
 """
-function IEqual(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[operand1, operand2]
+function IEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.IEqual",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "spirv.IEqual", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -8244,28 +6944,19 @@ imul-op ::= ssa-id `=` `spirv.IMul` ssa-use, ssa-use
 
 ```
 """
-function IMul(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function IMul(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand1, operand2]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.IMul",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.IMul", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -8299,36 +6990,20 @@ present, it is the same as specifying the memory operand None.
      !spirv.jointmatrix<8x16xi32, ColumnMajor, Subgroup>
 ```
 """
-function INTEL_JointMatrixLoad(
-    pointer::Value,
-    stride::Value;
-    result::IR.Type,
-    layout,
-    scope,
-    memory_access=nothing,
-    alignment=nothing,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[pointer, stride]
+function INTEL_JointMatrixLoad(pointer::Value, stride::Value; result::IR.Type, layout, scope, memory_access=nothing, alignment=nothing, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[pointer, stride, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("layout", layout), namedattribute("scope", scope)
-    ]
-    !isnothing(memory_access) &&
-        push!(attributes, namedattribute("memory_access", memory_access))
+    attributes = NamedAttribute[namedattribute("layout", layout), namedattribute("scope", scope), ]
+    !isnothing(memory_access) && push!(attributes, namedattribute("memory_access", memory_access))
     !isnothing(alignment) && push!(attributes, namedattribute("alignment", alignment))
-
-    return IR.create_operation(
-        "spirv.INTEL.JointMatrixLoad",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.INTEL.JointMatrixLoad", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -8366,30 +7041,19 @@ integer type.
      -> !spirv.jointmatrix<8x8xi32,  RowMajor, Subgroup>
 ```
 """
-function INTEL_JointMatrixMad(
-    a::Value,
-    b::Value,
-    c::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    scope,
-    location=Location(),
-)
+function INTEL_JointMatrixMad(a::Value, b::Value, c::Value; result=nothing::Union{Nothing, IR.Type}, scope, location=Location())
     results = IR.Type[]
-    operands = Value[a, b, c]
+    operands = Value[a, b, c, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("scope", scope),]
+    attributes = NamedAttribute[namedattribute("scope", scope), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.INTEL.JointMatrixMad",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.INTEL.JointMatrixMad", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -8427,36 +7091,20 @@ spirv.INTEL.JointMatrixStore <Subgroup> <ColumnMajor> %ptr, %m, %stride
 !spirv.jointmatrix<8x16xi32, RowMajor, Subgroup>, i32)
 ```
 """
-function INTEL_JointMatrixStore(
-    pointer::Value,
-    object::Value,
-    stride::Value;
-    layout,
-    scope,
-    memory_access=nothing,
-    alignment=nothing,
-    location=Location(),
-)
+function INTEL_JointMatrixStore(pointer::Value, object::Value, stride::Value; layout, scope, memory_access=nothing, alignment=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[pointer, object, stride]
+    operands = Value[pointer, object, stride, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("layout", layout), namedattribute("scope", scope)
-    ]
-    !isnothing(memory_access) &&
-        push!(attributes, namedattribute("memory_access", memory_access))
+    attributes = NamedAttribute[namedattribute("layout", layout), namedattribute("scope", scope), ]
+    !isnothing(memory_access) && push!(attributes, namedattribute("memory_access", memory_access))
     !isnothing(alignment) && push!(attributes, namedattribute("alignment", alignment))
-
-    return IR.create_operation(
-        "spirv.INTEL.JointMatrixStore",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.INTEL.JointMatrixStore", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -8481,25 +7129,19 @@ For example:
 %0 = spirv.INTEL.JointMatrixWorkItemLength : !spirv.jointmatrix<Subgroup, i32, 8, 16>
 ```
 """
-function INTEL_JointMatrixWorkItemLength(;
-    result=nothing::Union{Nothing,IR.Type}, joint_matrix_type, location=Location()
-)
+function INTEL_JointMatrixWorkItemLength(; result=nothing::Union{Nothing, IR.Type}, joint_matrix_type, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("joint_matrix_type", joint_matrix_type),]
+    attributes = NamedAttribute[namedattribute("joint_matrix_type", joint_matrix_type), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.INTEL.JointMatrixWorkItemLength",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.INTEL.JointMatrixWorkItemLength", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -8535,21 +7177,17 @@ subgroup-block-read-INTEL-op ::= ssa-id `=` `spirv.INTEL.SubgroupBlockRead`
 ```
 """
 function INTEL_SubgroupBlockRead(ptr::Value; value::IR.Type, location=Location())
-    results = IR.Type[value,]
-    operands = Value[ptr,]
+    results = IR.Type[value, ]
+    operands = Value[ptr, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.INTEL.SubgroupBlockRead",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.INTEL.SubgroupBlockRead", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -8585,20 +7223,16 @@ spirv.INTEL.SubgroupBlockWrite \"StorageBuffer\" %ptr, %value : i32
 """
 function INTEL_SubgroupBlockWrite(ptr::Value, value::Value; location=Location())
     results = IR.Type[]
-    operands = Value[ptr, value]
+    operands = Value[ptr, value, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.INTEL.SubgroupBlockWrite",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.INTEL.SubgroupBlockWrite", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -8628,28 +7262,18 @@ inot-equal-op ::= ssa-id `=` `spirv.INotEqual` ssa-use, ssa-use
 
 ```
 """
-function INotEqual(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[operand1, operand2]
+function INotEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.INotEqual",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "spirv.INotEqual", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -8685,21 +7309,17 @@ otherwise.
 ```
 """
 function ISubBorrow(operand1::Value, operand2::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand1, operand2]
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.ISubBorrow",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.ISubBorrow", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -8734,28 +7354,19 @@ isub-op ::= `spirv.ISub` ssa-use, ssa-use
 
 ```
 """
-function ISub(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function ISub(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand1, operand2]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.ISub",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.ISub", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -8795,32 +7406,19 @@ image-operands ::= `\"None\"` | `\"Bias\"` | `\"Lod\"` | `\"Grad\"`
 %0 = spirv.ImageDrefGather %1 : !spirv.sampled_image<!spirv.image<i32, Dim2D, NoDepth, NonArrayed, SingleSampled, NoSampler, Unknown>>, %2 : vector<4xf32>, %3 : f32 [\"NonPrivateTexel\"] : f32, f32 -> vector<4xi32>
 ```
 """
-function ImageDrefGather(
-    sampledimage::Value,
-    coordinate::Value,
-    dref::Value,
-    operand_arguments::Vector{Value};
-    result::IR.Type,
-    imageoperands=nothing,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[sampledimage, coordinate, dref, operand_arguments...]
+function ImageDrefGather(sampledimage::Value, coordinate::Value, dref::Value, operand_arguments::Vector{Value}; result::IR.Type, imageoperands=nothing, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[sampledimage, coordinate, dref, operand_arguments..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(imageoperands) &&
-        push!(attributes, namedattribute("imageoperands", imageoperands))
-
-    return IR.create_operation(
-        "spirv.ImageDrefGather",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(imageoperands) && push!(attributes, namedattribute("imageoperands", imageoperands))
+    
+    IR.create_operation(
+        "spirv.ImageDrefGather", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -8840,25 +7438,18 @@ same as Result Type.
 %0 = spirv.Image %1 : !spirv.sampled_image<!spirv.image<f32, Cube, NoDepth, NonArrayed, SingleSampled, NoSampler, Unknown>>
 ```
 """
-function Image(
-    sampledimage::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
-    results = IR.Type[]
-    operands = Value[sampledimage,]
+function Image(sampledimage::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[sampledimage, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.Image",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "spirv.Image", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -8897,21 +7488,17 @@ See the client API specification for additional image type restrictions.
 ```
 """
 function ImageQuerySize(image::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[image,]
+    results = IR.Type[result, ]
+    operands = Value[image, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.ImageQuerySize",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.ImageQuerySize", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -8937,28 +7524,18 @@ func @inbounds_ptr_access_chain(%arg0: !spirv.ptr<f32, CrossWorkgroup>, %arg1 : 
 }
 ```
 """
-function InBoundsPtrAccessChain(
-    base_ptr::Value,
-    element::Value,
-    indices::Vector{Value};
-    result::IR.Type,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[base_ptr, element, indices...]
+function InBoundsPtrAccessChain(base_ptr::Value, element::Value, indices::Vector{Value}; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[base_ptr, element, indices..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.InBoundsPtrAccessChain",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.InBoundsPtrAccessChain", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -8988,23 +7565,18 @@ isinf-op ::= ssa-id `=` `spirv.IsInf` ssa-use
 %3 = spirv.IsInf %1: vector<4xi32>
 ```
 """
-function IsInf(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
-    results = IR.Type[]
-    operands = Value[operand,]
+function IsInf(operand::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.IsInf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "spirv.IsInf", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -9034,23 +7606,18 @@ isnan-op ::= ssa-id `=` `spirv.IsNan` ssa-use
 %3 = spirv.IsNan %1: vector<4xi32>
 ```
 """
-function IsNan(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
-    results = IR.Type[]
-    operands = Value[operand,]
+function IsNan(operand::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.IsNan",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "spirv.IsNan", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -9073,20 +7640,16 @@ spirv.KHR.AssumeTrue %arg
 """
 function KHR_AssumeTrue(condition::Value; location=Location())
     results = IR.Type[]
-    operands = Value[condition,]
+    operands = Value[condition, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.KHR.AssumeTrue",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.KHR.AssumeTrue", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -9121,21 +7684,17 @@ subgroup-ballot-op ::= ssa-id `=` `spirv.KHR.SubgroupBallot`
 ```
 """
 function KHR_SubgroupBallot(predicate::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[predicate,]
+    results = IR.Type[result, ]
+    operands = Value[predicate, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.KHR.SubgroupBallot",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.KHR.SubgroupBallot", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -9172,31 +7731,20 @@ load-op ::= ssa-id ` = spirv.Load ` storage-class ssa-use
 %3 = spirv.Load \"Function\" %0 [\"Aligned\", 4] : f32
 ```
 """
-function Load(
-    ptr::Value;
-    value::IR.Type,
-    memory_access=nothing,
-    alignment=nothing,
-    location=Location(),
-)
-    results = IR.Type[value,]
-    operands = Value[ptr,]
+function Load(ptr::Value; value::IR.Type, memory_access=nothing, alignment=nothing, location=Location())
+    results = IR.Type[value, ]
+    operands = Value[ptr, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(memory_access) &&
-        push!(attributes, namedattribute("memory_access", memory_access))
+    !isnothing(memory_access) && push!(attributes, namedattribute("memory_access", memory_access))
     !isnothing(alignment) && push!(attributes, namedattribute("alignment", alignment))
-
-    return IR.create_operation(
-        "spirv.Load",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.Load", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -9225,28 +7773,18 @@ logical-and ::= `spirv.LogicalAnd` ssa-use `,` ssa-use
 %2 = spirv.LogicalAnd %0, %1 : vector<4xi1>
 ```
 """
-function LogicalAnd(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[operand1, operand2]
+function LogicalAnd(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.LogicalAnd",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "spirv.LogicalAnd", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -9275,28 +7813,18 @@ logical-equal ::= `spirv.LogicalEqual` ssa-use `,` ssa-use
 %2 = spirv.LogicalEqual %0, %1 : vector<4xi1>
 ```
 """
-function LogicalEqual(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[operand1, operand2]
+function LogicalEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.LogicalEqual",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "spirv.LogicalEqual", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -9325,28 +7853,18 @@ logical-not-equal ::= `spirv.LogicalNotEqual` ssa-use `,` ssa-use
 %2 = spirv.LogicalNotEqual %0, %1 : vector<4xi1>
 ```
 """
-function LogicalNotEqual(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[operand1, operand2]
+function LogicalNotEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.LogicalNotEqual",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "spirv.LogicalNotEqual", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -9372,25 +7890,18 @@ logical-not ::= `spirv.LogicalNot` ssa-use `:` operand-type
 %2 = spirv.LogicalNot %0 : vector<4xi1>
 ```
 """
-function LogicalNot(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
-    results = IR.Type[]
-    operands = Value[operand,]
+function LogicalNot(operand::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.LogicalNot",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "spirv.LogicalNot", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -9419,28 +7930,18 @@ logical-or ::= `spirv.LogicalOr` ssa-use `,` ssa-use
 %2 = spirv.LogicalOr %0, %1 : vector<4xi1>
 ```
 """
-function LogicalOr(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[operand1, operand2]
+function LogicalOr(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.LogicalOr",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "spirv.LogicalOr", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -9474,19 +7975,15 @@ block, except the entry block, branching to the header block.
 function mlir_loop(; loop_control, body::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[body,]
+    owned_regions = Region[body, ]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("loop_control", loop_control),]
-
-    return IR.create_operation(
-        "spirv.mlir.loop",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("loop_control", loop_control), ]
+    
+    IR.create_operation(
+        "spirv.mlir.loop", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -9519,24 +8016,18 @@ ssa-use `:` matrix-type `,` matrix-type `->` matrix-type
     !spirv.matrix<4 x vector<4xf32>>
 ```
 """
-function MatrixTimesMatrix(
-    leftmatrix::Value, rightmatrix::Value; result::IR.Type, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[leftmatrix, rightmatrix]
+function MatrixTimesMatrix(leftmatrix::Value, rightmatrix::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[leftmatrix, rightmatrix, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.MatrixTimesMatrix",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.MatrixTimesMatrix", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -9567,28 +8058,19 @@ ssa-use `:` matrix-type `,` float-type `->` matrix-type
 
 ```
 """
-function MatrixTimesScalar(
-    matrix::Value,
-    scalar::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function MatrixTimesScalar(matrix::Value, scalar::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[matrix, scalar]
+    operands = Value[matrix, scalar, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.MatrixTimesScalar",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.MatrixTimesScalar", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -9631,20 +8113,13 @@ function MemoryBarrier(; memory_scope, memory_semantics, location=Location())
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("memory_scope", memory_scope),
-        namedattribute("memory_semantics", memory_semantics),
-    ]
-
-    return IR.create_operation(
-        "spirv.MemoryBarrier",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("memory_semantics", memory_semantics), ]
+    
+    IR.create_operation(
+        "spirv.MemoryBarrier", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -9663,16 +8138,12 @@ function mlir_merge(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.mlir.merge",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.mlir.merge", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -9719,34 +8190,20 @@ spirv.module Logical Vulkan
 }
 ```
 """
-function module_(;
-    addressing_model,
-    memory_model,
-    vce_triple=nothing,
-    sym_name=nothing,
-    region_0::Region,
-    location=Location(),
-)
+function module_(; addressing_model, memory_model, vce_triple=nothing, sym_name=nothing, region_0::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[region_0,]
+    owned_regions = Region[region_0, ]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("addressing_model", addressing_model),
-        namedattribute("memory_model", memory_model),
-    ]
+    attributes = NamedAttribute[namedattribute("addressing_model", addressing_model), namedattribute("memory_model", memory_model), ]
     !isnothing(vce_triple) && push!(attributes, namedattribute("vce_triple", vce_triple))
     !isnothing(sym_name) && push!(attributes, namedattribute("sym_name", sym_name))
-
-    return IR.create_operation(
-        "spirv.module",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.module", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -9771,27 +8228,19 @@ For example:
 %0 = spirv.NV.CooperativeMatrixLength : !spirv.coopmatrix<Subgroup, i32, 8, 16>
 ```
 """
-function NV_CooperativeMatrixLength(;
-    result=nothing::Union{Nothing,IR.Type}, cooperative_matrix_type, location=Location()
-)
+function NV_CooperativeMatrixLength(; result=nothing::Union{Nothing, IR.Type}, cooperative_matrix_type, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute(
-        "cooperative_matrix_type", cooperative_matrix_type
-    ),]
+    attributes = NamedAttribute[namedattribute("cooperative_matrix_type", cooperative_matrix_type), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.NV.CooperativeMatrixLength",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.NV.CooperativeMatrixLength", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -9848,31 +8297,19 @@ For example:
      : !spirv.ptr<i32, StorageBuffer> as !spirv.coopmatrix<i32, Workgroup, 16, 8>
 ```
 """
-function NV_CooperativeMatrixLoad(
-    pointer::Value,
-    stride::Value,
-    columnmajor::Value;
-    result::IR.Type,
-    memory_access=nothing,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[pointer, stride, columnmajor]
+function NV_CooperativeMatrixLoad(pointer::Value, stride::Value, columnmajor::Value; result::IR.Type, memory_access=nothing, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[pointer, stride, columnmajor, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(memory_access) &&
-        push!(attributes, namedattribute("memory_access", memory_access))
-
-    return IR.create_operation(
-        "spirv.NV.CooperativeMatrixLoad",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(memory_access) && push!(attributes, namedattribute("memory_access", memory_access))
+    
+    IR.create_operation(
+        "spirv.NV.CooperativeMatrixLoad", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -9923,29 +8360,19 @@ For example:
   !spirv.coopmatrix<Subgroup, i32, 8, 16>
 ```
 """
-function NV_CooperativeMatrixMulAdd(
-    a::Value,
-    b::Value,
-    c::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function NV_CooperativeMatrixMulAdd(a::Value, b::Value, c::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[a, b, c]
+    operands = Value[a, b, c, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.NV.CooperativeMatrixMulAdd",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.NV.CooperativeMatrixMulAdd", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -9988,31 +8415,19 @@ For example:
     !spirv.ptr<i32, StorageBuffer>, !spirv.coopmatrix<Workgroup, i32, 16, 8>
 ```
 """
-function NV_CooperativeMatrixStore(
-    pointer::Value,
-    object::Value,
-    stride::Value,
-    columnmajor::Value;
-    memory_access=nothing,
-    location=Location(),
-)
+function NV_CooperativeMatrixStore(pointer::Value, object::Value, stride::Value, columnmajor::Value; memory_access=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[pointer, object, stride, columnmajor]
+    operands = Value[pointer, object, stride, columnmajor, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(memory_access) &&
-        push!(attributes, namedattribute("memory_access", memory_access))
-
-    return IR.create_operation(
-        "spirv.NV.CooperativeMatrixStore",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(memory_access) && push!(attributes, namedattribute("memory_access", memory_access))
+    
+    IR.create_operation(
+        "spirv.NV.CooperativeMatrixStore", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -10042,23 +8457,19 @@ Results are computed per component, and within each component, per bit.
     %3 = spirv.Not %1 : vector<4xi32>
     ```
 """
-function Not(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function Not(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.Not",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.Not", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -10089,28 +8500,18 @@ ordered-op ::= ssa-id `=` `spirv.Ordered` ssa-use, ssa-use
 %5 = spirv.Ordered %2, %3 : vector<4xf32>
 ```
 """
-function Ordered(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[operand1, operand2]
+function Ordered(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.Ordered",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "spirv.Ordered", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -10159,28 +8560,18 @@ func @ptr_access_chain(%arg0: !spirv.ptr<f32, CrossWorkgroup>, %arg1 : i64) -> (
 }
 ```
 """
-function PtrAccessChain(
-    base_ptr::Value,
-    element::Value,
-    indices::Vector{Value};
-    result::IR.Type,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[base_ptr, element, indices...]
+function PtrAccessChain(base_ptr::Value, element::Value, indices::Vector{Value}; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[base_ptr, element, indices..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.PtrAccessChain",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.PtrAccessChain", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -10204,21 +8595,17 @@ Result Type and Pointer must point to the same type.
 ```
 """
 function PtrCastToGeneric(pointer::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[pointer,]
+    results = IR.Type[result, ]
+    operands = Value[pointer, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.PtrCastToGeneric",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.PtrCastToGeneric", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -10248,21 +8635,17 @@ spv-reference-of-op ::= ssa-id `=` `spirv.mlir.referenceof` symbol-ref-id
 TODO Add support for composite specialization constants.
 """
 function mlir_referenceof(; reference::IR.Type, spec_const, location=Location())
-    results = IR.Type[reference,]
+    results = IR.Type[reference, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("spec_const", spec_const),]
-
-    return IR.create_operation(
-        "spirv.mlir.referenceof",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("spec_const", spec_const), ]
+    
+    IR.create_operation(
+        "spirv.mlir.referenceof", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -10283,16 +8666,12 @@ function Return(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.Return",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.Return", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -10319,20 +8698,16 @@ spirv.ReturnValue %0 : f32
 """
 function ReturnValue(value::Value; location=Location())
     results = IR.Type[]
-    operands = Value[value,]
+    operands = Value[value, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.ReturnValue",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.ReturnValue", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -10362,21 +8737,17 @@ s-convert-op ::= ssa-id `=` `spirv.SConvertOp` ssa-use
 ```
 """
 function SConvert(operand::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand,]
+    results = IR.Type[result, ]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.SConvert",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.SConvert", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -10408,28 +8779,19 @@ sdiv-op ::= ssa-id `=` `spirv.SDiv` ssa-use, ssa-use
 
 ```
 """
-function SDiv(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function SDiv(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand1, operand2]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.SDiv",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.SDiv", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -10472,30 +8834,19 @@ is undefined.
 %r = spirv.SDotAccSat %a, %b, %acc : (vector<4xi8>, vector<4xi8>, i32) -> i32
 ```
 """
-function SDotAccSat(
-    vector1::Value,
-    vector2::Value,
-    accumulator::Value;
-    result::IR.Type,
-    format=nothing,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[vector1, vector2, accumulator]
+function SDotAccSat(vector1::Value, vector2::Value, accumulator::Value; result::IR.Type, format=nothing, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[vector1, vector2, accumulator, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(format) && push!(attributes, namedattribute("format", format))
-
-    return IR.create_operation(
-        "spirv.SDotAccSat",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.SDotAccSat", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -10533,25 +8884,19 @@ overflow and underflow.
 %r = spirv.SDot %a, %b : (vector<4xi8>, vector<4xi8>) -> i32
 ```
 """
-function SDot(
-    vector1::Value, vector2::Value; result::IR.Type, format=nothing, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[vector1, vector2]
+function SDot(vector1::Value, vector2::Value; result::IR.Type, format=nothing, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[vector1, vector2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(format) && push!(attributes, namedattribute("format", format))
-
-    return IR.create_operation(
-        "spirv.SDot",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.SDot", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -10581,28 +8926,18 @@ sgreater-than-equal-op ::= ssa-id `=` `spirv.SGreaterThanEqual` ssa-use, ssa-use
 
 ```
 """
-function SGreaterThanEqual(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[operand1, operand2]
+function SGreaterThanEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.SGreaterThanEqual",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "spirv.SGreaterThanEqual", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -10632,28 +8967,18 @@ sgreater-than-op ::= ssa-id `=` `spirv.SGreaterThan` ssa-use, ssa-use
 
 ```
 """
-function SGreaterThan(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[operand1, operand2]
+function SGreaterThan(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.SGreaterThan",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "spirv.SGreaterThan", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -10683,28 +9008,18 @@ sless-than-equal-op ::= ssa-id `=` `spirv.SLessThanEqual` ssa-use, ssa-use
 
 ```
 """
-function SLessThanEqual(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[operand1, operand2]
+function SLessThanEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.SLessThanEqual",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "spirv.SLessThanEqual", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -10734,28 +9049,18 @@ sless-than-op ::= ssa-id `=` `spirv.SLessThan` ssa-use, ssa-use
 
 ```
 """
-function SLessThan(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[operand1, operand2]
+function SLessThan(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.SLessThan",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "spirv.SLessThan", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -10788,28 +9093,19 @@ smod-op ::= ssa-id `=` `spirv.SMod` ssa-use, ssa-use
 
 ```
 """
-function SMod(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function SMod(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand1, operand2]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.SMod",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.SMod", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -10838,24 +9134,18 @@ Member 1 of the result gets the high-order bits of the multiplication.
 %2 = spirv.SMulExtended %0, %1 : !spirv.struct<(vector<2xi32>, vector<2xi32>)>
 ```
 """
-function SMulExtended(
-    operand1::Value, operand2::Value; result::IR.Type, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[operand1, operand2]
+function SMulExtended(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.SMulExtended",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.SMulExtended", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -10879,25 +9169,19 @@ must equal the component width in Result Type.
 %3 = spirv.SNegate %2 : vector<4xi32>
 ```
 """
-function SNegate(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function SNegate(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.SNegate",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.SNegate", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -10930,28 +9214,19 @@ srem-op ::= ssa-id `=` `spirv.SRem` ssa-use, ssa-use
 
 ```
 """
-function SRem(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function SRem(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand1, operand2]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.SRem",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.SRem", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -10996,30 +9271,19 @@ is undefined.
 %r = spirv.SUDotAccSat %a, %b, %acc : (vector<4xi8>, vector<4xi8>, i32) -> i32
 ```
 """
-function SUDotAccSat(
-    vector1::Value,
-    vector2::Value,
-    accumulator::Value;
-    result::IR.Type,
-    format=nothing,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[vector1, vector2, accumulator]
+function SUDotAccSat(vector1::Value, vector2::Value, accumulator::Value; result::IR.Type, format=nothing, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[vector1, vector2, accumulator, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(format) && push!(attributes, namedattribute("format", format))
-
-    return IR.create_operation(
-        "spirv.SUDotAccSat",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.SUDotAccSat", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -11059,25 +9323,19 @@ avoid overflow and underflow.
 %r = spirv.SUDot %a, %b : (vector<4xi8>, vector<4xi8>) -> i32
 ```
 """
-function SUDot(
-    vector1::Value, vector2::Value; result::IR.Type, format=nothing, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[vector1, vector2]
+function SUDot(vector1::Value, vector2::Value; result::IR.Type, format=nothing, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[vector1, vector2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(format) && push!(attributes, namedattribute("format", format))
-
-    return IR.create_operation(
-        "spirv.SUDot",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.SUDot", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -11120,29 +9378,19 @@ select-op ::= ssa-id `=` `spirv.Select` ssa-use, ssa-use, ssa-use
 %3 = spirv.Select %0, %1, %2 : vector<3xi1>, vector<3xf32>
 ```
 """
-function Select(
-    condition::Value,
-    true_value::Value,
-    false_value::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function Select(condition::Value, true_value::Value, false_value::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[condition, true_value, false_value]
+    operands = Value[condition, true_value, false_value, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.Select",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.Select", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -11170,19 +9418,15 @@ The merge block should only contain a `spirv.mlir.merge` op.
 function mlir_selection(; selection_control, body::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[body,]
+    owned_regions = Region[body, ]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("selection_control", selection_control),]
-
-    return IR.create_operation(
-        "spirv.mlir.selection",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("selection_control", selection_control), ]
+    
+    IR.create_operation(
+        "spirv.mlir.selection", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -11222,28 +9466,19 @@ shift-left-logical-op ::= ssa-id `=` `spirv.ShiftLeftLogical`
 %5 = spirv.ShiftLeftLogical %3, %4 : vector<3xi32>, vector<3xi16>
 ```
 """
-function ShiftLeftLogical(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function ShiftLeftLogical(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand1, operand2]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.ShiftLeftLogical",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.ShiftLeftLogical", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -11280,28 +9515,19 @@ shift-right-arithmetic-op ::= ssa-id `=` `spirv.ShiftRightArithmetic`
 %5 = spirv.ShiftRightArithmetic %3, %4 : vector<3xi32>, vector<3xi16>
 ```
 """
-function ShiftRightArithmetic(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function ShiftRightArithmetic(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand1, operand2]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.ShiftRightArithmetic",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.ShiftRightArithmetic", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -11339,28 +9565,19 @@ shift-right-logical-op ::= ssa-id `=` `spirv.ShiftRightLogical`
 %5 = spirv.ShiftRightLogical %3, %4 : vector<3xi32>, vector<3xi16>
 ```
 """
-function ShiftRightLogical(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function ShiftRightLogical(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand1, operand2]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.ShiftRightLogical",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.ShiftRightLogical", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -11405,21 +9622,13 @@ function SpecConstantComposite(; type, sym_name, constituents, location=Location
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("type", type),
-        namedattribute("sym_name", sym_name),
-        namedattribute("constituents", constituents),
-    ]
-
-    return IR.create_operation(
-        "spirv.SpecConstantComposite",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("type", type), namedattribute("sym_name", sym_name), namedattribute("constituents", constituents), ]
+    
+    IR.create_operation(
+        "spirv.SpecConstantComposite", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -11459,19 +9668,13 @@ function SpecConstant(; sym_name, default_value, location=Location())
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("sym_name", sym_name), namedattribute("default_value", default_value)
-    ]
-
-    return IR.create_operation(
-        "spirv.SpecConstant",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("sym_name", sym_name), namedattribute("default_value", default_value), ]
+    
+    IR.create_operation(
+        "spirv.SpecConstant", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -11545,21 +9748,17 @@ TODO Add capability-specific ops when supported.
 ```
 """
 function SpecConstantOperation(; result::IR.Type, body::Region, location=Location())
-    results = IR.Type[result,]
+    results = IR.Type[result, ]
     operands = Value[]
-    owned_regions = Region[body,]
+    owned_regions = Region[body, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.SpecConstantOperation",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.SpecConstantOperation", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -11592,27 +9791,20 @@ spirv.Store \"Function\" %0, %1 [\"Volatile\"] : f32
 spirv.Store \"Function\" %0, %1 [\"Aligned\", 4] : f32
 ```
 """
-function Store(
-    ptr::Value, value::Value; memory_access=nothing, alignment=nothing, location=Location()
-)
+function Store(ptr::Value, value::Value; memory_access=nothing, alignment=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[ptr, value]
+    operands = Value[ptr, value, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(memory_access) &&
-        push!(attributes, namedattribute("memory_access", memory_access))
+    !isnothing(memory_access) && push!(attributes, namedattribute("memory_access", memory_access))
     !isnothing(alignment) && push!(attributes, namedattribute("alignment", alignment))
-
-    return IR.create_operation(
-        "spirv.Store",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.Store", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -11645,21 +9837,17 @@ matrix-type
 ```
 """
 function Transpose(matrix::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[matrix,]
+    results = IR.Type[result, ]
+    operands = Value[matrix, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.Transpose",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.Transpose", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -11690,21 +9878,17 @@ u-convert-op ::= ssa-id `=` `spirv.UConvertOp` ssa-use
 ```
 """
 function UConvert(operand::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand,]
+    results = IR.Type[result, ]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.UConvert",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.UConvert", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -11735,28 +9919,19 @@ udiv-op ::= ssa-id `=` `spirv.UDiv` ssa-use, ssa-use
 
 ```
 """
-function UDiv(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function UDiv(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand1, operand2]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.UDiv",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.UDiv", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -11801,30 +9976,19 @@ is undefined.
 %r = spirv.UDotAccSat %a, %b, %acc : (vector<4xi8>, vector<4xi8>, i32) -> i32
 ```
 """
-function UDotAccSat(
-    vector1::Value,
-    vector2::Value,
-    accumulator::Value;
-    result::IR.Type,
-    format=nothing,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[vector1, vector2, accumulator]
+function UDotAccSat(vector1::Value, vector2::Value, accumulator::Value; result::IR.Type, format=nothing, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[vector1, vector2, accumulator, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(format) && push!(attributes, namedattribute("format", format))
-
-    return IR.create_operation(
-        "spirv.UDotAccSat",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.UDotAccSat", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -11864,25 +10028,19 @@ overflow and underflow.
 %r = spirv.UDot %a, %b : (vector<4xi8>, vector<4xi8>) -> i32
 ```
 """
-function UDot(
-    vector1::Value, vector2::Value; result::IR.Type, format=nothing, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[vector1, vector2]
+function UDot(vector1::Value, vector2::Value; result::IR.Type, format=nothing, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[vector1, vector2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(format) && push!(attributes, namedattribute("format", format))
-
-    return IR.create_operation(
-        "spirv.UDot",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.UDot", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -11912,28 +10070,18 @@ ugreater-than-equal-op ::= ssa-id `=` `spirv.UGreaterThanEqual` ssa-use, ssa-use
 
 ```
 """
-function UGreaterThanEqual(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[operand1, operand2]
+function UGreaterThanEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.UGreaterThanEqual",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "spirv.UGreaterThanEqual", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -11963,28 +10111,18 @@ ugreater-than-op ::= ssa-id `=` `spirv.UGreaterThan` ssa-use, ssa-use
 
 ```
 """
-function UGreaterThan(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[operand1, operand2]
+function UGreaterThan(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.UGreaterThan",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "spirv.UGreaterThan", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -12014,28 +10152,18 @@ uless-than-equal-op ::= ssa-id `=` `spirv.ULessThanEqual` ssa-use, ssa-use
 
 ```
 """
-function ULessThanEqual(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[operand1, operand2]
+function ULessThanEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.ULessThanEqual",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "spirv.ULessThanEqual", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -12065,28 +10193,18 @@ uless-than-op ::= ssa-id `=` `spirv.ULessThan` ssa-use, ssa-use
 
 ```
 """
-function ULessThan(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[operand1, operand2]
+function ULessThan(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.ULessThan",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "spirv.ULessThan", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -12117,28 +10235,19 @@ umod-op ::= ssa-id `=` `spirv.UMod` ssa-use, ssa-use
 
 ```
 """
-function UMod(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function UMod(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand1, operand2]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.UMod",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.UMod", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -12168,24 +10277,18 @@ Member 1 of the result gets the high-order bits of the multiplication.
 %2 = spirv.UMulExtended %0, %1 : !spirv.struct<(vector<2xi32>, vector<2xi32>)>
 ```
 """
-function UMulExtended(
-    operand1::Value, operand2::Value; result::IR.Type, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[operand1, operand2]
+function UMulExtended(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.UMulExtended",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.UMulExtended", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -12212,21 +10315,17 @@ undef-op ::= `spirv.Undef` `:` spirv-type
 ```
 """
 function Undef(; result::IR.Type, location=Location())
-    results = IR.Type[result,]
+    results = IR.Type[result, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.Undef",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.Undef", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -12257,28 +10356,18 @@ unordered-op ::= ssa-id `=` `spirv.Unordered` ssa-use, ssa-use
 %5 = spirv.Unordered %2, %3 : vector<4xf32>
 ```
 """
-function Unordered(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[operand1, operand2]
+function Unordered(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.Unordered",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "spirv.Unordered", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -12299,16 +10388,12 @@ function Unreachable(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.Unreachable",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.Unreachable", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -12346,28 +10431,19 @@ where `init` specifies initializer.
 %2 = spirv.Variable init(%0): !spirv.ptr<f32, Function>
 ```
 """
-function Variable(
-    initializer=nothing::Union{Nothing,Value};
-    pointer::IR.Type,
-    storage_class,
-    location=Location(),
-)
-    results = IR.Type[pointer,]
+function Variable(initializer=nothing::Union{Nothing, Value}; pointer::IR.Type, storage_class, location=Location())
+    results = IR.Type[pointer, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("storage_class", storage_class),]
+    attributes = NamedAttribute[namedattribute("storage_class", storage_class), ]
     !isnothing(initializer) && push!(operands, initializer)
-
-    return IR.create_operation(
-        "spirv.Variable",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.Variable", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -12393,25 +10469,18 @@ or equal to the number of components in Vector.
 %2 = spirv.VectorExtractDynamic %0[%1] : vector<8xf32>, i32
 ```
 """
-function VectorExtractDynamic(
-    vector::Value, index::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
-    results = IR.Type[]
-    operands = Value[vector, index]
+function VectorExtractDynamic(vector::Value, index::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[vector, index, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.VectorExtractDynamic",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "spirv.VectorExtractDynamic", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -12449,29 +10518,19 @@ vector-insert-dynamic-op ::= `spirv.VectorInsertDynamic ` ssa-use `,`
 %2 = spirv.VectorInsertDynamic %scalar %0[%1] : f32, vector<8xf32>, i32
 ```
 """
-function VectorInsertDynamic(
-    vector::Value,
-    component::Value,
-    index::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function VectorInsertDynamic(vector::Value, component::Value, index::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[vector, component, index]
+    operands = Value[vector, component, index, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.VectorInsertDynamic",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.VectorInsertDynamic", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -12512,24 +10571,18 @@ operands, or using an OpUndef for one of the Vector operands.
                     -> vector<3xf32>
 ```
 """
-function VectorShuffle(
-    vector1::Value, vector2::Value; result::IR.Type, components, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[vector1, vector2]
+function VectorShuffle(vector1::Value, vector2::Value; result::IR.Type, components, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[vector1, vector2, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("components", components),]
-
-    return IR.create_operation(
-        "spirv.VectorShuffle",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("components", components), ]
+    
+    IR.create_operation(
+        "spirv.VectorShuffle", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -12551,24 +10604,18 @@ Scalar must have the same type as the Component Type in Result Type.
 %0 = spirv.VectorTimesScalar %vector, %scalar : vector<4xf32>
 ```
 """
-function VectorTimesScalar(
-    vector::Value, scalar::Value; result::IR.Type, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[vector, scalar]
+function VectorTimesScalar(vector::Value, scalar::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[vector, scalar, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.VectorTimesScalar",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.VectorTimesScalar", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -12593,20 +10640,16 @@ spirv.mlir.yield %0
 """
 function mlir_yield(operand::Value; location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.mlir.yield",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.mlir.yield", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/16/Shape.jl
+++ b/src/Dialects/16/Shape.jl
@@ -1,8 +1,8 @@
 module shape
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `add`
@@ -14,25 +14,19 @@ at least one of the operands can hold an error, i.e. if it is of type
 possible because both operands are of type `index` then the result may be
 of type `size` or `index`.
 """
-function add(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function add(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "shape.add",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.add", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -53,21 +47,17 @@ inputs have differing ranks or differ in extents of shared dimensions.
 ```
 """
 function any(inputs::Vector{Value}; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[inputs...,]
+    results = IR.Type[result, ]
+    operands = Value[inputs..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "shape.any",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.any", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -91,25 +81,19 @@ ready to execute.
 %wt = shape.assuming_all %w0, %w2 // Passing
 ```
 """
-function assuming_all(
-    inputs::Vector{Value}; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function assuming_all(inputs::Vector{Value}; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[inputs...,]
+    operands = Value[inputs..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "shape.assuming_all",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.assuming_all", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -123,24 +107,18 @@ compiler, information for dependent code to rely on (by assuming), and
 nothing else. They should not exist after a program is fully lowered and
 ready to execute.
 """
-function assuming(
-    witness::Value; results::Vector{IR.Type}, doRegion::Region, location=Location()
-)
-    results = IR.Type[results...,]
-    operands = Value[witness,]
-    owned_regions = Region[doRegion,]
+function assuming(witness::Value; results_::Vector{IR.Type}, doRegion::Region, location=Location())
+    results = IR.Type[results_..., ]
+    operands = Value[witness, ]
+    owned_regions = Region[doRegion, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "shape.assuming",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.assuming", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -152,22 +130,18 @@ This yield operation represents a return operation within the
 operands and produces no results. The operand number and types must match
 the number and types of parent `shape.assuming` results.
 """
-function assuming_yield(operands::Vector{Value}; location=Location())
+function assuming_yield(operands_::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[operands...,]
+    operands = Value[operands_..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "shape.assuming_yield",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.assuming_yield", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -194,25 +168,19 @@ value. If the result type is an extent tensor (and can therefore not hold
 the error value) the behavior may be undefined. The optional string
 attribute can be used to describe the error case.
 """
-function broadcast(
-    shapes::Vector{Value}; result::IR.Type, error=nothing, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[shapes...,]
+function broadcast(shapes::Vector{Value}; result::IR.Type, error=nothing, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[shapes..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(error) && push!(attributes, namedattribute("error", error))
-
-    return IR.create_operation(
-        "shape.broadcast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.broadcast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -228,21 +196,17 @@ concat([], []) -> []
 concat([], [4,5,6]) -> [4,5,6]
 """
 function concat(lhs::Value, rhs::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[lhs, rhs]
+    results = IR.Type[result, ]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "shape.concat",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.concat", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -259,23 +223,19 @@ rank.
 %2 = shape.const_shape [4, 5, 6] : tensor<3xindex>
 ```
 """
-function const_shape(; result=nothing::Union{Nothing,IR.Type}, shape, location=Location())
+function const_shape(; result=nothing::Union{Nothing, IR.Type}, shape, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("shape", shape),]
+    attributes = NamedAttribute[namedattribute("shape", shape), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "shape.const_shape",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.const_shape", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -288,23 +248,19 @@ Creates a `shape.size` type representing the constant size given by `value`.
 %x = shape.const_size 10
 ```
 """
-function const_size(; result=nothing::Union{Nothing,IR.Type}, value, location=Location())
+function const_size(; result=nothing::Union{Nothing, IR.Type}, value, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("value", value),]
+    attributes = NamedAttribute[namedattribute("value", value), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "shape.const_size",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.const_size", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -323,25 +279,19 @@ pass.
 %w2 = shape.assuming_all(%w0, %w2) // Can be folded to \"const_witness true\"
 ```
 """
-function const_witness(;
-    result=nothing::Union{Nothing,IR.Type}, passing, location=Location()
-)
+function const_witness(; result=nothing::Union{Nothing, IR.Type}, passing, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("passing", passing),]
+    attributes = NamedAttribute[namedattribute("passing", passing), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "shape.const_witness",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.const_witness", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -360,25 +310,19 @@ shape.broadcast documents.
 %w1 = shape.cstr_broadcastable [2,2], [3,2] // Failure
 ```
 """
-function cstr_broadcastable(
-    shapes::Vector{Value}; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function cstr_broadcastable(shapes::Vector{Value}; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[shapes...,]
+    operands = Value[shapes..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "shape.cstr_broadcastable",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.cstr_broadcastable", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -395,25 +339,19 @@ Given 1 or more input shapes, determine if all shapes are the exact same.
 %w1 = shape.cstr_eq [2,2], [1,2] // Failure
 ```
 """
-function cstr_eq(
-    shapes::Vector{Value}; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function cstr_eq(shapes::Vector{Value}; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[shapes...,]
+    operands = Value[shapes..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "shape.cstr_eq",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.cstr_eq", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -436,25 +374,19 @@ Since this op can be used to express many different possible assertions
 (depending on whatever computation calculated `pred`), the `msg`
 should clarify the nature of the assertion for users.
 """
-function cstr_require(
-    pred::Value; result=nothing::Union{Nothing,IR.Type}, msg, location=Location()
-)
+function cstr_require(pred::Value; result=nothing::Union{Nothing, IR.Type}, msg, location=Location())
     results = IR.Type[]
-    operands = Value[pred,]
+    operands = Value[pred, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("msg", msg),]
+    attributes = NamedAttribute[namedattribute("msg", msg), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "shape.cstr_require",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.cstr_require", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -466,21 +398,17 @@ Prints the input dim or shape and passes through input.
 Note: This is intended for testing and debugging only.
 """
 function debug_print(input::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input,]
+    results = IR.Type[output, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "shape.debug_print",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.debug_print", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -494,25 +422,19 @@ return type carries error information else the behavior is undefined.
 This is a convenience op that performs the equivalent of getting the extent
 of a shape (e.g., `dim(x, i) == get_extent(shape_of(x), i)`).
 """
-function dim(
-    value::Value, index::Value; extent=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function dim(value::Value, index::Value; extent=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[value, index]
+    operands = Value[value, index, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(extent) && push!(results, extent)
-
-    return IR.create_operation(
-        "shape.dim",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.dim", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -533,25 +455,19 @@ toward negative infinity, i.e. floor(lhs / rhs), such that
 always holds. If any of the values is of type `size`, the behavior for
 negative value is undefined.
 """
-function div(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function div(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "shape.div",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.div", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -562,25 +478,19 @@ Creates a shape from a 1D integral tensor of extents. The rank of the
 resulting shape equals the number of elements in the tensor, and the
 extents match the values of the elements.
 """
-function from_extent_tensor(
-    input::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function from_extent_tensor(input::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[input,]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "shape.from_extent_tensor",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.from_extent_tensor", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -597,25 +507,19 @@ the shape.
 %s1 = shape.from_extents
 ```
 """
-function from_extents(
-    extents::Vector{Value}; shape=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function from_extents(extents::Vector{Value}; shape=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[extents...,]
+    operands = Value[extents..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(shape) && push!(results, shape)
-
-    return IR.create_operation(
-        "shape.from_extents",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.from_extents", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -626,36 +530,21 @@ An operation with a name containing a single `SSACFG` region which
 represents a shape transfer function or helper function for shape transfer
 function.
 """
-function func(;
-    sym_name,
-    function_type,
-    arg_attrs=nothing,
-    res_attrs=nothing,
-    sym_visibility=nothing,
-    body::Region,
-    location=Location(),
-)
+function func(; sym_name, function_type, arg_attrs=nothing, res_attrs=nothing, sym_visibility=nothing, body::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[body,]
+    owned_regions = Region[body, ]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("sym_name", sym_name), namedattribute("function_type", function_type)
-    ]
+    attributes = NamedAttribute[namedattribute("sym_name", sym_name), namedattribute("function_type", function_type), ]
     !isnothing(arg_attrs) && push!(attributes, namedattribute("arg_attrs", arg_attrs))
     !isnothing(res_attrs) && push!(attributes, namedattribute("res_attrs", res_attrs))
-    !isnothing(sym_visibility) &&
-        push!(attributes, namedattribute("sym_visibility", sym_visibility))
-
-    return IR.create_operation(
-        "shape.func",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(sym_visibility) && push!(attributes, namedattribute("sym_visibility", sym_visibility))
+    
+    IR.create_operation(
+        "shape.func", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -678,28 +567,19 @@ shape.function_library {
 }
 ```
 """
-function function_library(;
-    sym_name, sym_visibility=nothing, mapping, body::Region, location=Location()
-)
+function function_library(; sym_name, sym_visibility=nothing, mapping, body::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[body,]
+    owned_regions = Region[body, ]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("sym_name", sym_name), namedattribute("mapping", mapping)
-    ]
-    !isnothing(sym_visibility) &&
-        push!(attributes, namedattribute("sym_visibility", sym_visibility))
-
-    return IR.create_operation(
-        "shape.function_library",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("sym_name", sym_name), namedattribute("mapping", mapping), ]
+    !isnothing(sym_visibility) && push!(attributes, namedattribute("sym_visibility", sym_visibility))
+    
+    IR.create_operation(
+        "shape.function_library", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -709,25 +589,19 @@ end
 Gets the extent indexed by `dim` from the `shape` operand. If the shape is
 an error then it returns an invalid size.
 """
-function get_extent(
-    shape::Value, dim::Value; extent=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function get_extent(shape::Value, dim::Value; extent=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[shape, dim]
+    operands = Value[shape, dim, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(extent) && push!(results, extent)
-
-    return IR.create_operation(
-        "shape.get_extent",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.get_extent", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -740,25 +614,19 @@ and the shape dialect.
 
 The behavior is undefined for negative indices.
 """
-function index_to_size(
-    arg::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function index_to_size(arg::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[arg,]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "shape.index_to_size",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.index_to_size", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -780,25 +648,19 @@ assertion failure.
 %false = shape.is_broadcastable [2,2], [3,2]
 ```
 """
-function is_broadcastable(
-    shapes::Vector{Value}; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function is_broadcastable(shapes::Vector{Value}; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[shapes...,]
+    operands = Value[shapes..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "shape.is_broadcastable",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.is_broadcastable", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -810,25 +672,19 @@ If either operand is an error, then an error will be propagated to the
 result. If the input types mismatch or the ranks do not match, then the
 result is an error.
 """
-function max(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function max(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "shape.max",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.max", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -859,30 +715,20 @@ used to return an error to the user upon mismatch of dimensions.
 %c = shape.meet %a, %b, error=\"<reason>\" : !shape.shape, !shape.shape -> !shape.shape
 ```
 """
-function meet(
-    arg0::Value,
-    arg1::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    error=nothing,
-    location=Location(),
-)
+function meet(arg0::Value, arg1::Value; result=nothing::Union{Nothing, IR.Type}, error=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[arg0, arg1]
+    operands = Value[arg0, arg1, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(error) && push!(attributes, namedattribute("error", error))
-
-    return IR.create_operation(
-        "shape.meet",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.meet", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -894,25 +740,19 @@ If either operand is an error, then an error will be propagated to the
 result. If the input types mismatch or the ranks do not match, then the
 result is an error.
 """
-function min(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function min(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "shape.min",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.min", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -926,25 +766,19 @@ at least one of the operands can hold an error, i.e. if it is of type
 possible because both operands are of type `index` then the result may be
 of type `size` or `index`.
 """
-function mul(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function mul(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "shape.mul",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.mul", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -957,25 +791,19 @@ type `size` and potential errors will be propagated. Otherwise, if the
 argument is and extent tensor `tensor<?xindex>` then the result will be of
 type `index`.
 """
-function num_elements(
-    shape::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function num_elements(shape::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[shape,]
+    operands = Value[shape, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "shape.num_elements",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.num_elements", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -984,23 +812,19 @@ end
 
 Returns the rank of the shape or extent tensor, i.e. the number of extents.
 """
-function rank(shape::Value; rank=nothing::Union{Nothing,IR.Type}, location=Location())
+function rank(shape::Value; rank=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[shape,]
+    operands = Value[shape, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(rank) && push!(results, rank)
-
-    return IR.create_operation(
-        "shape.rank",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.rank", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1038,28 +862,18 @@ func.func @reduce(%shape : !shape.shape, %init : !shape.size) ->
 }
 ```
 """
-function reduce(
-    shape::Value,
-    initVals::Vector{Value};
-    result::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result...,]
-    operands = Value[shape, initVals...]
-    owned_regions = Region[region,]
+function reduce(shape::Value, initVals::Vector{Value}; result::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[result..., ]
+    operands = Value[shape, initVals..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "shape.reduce",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.reduce", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1070,22 +884,18 @@ The `shape.return` operation represents a return operation within a
 function.  The operation takes variable number of operands and produces no
 results.
 """
-function return_(operands::Vector{Value}; location=Location())
+function return_(operands_::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[operands...,]
+    operands = Value[operands_..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "shape.return",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.return", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1098,25 +908,19 @@ regarded as their equivalent non-error shapes. Error shapes can be tested
 for equality like any other shape value, meaning that the error value is
 equal to itself.
 """
-function shape_eq(
-    shapes::Vector{Value}; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function shape_eq(shapes::Vector{Value}; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[shapes...,]
+    operands = Value[shapes..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "shape.shape_eq",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.shape_eq", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1126,23 +930,19 @@ end
 The operation takes a value or a shaped operand as an argument and it
 returns a shape or extent tensor.
 """
-function shape_of(arg::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function shape_of(arg::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[arg,]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "shape.shape_of",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.shape_of", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1154,25 +954,19 @@ inverse, `index_to_size`, facilitate index conversion between the standard
 and the shape dialect. The behavior is undefined for unknown and invalid
 arguments.
 """
-function size_to_index(
-    arg::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function size_to_index(arg::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[arg,]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "shape.size_to_index",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.size_to_index", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1200,24 +994,18 @@ Examples:
 Requires:
 - `index` is in the range [-rank(operand),rank(operand)]
 """
-function split_at(
-    operand::Value, index::Value; head::IR.Type, tail::IR.Type, location=Location()
-)
-    results = IR.Type[head, tail]
-    operands = Value[operand, index]
+function split_at(operand::Value, index::Value; head::IR.Type, tail::IR.Type, location=Location())
+    results = IR.Type[head, tail, ]
+    operands = Value[operand, index, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "shape.split_at",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.split_at", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1231,21 +1019,17 @@ extents of the shape.
 If the shape represents an error, this op\'s behavior is undefined.
 """
 function to_extent_tensor(input::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[input,]
+    results = IR.Type[result, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "shape.to_extent_tensor",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.to_extent_tensor", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1268,21 +1052,17 @@ E.g.,
 This operation is the complement of `shape_of` wrt ValueShape values.
 """
 function value_as_shape(arg::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[arg,]
+    results = IR.Type[result, ]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "shape.value_as_shape",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.value_as_shape", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1294,21 +1074,17 @@ argument, and returns its value. The behavior is undefined for unknown and
 invalid arguments.
 """
 function value_of(arg::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[arg,]
+    results = IR.Type[result, ]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "shape.value_of",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.value_of", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1347,28 +1123,19 @@ the result may be less specified than `operand`\'s shape as `shape` is
 merely used to construct the new ValueShape. If join behavior is desired
 then a join op should be used.
 """
-function with_shape(
-    operand::Value,
-    shape::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function with_shape(operand::Value, shape::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand, shape]
+    operands = Value[operand, shape, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "shape.with_shape",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.with_shape", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1376,22 +1143,18 @@ end
 `yield`
 
 """
-function yield(operands::Vector{Value}; location=Location())
+function yield(operands_::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[operands...,]
+    operands = Value[operands_..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "shape.yield",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.yield", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/16/SparseTensor.jl
+++ b/src/Dialects/16/SparseTensor.jl
@@ -1,8 +1,8 @@
 module sparse_tensor
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `binary`
@@ -105,36 +105,20 @@ because we never use its values, only its sparse structure:
 } -> tensor<?x?xf64, #CSR>
 ```
 """
-function binary(
-    x::Value,
-    y::Value;
-    output::IR.Type,
-    left_identity=nothing,
-    right_identity=nothing,
-    overlapRegion::Region,
-    leftRegion::Region,
-    rightRegion::Region,
-    location=Location(),
-)
-    results = IR.Type[output,]
-    operands = Value[x, y]
-    owned_regions = Region[overlapRegion, leftRegion, rightRegion]
+function binary(x::Value, y::Value; output::IR.Type, left_identity=nothing, right_identity=nothing, overlapRegion::Region, leftRegion::Region, rightRegion::Region, location=Location())
+    results = IR.Type[output, ]
+    operands = Value[x, y, ]
+    owned_regions = Region[overlapRegion, leftRegion, rightRegion, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(left_identity) &&
-        push!(attributes, namedattribute("left_identity", left_identity))
-    !isnothing(right_identity) &&
-        push!(attributes, namedattribute("right_identity", right_identity))
-
-    return IR.create_operation(
-        "sparse_tensor.binary",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(left_identity) && push!(attributes, namedattribute("left_identity", left_identity))
+    !isnothing(right_identity) && push!(attributes, namedattribute("right_identity", right_identity))
+    
+    IR.create_operation(
+        "sparse_tensor.binary", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -161,32 +145,19 @@ done \"in place\", and referencing the old SSA value is undefined behavior.
   : memref<?xf64>, memref<?xi1>, memref<?xindex>, tensor<4x4xf64, #CSR>
 ```
 """
-function compress(
-    values::Value,
-    filled::Value,
-    added::Value,
-    count::Value,
-    tensor::Value,
-    indices::Vector{Value};
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function compress(values::Value, filled::Value, added::Value, count::Value, tensor::Value, indices::Vector{Value}; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[values, filled, added, count, tensor, indices...]
+    operands = Value[values, filled, added, count, tensor, indices..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "sparse_tensor.compress",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "sparse_tensor.compress", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -210,21 +181,17 @@ can be dynamically-sized.
 ```
 """
 function concatenate(inputs::Vector{Value}; result::IR.Type, dimension, location=Location())
-    results = IR.Type[result,]
-    operands = Value[inputs...,]
+    results = IR.Type[result, ]
+    operands = Value[inputs..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("dimension", dimension),]
-
-    return IR.create_operation(
-        "sparse_tensor.concatenate",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("dimension", dimension), ]
+    
+    IR.create_operation(
+        "sparse_tensor.concatenate", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -268,21 +235,17 @@ Examples:
 ```
 """
 function convert(source::Value; dest::IR.Type, location=Location())
-    results = IR.Type[dest,]
-    operands = Value[source,]
+    results = IR.Type[dest, ]
+    operands = Value[source, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "sparse_tensor.convert",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "sparse_tensor.convert", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -318,29 +281,18 @@ side-effecting context that sets and resets the expanded arrays.
   : tensor<4x4xf64, #CSR> to memref<?xf64>, memref<?xi1>, memref<?xindex>
 ```
 """
-function expand(
-    tensor::Value;
-    values::IR.Type,
-    filled::IR.Type,
-    added::IR.Type,
-    count::IR.Type,
-    location=Location(),
-)
-    results = IR.Type[values, filled, added, count]
-    operands = Value[tensor,]
+function expand(tensor::Value; values::IR.Type, filled::IR.Type, added::IR.Type, count::IR.Type, location=Location())
+    results = IR.Type[values, filled, added, count, ]
+    operands = Value[tensor, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "sparse_tensor.expand",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "sparse_tensor.expand", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -406,28 +358,18 @@ sparse_tensor.foreach in %0 : tensor<2x3xf64, #ROW_MAJOR> do {
 
 ```
 """
-function foreach(
-    tensor::Value,
-    initArgs::Vector{Value};
-    results::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[results...,]
-    operands = Value[tensor, initArgs...]
-    owned_regions = Region[region,]
+function foreach(tensor::Value, initArgs::Vector{Value}; results_::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[results_..., ]
+    operands = Value[tensor, initArgs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "sparse_tensor.foreach",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "sparse_tensor.foreach", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -443,25 +385,19 @@ Example of querying the size of the index array for level 0:
      : !sparse_tensor.storage_specifier<#COO> to i64
 ```
 """
-function storage_specifier_get(
-    specifier::Value; result::IR.Type, specifierKind, dim=nothing, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[specifier,]
+function storage_specifier_get(specifier::Value; result::IR.Type, specifierKind, dim=nothing, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[specifier, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("specifierKind", specifierKind),]
+    attributes = NamedAttribute[namedattribute("specifierKind", specifierKind), ]
     !isnothing(dim) && push!(attributes, namedattribute("dim", dim))
-
-    return IR.create_operation(
-        "sparse_tensor.storage_specifier.get",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "sparse_tensor.storage_specifier.get", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -495,29 +431,19 @@ This operation is scheduled to be unified with the dense counterpart
 %result = sparse_tensor.insert %val into %tensor[%i,%j] : tensor<1024x1024xf64, #CSR>
 ```
 """
-function insert(
-    value::Value,
-    tensor::Value,
-    indices::Vector{Value};
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function insert(value::Value, tensor::Value, indices::Vector{Value}; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[value, tensor, indices...]
+    operands = Value[value, tensor, indices..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "sparse_tensor.insert",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "sparse_tensor.insert", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -549,29 +475,20 @@ Examples:
 %1 = sparse_tensor.load %0 hasInserts : tensor<16x32xf32, #CSR>
 ```
 """
-function load(
-    tensor::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    hasInserts=nothing,
-    location=Location(),
-)
+function load(tensor::Value; result=nothing::Union{Nothing, IR.Type}, hasInserts=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[tensor,]
+    operands = Value[tensor, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(hasInserts) && push!(attributes, namedattribute("hasInserts", hasInserts))
-
-    return IR.create_operation(
-        "sparse_tensor.load",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "sparse_tensor.load", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -601,23 +518,18 @@ sparse_tensor.new %source : !Source to tensor<1024x1024xf64, #CSR>
 ```
 """
 function new(source::Value; result::IR.Type, expandSymmetry=nothing, location=Location())
-    results = IR.Type[result,]
-    operands = Value[source,]
+    results = IR.Type[result, ]
+    operands = Value[source, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(expandSymmetry) &&
-        push!(attributes, namedattribute("expandSymmetry", expandSymmetry))
-
-    return IR.create_operation(
-        "sparse_tensor.new",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(expandSymmetry) && push!(attributes, namedattribute("expandSymmetry", expandSymmetry))
+    
+    IR.create_operation(
+        "sparse_tensor.new", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -635,25 +547,19 @@ accurate nomenclature is used.
 %noe = sparse_tensor.number_of_entries %tensor : tensor<64x64xf64, #CSR>
 ```
 """
-function number_of_entries(
-    tensor::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function number_of_entries(tensor::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[tensor,]
+    operands = Value[tensor, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "sparse_tensor.number_of_entries",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "sparse_tensor.number_of_entries", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -678,20 +584,16 @@ sparse_tensor.out %t, %dest : tensor<1024x1024xf64, #CSR>, !Dest
 """
 function out(tensor::Value, dest::Value; location=Location())
     results = IR.Type[]
-    operands = Value[tensor, dest]
+    operands = Value[tensor, dest, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "sparse_tensor.out",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "sparse_tensor.out", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -739,18 +641,9 @@ through the old SSA value after this operation is undefined behavior.
    : xindex, memref<?xf64>, f64
 ```
 """
-function push_back(
-    curSize::Value,
-    inBuffer::Value,
-    value::Value,
-    n=nothing::Union{Nothing,Value};
-    outBuffer=nothing::Union{Nothing,IR.Type},
-    newSize=nothing::Union{Nothing,IR.Type},
-    inbounds=nothing,
-    location=Location(),
-)
+function push_back(curSize::Value, inBuffer::Value, value::Value, n=nothing::Union{Nothing, Value}; outBuffer=nothing::Union{Nothing, IR.Type}, newSize=nothing::Union{Nothing, IR.Type}, inbounds=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[curSize, inBuffer, value]
+    operands = Value[curSize, inBuffer, value, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
@@ -758,16 +651,12 @@ function push_back(
     !isnothing(outBuffer) && push!(results, outBuffer)
     !isnothing(newSize) && push!(results, newSize)
     !isnothing(inbounds) && push!(attributes, namedattribute("inbounds", inbounds))
-
-    return IR.create_operation(
-        "sparse_tensor.push_back",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "sparse_tensor.push_back", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -809,30 +698,19 @@ Example of Matrix->Vector reduction using max(product(x_i), 100):
 } -> tensor<?xf64, #SparseVector>
 ```
 """
-function reduce(
-    x::Value,
-    y::Value,
-    identity::Value;
-    output=nothing::Union{Nothing,IR.Type},
-    region::Region,
-    location=Location(),
-)
+function reduce(x::Value, y::Value, identity::Value; output=nothing::Union{Nothing, IR.Type}, region::Region, location=Location())
     results = IR.Type[]
-    operands = Value[x, y, identity]
-    owned_regions = Region[region,]
+    operands = Value[x, y, identity, ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(output) && push!(results, output)
-
-    return IR.create_operation(
-        "sparse_tensor.reduce",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "sparse_tensor.reduce", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -886,25 +764,19 @@ Example of selecting lower triangle of a matrix:
 } -> tensor<?x?xf64, #CSR>
 ```
 """
-function select(
-    x::Value; output=nothing::Union{Nothing,IR.Type}, region::Region, location=Location()
-)
+function select(x::Value; output=nothing::Union{Nothing, IR.Type}, region::Region, location=Location())
     results = IR.Type[]
-    operands = Value[x,]
-    owned_regions = Region[region,]
+    operands = Value[x, ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(output) && push!(results, output)
-
-    return IR.create_operation(
-        "sparse_tensor.select",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "sparse_tensor.select", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -922,31 +794,20 @@ Example of updating the sizes of the index array for level 0:
 
 ```
 """
-function storage_specifier_set(
-    specifier::Value,
-    value::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    specifierKind,
-    dim=nothing,
-    location=Location(),
-)
+function storage_specifier_set(specifier::Value, value::Value; result=nothing::Union{Nothing, IR.Type}, specifierKind, dim=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[specifier, value]
+    operands = Value[specifier, value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("specifierKind", specifierKind),]
+    attributes = NamedAttribute[namedattribute("specifierKind", specifierKind), ]
     !isnothing(result) && push!(results, result)
     !isnothing(dim) && push!(attributes, namedattribute("dim", dim))
-
-    return IR.create_operation(
-        "sparse_tensor.storage_specifier.set",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "sparse_tensor.storage_specifier.set", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -977,33 +838,21 @@ sparse_tensor.sort %n, %xy jointly %y1 { nx = 2 : index, ny = 2 : index}
   : memref<?xi64> jointly memref<?xf32>
 ```
 """
-function sort_coo(
-    n::Value,
-    xy::Value,
-    ys::Vector{Value};
-    nx=nothing,
-    ny=nothing,
-    stable=nothing,
-    location=Location(),
-)
+function sort_coo(n::Value, xy::Value, ys::Vector{Value}; nx=nothing, ny=nothing, stable=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[n, xy, ys...]
+    operands = Value[n, xy, ys..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(nx) && push!(attributes, namedattribute("nx", nx))
     !isnothing(ny) && push!(attributes, namedattribute("ny", ny))
     !isnothing(stable) && push!(attributes, namedattribute("stable", stable))
-
-    return IR.create_operation(
-        "sparse_tensor.sort_coo",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "sparse_tensor.sort_coo", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1046,26 +895,20 @@ sparse_tensor.sort stable %n, %x1, %x2 jointly y1, %y2
   : memref<?xindex>, memref<?xindex> jointly memref<?xindex>, memref<?xf32>
 ```
 """
-function sort(
-    n::Value, xs::Vector{Value}, ys::Vector{Value}; stable=nothing, location=Location()
-)
+function sort(n::Value, xs::Vector{Value}, ys::Vector{Value}; stable=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[n, xs..., ys...]
+    operands = Value[n, xs..., ys..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([1, length(xs), length(ys)]))
+    push!(attributes, operandsegmentsizes([1, length(xs), length(ys), ]))
     !isnothing(stable) && push!(attributes, namedattribute("stable", stable))
-
-    return IR.create_operation(
-        "sparse_tensor.sort",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "sparse_tensor.sort", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1082,21 +925,17 @@ the sizes for tensor dimensions, pointer arrays, index arrays, and the value arr
 ```
 """
 function storage_specifier_init(; result::IR.Type, location=Location())
-    results = IR.Type[result,]
+    results = IR.Type[result, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "sparse_tensor.storage_specifier.init",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "sparse_tensor.storage_specifier.init", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1123,21 +962,17 @@ and (3, 6).
 ```
 """
 function indices_buffer(tensor::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[tensor,]
+    results = IR.Type[result, ]
+    operands = Value[tensor, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "sparse_tensor.indices_buffer",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "sparse_tensor.indices_buffer", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1160,21 +995,17 @@ scheme (either by calling a support library or through direct code).
 ```
 """
 function indices(tensor::Value; result::IR.Type, dimension, location=Location())
-    results = IR.Type[result,]
-    operands = Value[tensor,]
+    results = IR.Type[result, ]
+    operands = Value[tensor, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("dimension", dimension),]
-
-    return IR.create_operation(
-        "sparse_tensor.indices",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("dimension", dimension), ]
+    
+    IR.create_operation(
+        "sparse_tensor.indices", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1197,21 +1028,17 @@ scheme (either by calling a support library or through direct code).
 ```
 """
 function pointers(tensor::Value; result::IR.Type, dimension, location=Location())
-    results = IR.Type[result,]
-    operands = Value[tensor,]
+    results = IR.Type[result, ]
+    operands = Value[tensor, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("dimension", dimension),]
-
-    return IR.create_operation(
-        "sparse_tensor.pointers",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("dimension", dimension), ]
+    
+    IR.create_operation(
+        "sparse_tensor.pointers", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1233,21 +1060,17 @@ scheme (either by calling a support library or through direct code).
 ```
 """
 function values(tensor::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[tensor,]
+    results = IR.Type[result, ]
+    operands = Value[tensor, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "sparse_tensor.values",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "sparse_tensor.values", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1317,28 +1140,18 @@ the output, while missing values are filled with 1):
   }
 ```
 """
-function unary(
-    x::Value;
-    output::IR.Type,
-    presentRegion::Region,
-    absentRegion::Region,
-    location=Location(),
-)
-    results = IR.Type[output,]
-    operands = Value[x,]
-    owned_regions = Region[presentRegion, absentRegion]
+function unary(x::Value; output::IR.Type, presentRegion::Region, absentRegion::Region, location=Location())
+    results = IR.Type[output, ]
+    operands = Value[x, ]
+    owned_regions = Region[presentRegion, absentRegion, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "sparse_tensor.unary",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "sparse_tensor.unary", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1359,23 +1172,19 @@ Yields a value from within a `binary`, `unary`, `reduce`,
 }
 ```
 """
-function yield(result=nothing::Union{Nothing,Value}; location=Location())
+function yield(result=nothing::Union{Nothing, Value}; location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(operands, result)
-
-    return IR.create_operation(
-        "sparse_tensor.yield",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "sparse_tensor.yield", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/16/Tensor.jl
+++ b/src/Dialects/16/Tensor.jl
@@ -1,8 +1,8 @@
 module tensor
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `cast`
@@ -28,21 +28,17 @@ converting to a mismatching constant dimension.
 ```
 """
 function cast(source::Value; dest::IR.Type, location=Location())
-    results = IR.Type[dest,]
-    operands = Value[source,]
+    results = IR.Type[dest, ]
+    operands = Value[source, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tensor.cast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tensor.cast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -72,21 +68,17 @@ Examples:
 ```
 """
 function collapse_shape(src::Value; result::IR.Type, reassociation, location=Location())
-    results = IR.Type[result,]
-    operands = Value[src,]
+    results = IR.Type[result, ]
+    operands = Value[src, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("reassociation", reassociation),]
-
-    return IR.create_operation(
-        "tensor.collapse_shape",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("reassociation", reassociation), ]
+    
+    IR.create_operation(
+        "tensor.collapse_shape", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -115,25 +107,19 @@ The specified tensor type is that of the first operand.
 %y = \"tensor.dim\"(%A, %c1) : (memref<4x?xf32>, index) -> index
 ```
 """
-function dim(
-    source::Value, index::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function dim(source::Value, index::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[source, index]
+    operands = Value[source, index, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "tensor.dim",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tensor.dim", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -154,21 +140,17 @@ Note: This op can be lowered to a `bufferization.alloc_tensor`, at which
 point it turns into an explicit buffer allocation.
 """
 function empty(dynamicSizes::Vector{Value}; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[dynamicSizes...,]
+    results = IR.Type[result, ]
+    operands = Value[dynamicSizes..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tensor.empty",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tensor.empty", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -198,21 +180,17 @@ Examples:
 ```
 """
 function expand_shape(src::Value; result::IR.Type, reassociation, location=Location())
-    results = IR.Type[result,]
-    operands = Value[src,]
+    results = IR.Type[result, ]
+    operands = Value[src, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("reassociation", reassociation),]
-
-    return IR.create_operation(
-        "tensor.expand_shape",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("reassociation", reassociation), ]
+    
+    IR.create_operation(
+        "tensor.expand_shape", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -231,28 +209,18 @@ the rank of the accessed value. All indices should all be of `index` type.
 %5 = tensor.extract %rt[%1, %2] : tensor<?x?xi32>
 ```
 """
-function extract(
-    tensor::Value,
-    indices::Vector{Value};
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[tensor, indices...]
+function extract(tensor::Value, indices::Vector{Value}; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[tensor, indices..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "tensor.extract",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "tensor.extract", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -317,40 +285,19 @@ dims, to map the rank-reduced type to the source type by dropping ones:
   tensor<8x16x4xf32> to tensor<1x?xf32>
 ```
 """
-function extract_slice(
-    source::Value,
-    offsets::Vector{Value},
-    sizes::Vector{Value},
-    strides::Vector{Value};
-    result::IR.Type,
-    static_offsets,
-    static_sizes,
-    static_strides,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[source, offsets..., sizes..., strides...]
+function extract_slice(source::Value, offsets::Vector{Value}, sizes::Vector{Value}, strides::Vector{Value}; result::IR.Type, static_offsets, static_sizes, static_strides, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[source, offsets..., sizes..., strides..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("static_offsets", static_offsets),
-        namedattribute("static_sizes", static_sizes),
-        namedattribute("static_strides", static_strides),
-    ]
-    push!(
-        attributes,
-        operandsegmentsizes([1, length(offsets), length(sizes), length(strides)]),
-    )
-
-    return IR.create_operation(
-        "tensor.extract_slice",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("static_offsets", static_offsets), namedattribute("static_sizes", static_sizes), namedattribute("static_strides", static_strides), ]
+    push!(attributes, operandsegmentsizes([1, length(offsets), length(sizes), length(strides), ]))
+    
+    IR.create_operation(
+        "tensor.extract_slice", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -373,21 +320,17 @@ will result in a tensor
  [%d, %e, %f]]
 """
 function from_elements(elements::Vector{Value}; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[elements...,]
+    results = IR.Type[result, ]
+    operands = Value[elements..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tensor.from_elements",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tensor.from_elements", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -488,30 +431,19 @@ op:
       (memref<4x4xf32>, memref<?x 1xindex>) -> memref<? x memref<4x1xf32>>
 ```
 """
-function gather(
-    source::Value,
-    indices::Value;
-    result::IR.Type,
-    gather_dims,
-    unique=nothing,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[source, indices]
+function gather(source::Value, indices::Value; result::IR.Type, gather_dims, unique=nothing, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[source, indices, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("gather_dims", gather_dims),]
+    attributes = NamedAttribute[namedattribute("gather_dims", gather_dims), ]
     !isnothing(unique) && push!(attributes, namedattribute("unique", unique))
-
-    return IR.create_operation(
-        "tensor.gather",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tensor.gather", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -537,24 +469,18 @@ a \"parallel map\" operation.
   } : tensor<?x3x?f32>
 ```
 """
-function generate(
-    dynamicExtents::Vector{Value}; result::IR.Type, body::Region, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[dynamicExtents...,]
-    owned_regions = Region[body,]
+function generate(dynamicExtents::Vector{Value}; result::IR.Type, body::Region, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[dynamicExtents..., ]
+    owned_regions = Region[body, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tensor.generate",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tensor.generate", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -577,29 +503,18 @@ indices should be of `index` type.
 %5 = tensor.insert %rt into %dest[%1, %2] : tensor<?x?xi32>
 ```
 """
-function insert(
-    scalar::Value,
-    dest::Value,
-    indices::Vector{Value};
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[scalar, dest, indices...]
+function insert(scalar::Value, dest::Value, indices::Vector{Value}; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[scalar, dest, indices..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "tensor.insert",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "tensor.insert", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -658,42 +573,19 @@ Unlike ExtractSliceOp however, there is no need for a specific inference.
   tensor<1x?xf32> into tensor<8x16x4xf32>
 ```
 """
-function insert_slice(
-    source::Value,
-    dest::Value,
-    offsets::Vector{Value},
-    sizes::Vector{Value},
-    strides::Vector{Value};
-    result=nothing::Union{Nothing,IR.Type},
-    static_offsets,
-    static_sizes,
-    static_strides,
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[source, dest, offsets..., sizes..., strides...]
+function insert_slice(source::Value, dest::Value, offsets::Vector{Value}, sizes::Vector{Value}, strides::Vector{Value}; result::IR.Type, static_offsets, static_sizes, static_strides, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[source, dest, offsets..., sizes..., strides..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("static_offsets", static_offsets),
-        namedattribute("static_sizes", static_sizes),
-        namedattribute("static_strides", static_strides),
-    ]
-    push!(
-        attributes,
-        operandsegmentsizes([1, 1, length(offsets), length(sizes), length(strides)]),
-    )
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "tensor.insert_slice",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    attributes = NamedAttribute[namedattribute("static_offsets", static_offsets), namedattribute("static_sizes", static_sizes), namedattribute("static_strides", static_strides), ]
+    push!(attributes, operandsegmentsizes([1, 1, length(offsets), length(sizes), length(strides), ]))
+    
+    IR.create_operation(
+        "tensor.insert_slice", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -736,43 +628,21 @@ Example NC_to_NCnc with padding:
   inner_tiles = [8, 2] into %arg1 : tensor<13x15xf32> -> tensor<2x8x8x2xf32>
 ```
 """
-function pack(
-    source::Value,
-    dest::Value,
-    padding_value=nothing::Union{Nothing,Value};
-    inner_tiles::Vector{Value},
-    result=nothing::Union{Nothing,IR.Type},
-    outer_dims_perm=nothing,
-    inner_dims_pos,
-    static_inner_tiles,
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[source, dest, inner_tiles...]
+function pack(source::Value, dest::Value, padding_value=nothing::Union{Nothing, Value}; inner_tiles::Vector{Value}, result::IR.Type, outer_dims_perm=nothing, inner_dims_pos, static_inner_tiles, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[source, dest, inner_tiles..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("inner_dims_pos", inner_dims_pos),
-        namedattribute("static_inner_tiles", static_inner_tiles),
-    ]
+    attributes = NamedAttribute[namedattribute("inner_dims_pos", inner_dims_pos), namedattribute("static_inner_tiles", static_inner_tiles), ]
     !isnothing(padding_value) && push!(operands, padding_value)
-    push!(
-        attributes,
-        operandsegmentsizes([1, 1, (padding_value == nothing) ? 0 : 1length(inner_tiles)]),
-    )
-    !isnothing(result) && push!(results, result)
-    !isnothing(outer_dims_perm) &&
-        push!(attributes, namedattribute("outer_dims_perm", outer_dims_perm))
-
-    return IR.create_operation(
-        "tensor.pack",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    push!(attributes, operandsegmentsizes([1, 1, isnothing(padding_value) ? 0 : 1, length(inner_tiles), ]))
+    !isnothing(outer_dims_perm) && push!(attributes, namedattribute("outer_dims_perm", outer_dims_perm))
+    
+    IR.create_operation(
+        "tensor.pack", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -848,36 +718,20 @@ Example 4:
   } : tensor<2x3xf32> to tensor<2x3xf32>
 ```
 """
-function pad(
-    source::Value,
-    low::Vector{Value},
-    high::Vector{Value};
-    result::IR.Type,
-    static_low,
-    static_high,
-    nofold=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[source, low..., high...]
-    owned_regions = Region[region,]
+function pad(source::Value, low::Vector{Value}, high::Vector{Value}; result::IR.Type, static_low, static_high, nofold=nothing, region::Region, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[source, low..., high..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("static_low", static_low), namedattribute("static_high", static_high)
-    ]
-    push!(attributes, operandsegmentsizes([1, length(low), length(high)]))
+    attributes = NamedAttribute[namedattribute("static_low", static_low), namedattribute("static_high", static_high), ]
+    push!(attributes, operandsegmentsizes([1, length(low), length(high), ]))
     !isnothing(nofold) && push!(attributes, namedattribute("nofold", nofold))
-
-    return IR.create_operation(
-        "tensor.pad",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tensor.pad", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -942,40 +796,19 @@ rank-reducing behavior of tensor.insert_slice and tensor.extract_slice.
 The same verification discussion and mechanisms apply as for ExtractSliceOp.
 Unlike ExtractSliceOp however, there is no need for a specific inference.
 """
-function parallel_insert_slice(
-    source::Value,
-    dest::Value,
-    offsets::Vector{Value},
-    sizes::Vector{Value},
-    strides::Vector{Value};
-    static_offsets,
-    static_sizes,
-    static_strides,
-    location=Location(),
-)
+function parallel_insert_slice(source::Value, dest::Value, offsets::Vector{Value}, sizes::Vector{Value}, strides::Vector{Value}; static_offsets, static_sizes, static_strides, location=Location())
     results = IR.Type[]
-    operands = Value[source, dest, offsets..., sizes..., strides...]
+    operands = Value[source, dest, offsets..., sizes..., strides..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("static_offsets", static_offsets),
-        namedattribute("static_sizes", static_sizes),
-        namedattribute("static_strides", static_strides),
-    ]
-    push!(
-        attributes,
-        operandsegmentsizes([1, 1, length(offsets), length(sizes), length(strides)]),
-    )
-
-    return IR.create_operation(
-        "tensor.parallel_insert_slice",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("static_offsets", static_offsets), namedattribute("static_sizes", static_sizes), namedattribute("static_strides", static_strides), ]
+    push!(attributes, operandsegmentsizes([1, 1, length(offsets), length(sizes), length(strides), ]))
+    
+    IR.create_operation(
+        "tensor.parallel_insert_slice", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -991,23 +824,19 @@ The `tensor.rank` operation takes a tensor operand and returns its rank.
 %1 = tensor.rank %arg1 : tensor<?x?xf32>
 ```
 """
-function rank(tensor::Value; result_0=nothing::Union{Nothing,IR.Type}, location=Location())
+function rank(tensor::Value; result_0=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[tensor,]
+    operands = Value[tensor, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result_0) && push!(results, result_0)
-
-    return IR.create_operation(
-        "tensor.rank",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tensor.rank", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1046,21 +875,17 @@ Result type is unranked.
 ```
 """
 function reshape(source::Value, shape::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[source, shape]
+    results = IR.Type[result, ]
+    operands = Value[source, shape, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tensor.reshape",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tensor.reshape", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1164,31 +989,19 @@ op:
     some_side_effecting_op_writing_into %v, ...: memref<? x memref<4xf32>>
 ```
 """
-function scatter(
-    source::Value,
-    dest::Value,
-    indices::Value;
-    result::IR.Type,
-    scatter_dims,
-    unique=nothing,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[source, dest, indices]
+function scatter(source::Value, dest::Value, indices::Value; result::IR.Type, scatter_dims, unique=nothing, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[source, dest, indices, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("scatter_dims", scatter_dims),]
+    attributes = NamedAttribute[namedattribute("scatter_dims", scatter_dims), ]
     !isnothing(unique) && push!(attributes, namedattribute("unique", unique))
-
-    return IR.create_operation(
-        "tensor.scatter",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tensor.scatter", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1218,21 +1031,17 @@ TODO: This operation is easy to extend to broadcast to dynamically shaped
 ```
 """
 function splat(input::Value; aggregate::IR.Type, location=Location())
-    results = IR.Type[aggregate,]
-    operands = Value[input,]
+    results = IR.Type[aggregate, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tensor.splat",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tensor.splat", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1260,37 +1069,19 @@ Example CK to KCck:
   inner_tiles = [8, 32] into %dest : tensor<8x16x8x32xf32> -> tensor<128x256xf32>
 ```
 """
-function unpack(
-    source::Value,
-    dest::Value,
-    inner_tiles::Vector{Value};
-    result=nothing::Union{Nothing,IR.Type},
-    outer_dims_perm=nothing,
-    inner_dims_pos,
-    static_inner_tiles,
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[source, dest, inner_tiles...]
+function unpack(source::Value, dest::Value, inner_tiles::Vector{Value}; result::IR.Type, outer_dims_perm=nothing, inner_dims_pos, static_inner_tiles, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[source, dest, inner_tiles..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("inner_dims_pos", inner_dims_pos),
-        namedattribute("static_inner_tiles", static_inner_tiles),
-    ]
-    !isnothing(result) && push!(results, result)
-    !isnothing(outer_dims_perm) &&
-        push!(attributes, namedattribute("outer_dims_perm", outer_dims_perm))
-
-    return IR.create_operation(
-        "tensor.unpack",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    attributes = NamedAttribute[namedattribute("inner_dims_pos", inner_dims_pos), namedattribute("static_inner_tiles", static_inner_tiles), ]
+    !isnothing(outer_dims_perm) && push!(attributes, namedattribute("outer_dims_perm", outer_dims_perm))
+    
+    IR.create_operation(
+        "tensor.unpack", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -1303,20 +1094,16 @@ is used to create dynamically sized tensors
 """
 function yield(value::Value; location=Location())
     results = IR.Type[]
-    operands = Value[value,]
+    operands = Value[value, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tensor.yield",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tensor.yield", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/16/Tosa.jl
+++ b/src/Dialects/16/Tosa.jl
@@ -1,8 +1,8 @@
 module tosa
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `abs`
@@ -10,21 +10,17 @@ import ..Dialects: namedattribute, operandsegmentsizes
 Elementwise absolute value operation
 """
 function abs(input1::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1,]
+    results = IR.Type[output, ]
+    operands = Value[input1, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.abs",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.abs", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -35,21 +31,17 @@ Elementwise addition of input1 and input2. Axis of size 1 will be broadcast,
 as necessary.
 """
 function add(input1::Value, input2::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1, input2]
+    results = IR.Type[output, ]
+    operands = Value[input1, input2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.add",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.add", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -63,29 +55,18 @@ The commonplace implementation is to use i64 operations to avoid integer
 overflow with target specific implementations can use native operations to
 avoid wider than necessary types.
 """
-function apply_scale(
-    value::Value,
-    multiplier::Value,
-    shift::Value;
-    output::IR.Type,
-    double_round,
-    location=Location(),
-)
-    results = IR.Type[output,]
-    operands = Value[value, multiplier, shift]
+function apply_scale(value::Value, multiplier::Value, shift::Value; output::IR.Type, double_round, location=Location())
+    results = IR.Type[output, ]
+    operands = Value[value, multiplier, shift, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("double_round", double_round),]
-
-    return IR.create_operation(
-        "tosa.apply_scale",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("double_round", double_round), ]
+    
+    IR.create_operation(
+        "tosa.apply_scale", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -96,21 +77,17 @@ This returns the index with the largest value across the given axis of the
 input tensor.
 """
 function argmax(input::Value; output::IR.Type, axis, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input,]
+    results = IR.Type[output, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("axis", axis),]
-
-    return IR.create_operation(
-        "tosa.argmax",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("axis", axis), ]
+    
+    IR.create_operation(
+        "tosa.argmax", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -120,24 +97,18 @@ end
 Elementwise arithmetic right shift of input1 by the amount specified in
 input2. Axis of size 1 will be broadcast, as necessary.
 """
-function arithmetic_right_shift(
-    input1::Value, input2::Value; output::IR.Type, round, location=Location()
-)
-    results = IR.Type[output,]
-    operands = Value[input1, input2]
+function arithmetic_right_shift(input1::Value, input2::Value; output::IR.Type, round, location=Location())
+    results = IR.Type[output, ]
+    operands = Value[input1, input2, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("round", round),]
-
-    return IR.create_operation(
-        "tosa.arithmetic_right_shift",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("round", round), ]
+    
+    IR.create_operation(
+        "tosa.arithmetic_right_shift", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -148,36 +119,19 @@ This performs an average pooling over the given input tensor. A sliding
 window of size given by <kernel size> is passed over the input tensor, with
 the mean value being placed in the output tensor.
 """
-function avg_pool2d(
-    input::Value;
-    output::IR.Type,
-    kernel,
-    stride,
-    pad,
-    quantization_info=nothing,
-    location=Location(),
-)
-    results = IR.Type[output,]
-    operands = Value[input,]
+function avg_pool2d(input::Value; output::IR.Type, kernel, stride, pad, quantization_info=nothing, location=Location())
+    results = IR.Type[output, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("kernel", kernel),
-        namedattribute("stride", stride),
-        namedattribute("pad", pad),
-    ]
-    !isnothing(quantization_info) &&
-        push!(attributes, namedattribute("quantization_info", quantization_info))
-
-    return IR.create_operation(
-        "tosa.avg_pool2d",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("kernel", kernel), namedattribute("stride", stride), namedattribute("pad", pad), ]
+    !isnothing(quantization_info) && push!(attributes, namedattribute("quantization_info", quantization_info))
+    
+    IR.create_operation(
+        "tosa.avg_pool2d", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -188,21 +142,17 @@ Elementwise bitwise AND of input1 and input2. Axis of size 1
 will be broadcast as necessary.
 """
 function bitwise_and(input1::Value, input2::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1, input2]
+    results = IR.Type[output, ]
+    operands = Value[input1, input2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.bitwise_and",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.bitwise_and", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -212,21 +162,17 @@ end
 Elementwise bitwise NOT of input tensor.
 """
 function bitwise_not(input1::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1,]
+    results = IR.Type[output, ]
+    operands = Value[input1, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.bitwise_not",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.bitwise_not", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -237,21 +183,17 @@ Elementwise bitwise OR of input1 and input2. Axis of size 1 will be
 broadcast as necessary.
 """
 function bitwise_or(input1::Value, input2::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1, input2]
+    results = IR.Type[output, ]
+    operands = Value[input1, input2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.bitwise_or",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.bitwise_or", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -262,21 +204,17 @@ Elementwise bitwise XOR of input1 and input2. Axis of size 1 will be
 broadcast as necessary.
 """
 function bitwise_xor(input1::Value, input2::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1, input2]
+    results = IR.Type[output, ]
+    operands = Value[input1, input2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.bitwise_xor",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.bitwise_xor", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -304,21 +242,17 @@ Performs a set of permissible cast operations
     signed 16 to float      int16   float
 """
 function cast(input::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input,]
+    results = IR.Type[output, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.cast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.cast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -328,21 +262,17 @@ end
 Elementwise ceiling operation
 """
 function ceil(input1::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1,]
+    results = IR.Type[output, ]
+    operands = Value[input1, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.ceil",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.ceil", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -355,29 +285,18 @@ input type.
 No zero point subtraction is done to the values, thus to clamp to the zero
 point value, the zero point itself should be supplied as the minimum value.
 """
-function clamp(
-    input::Value; output::IR.Type, min_int, max_int, min_fp, max_fp, location=Location()
-)
-    results = IR.Type[output,]
-    operands = Value[input,]
+function clamp(input::Value; output::IR.Type, min_int, max_int, min_fp, max_fp, location=Location())
+    results = IR.Type[output, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("min_int", min_int),
-        namedattribute("max_int", max_int),
-        namedattribute("min_fp", min_fp),
-        namedattribute("max_fp", max_fp),
-    ]
-
-    return IR.create_operation(
-        "tosa.clamp",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("min_int", min_int), namedattribute("max_int", max_int), namedattribute("min_fp", min_fp), namedattribute("max_fp", max_fp), ]
+    
+    IR.create_operation(
+        "tosa.clamp", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -387,21 +306,17 @@ end
 Elementwise count leading zeros operation
 """
 function clz(input1::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1,]
+    results = IR.Type[output, ]
+    operands = Value[input1, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.clz",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.clz", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -412,21 +327,17 @@ Concatenate a variadic amount of tensors along a given axis. No data
 conversion happens during a concat operation.
 """
 function concat(input1::Vector{Value}; output::IR.Type, axis, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1...,]
+    results = IR.Type[output, ]
+    operands = Value[input1..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("axis", axis),]
-
-    return IR.create_operation(
-        "tosa.concat",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("axis", axis), ]
+    
+    IR.create_operation(
+        "tosa.concat", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -436,23 +347,19 @@ end
 A node containing constant data for use as the input to an operation. May
 hold data in any of the supported data formats.
 """
-function const_(; output=nothing::Union{Nothing,IR.Type}, value, location=Location())
+function const_(; output=nothing::Union{Nothing, IR.Type}, value, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("value", value),]
+    attributes = NamedAttribute[namedattribute("value", value), ]
     !isnothing(output) && push!(results, output)
-
-    return IR.create_operation(
-        "tosa.const",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.const", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -462,38 +369,19 @@ end
 Performs a 2D convolution over the given tensor input, using the weight
 tensor.
 """
-function conv2d(
-    input::Value,
-    weight::Value,
-    bias::Value;
-    output::IR.Type,
-    pad,
-    stride,
-    dilation,
-    quantization_info=nothing,
-    location=Location(),
-)
-    results = IR.Type[output,]
-    operands = Value[input, weight, bias]
+function conv2d(input::Value, weight::Value, bias::Value; output::IR.Type, pad, stride, dilation, quantization_info=nothing, location=Location())
+    results = IR.Type[output, ]
+    operands = Value[input, weight, bias, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("pad", pad),
-        namedattribute("stride", stride),
-        namedattribute("dilation", dilation),
-    ]
-    !isnothing(quantization_info) &&
-        push!(attributes, namedattribute("quantization_info", quantization_info))
-
-    return IR.create_operation(
-        "tosa.conv2d",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("pad", pad), namedattribute("stride", stride), namedattribute("dilation", dilation), ]
+    !isnothing(quantization_info) && push!(attributes, namedattribute("quantization_info", quantization_info))
+    
+    IR.create_operation(
+        "tosa.conv2d", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -502,38 +390,19 @@ end
 
 Performs a 3D convolution over the given input tensor.
 """
-function conv3d(
-    input::Value,
-    weight::Value,
-    bias::Value;
-    output::IR.Type,
-    pad,
-    stride,
-    dilation,
-    quantization_info=nothing,
-    location=Location(),
-)
-    results = IR.Type[output,]
-    operands = Value[input, weight, bias]
+function conv3d(input::Value, weight::Value, bias::Value; output::IR.Type, pad, stride, dilation, quantization_info=nothing, location=Location())
+    results = IR.Type[output, ]
+    operands = Value[input, weight, bias, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("pad", pad),
-        namedattribute("stride", stride),
-        namedattribute("dilation", dilation),
-    ]
-    !isnothing(quantization_info) &&
-        push!(attributes, namedattribute("quantization_info", quantization_info))
-
-    return IR.create_operation(
-        "tosa.conv3d",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("pad", pad), namedattribute("stride", stride), namedattribute("dilation", dilation), ]
+    !isnothing(quantization_info) && push!(attributes, namedattribute("quantization_info", quantization_info))
+    
+    IR.create_operation(
+        "tosa.conv3d", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -559,33 +428,18 @@ set of attributes to the custom operator.
 `outputs is the list of tensors returned by the operator. The number of operators
 is backend specific.
 """
-function custom(
-    inputs::Vector{Value};
-    outputs::Vector{IR.Type},
-    identifier,
-    config,
-    implementation_attrs,
-    location=Location(),
-)
-    results = IR.Type[outputs...,]
-    operands = Value[inputs...,]
+function custom(inputs::Vector{Value}; outputs::Vector{IR.Type}, identifier, config, implementation_attrs, location=Location())
+    results = IR.Type[outputs..., ]
+    operands = Value[inputs..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("identifier", identifier),
-        namedattribute("config", config),
-        namedattribute("implementation_attrs", implementation_attrs),
-    ]
-
-    return IR.create_operation(
-        "tosa.custom",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("identifier", identifier), namedattribute("config", config), namedattribute("implementation_attrs", implementation_attrs), ]
+    
+    IR.create_operation(
+        "tosa.custom", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -595,38 +449,19 @@ end
 Performs 2D convolutions separately over each channel of the given tensor
 input, using the weight tensor.
 """
-function depthwise_conv2d(
-    input::Value,
-    weight::Value,
-    bias::Value;
-    output::IR.Type,
-    pad,
-    stride,
-    dilation,
-    quantization_info=nothing,
-    location=Location(),
-)
-    results = IR.Type[output,]
-    operands = Value[input, weight, bias]
+function depthwise_conv2d(input::Value, weight::Value, bias::Value; output::IR.Type, pad, stride, dilation, quantization_info=nothing, location=Location())
+    results = IR.Type[output, ]
+    operands = Value[input, weight, bias, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("pad", pad),
-        namedattribute("stride", stride),
-        namedattribute("dilation", dilation),
-    ]
-    !isnothing(quantization_info) &&
-        push!(attributes, namedattribute("quantization_info", quantization_info))
-
-    return IR.create_operation(
-        "tosa.depthwise_conv2d",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("pad", pad), namedattribute("stride", stride), namedattribute("dilation", dilation), ]
+    !isnothing(quantization_info) && push!(attributes, namedattribute("quantization_info", quantization_info))
+    
+    IR.create_operation(
+        "tosa.depthwise_conv2d", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -637,21 +472,17 @@ Elementwise integer divide operator of input1 by input2. Axis of size 1
 will be broadcast, as necessary.
 """
 function div(input1::Value, input2::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1, input2]
+    results = IR.Type[output, ]
+    operands = Value[input1, input2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.div",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.div", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -660,28 +491,19 @@ end
 
 Elementwise comparison operation
 """
-function equal(
-    input1::Value,
-    input2::Value;
-    output=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function equal(input1::Value, input2::Value; output=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[input1, input2]
+    operands = Value[input1, input2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(output) && push!(results, output)
-
-    return IR.create_operation(
-        "tosa.equal",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.equal", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -691,21 +513,17 @@ end
 Elementwise e to the x operation
 """
 function exp(input1::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1,]
+    results = IR.Type[output, ]
+    operands = Value[input1, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.exp",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.exp", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -715,21 +533,17 @@ end
 Elementwise floor operation
 """
 function floor(input1::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1,]
+    results = IR.Type[output, ]
+    operands = Value[input1, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.floor",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.floor", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -738,31 +552,19 @@ end
 
 Performs a fully connected network.
 """
-function fully_connected(
-    input::Value,
-    weight::Value,
-    bias::Value;
-    output::IR.Type,
-    quantization_info=nothing,
-    location=Location(),
-)
-    results = IR.Type[output,]
-    operands = Value[input, weight, bias]
+function fully_connected(input::Value, weight::Value, bias::Value; output::IR.Type, quantization_info=nothing, location=Location())
+    results = IR.Type[output, ]
+    operands = Value[input, weight, bias, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(quantization_info) &&
-        push!(attributes, namedattribute("quantization_info", quantization_info))
-
-    return IR.create_operation(
-        "tosa.fully_connected",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(quantization_info) && push!(attributes, namedattribute("quantization_info", quantization_info))
+    
+    IR.create_operation(
+        "tosa.fully_connected", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -773,21 +575,17 @@ Generate a tensor for which each element in the output is a slice of the
 values tensor based on the value of indices.
 """
 function gather(values::Value, indices::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[values, indices]
+    results = IR.Type[output, ]
+    operands = Value[values, indices, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.gather",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.gather", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -797,21 +595,17 @@ end
 Elementwise comparison operation
 """
 function greater_equal(input1::Value, input2::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1, input2]
+    results = IR.Type[output, ]
+    operands = Value[input1, input2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.greater_equal",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.greater_equal", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -821,21 +615,17 @@ end
 Elementwise greater than comparison operation
 """
 function greater(input1::Value, input2::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1, input2]
+    results = IR.Type[output, ]
+    operands = Value[input1, input2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.greater",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.greater", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -846,21 +636,17 @@ Returns a tensor with the same shape, size, type
 and content as the input.
 """
 function identity(input1::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1,]
+    results = IR.Type[output, ]
+    operands = Value[input1, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.identity",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.identity", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -870,29 +656,18 @@ end
 Evaluates a Boolean condition and then takes one of two distinct execution
 paths. This implements the semantic If-then-else structure.
 """
-function cond_if(
-    cond::Value,
-    inputs::Vector{Value};
-    output::Vector{IR.Type},
-    then_branch::Region,
-    else_branch::Region,
-    location=Location(),
-)
-    results = IR.Type[output...,]
-    operands = Value[cond, inputs...]
-    owned_regions = Region[then_branch, else_branch]
+function cond_if(cond::Value, inputs::Vector{Value}; output::Vector{IR.Type}, then_branch::Region, else_branch::Region, location=Location())
+    results = IR.Type[output..., ]
+    operands = Value[cond, inputs..., ]
+    owned_regions = Region[then_branch, else_branch, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.cond_if",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.cond_if", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -902,21 +677,17 @@ end
 Elementwise natural logarithm operation
 """
 function log(input1::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1,]
+    results = IR.Type[output, ]
+    operands = Value[input1, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.log",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.log", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -927,21 +698,17 @@ Elementwise logical AND of input1 and input2. Axis of size 1 will be
 broadcast, as necessary.
 """
 function logical_and(input1::Value, input2::Value; z::IR.Type, location=Location())
-    results = IR.Type[z,]
-    operands = Value[input1, input2]
+    results = IR.Type[z, ]
+    operands = Value[input1, input2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.logical_and",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.logical_and", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -951,24 +718,18 @@ end
 Elementwise left shift of input1 and input2. Axis of size 1 will be
 broadcast, as necessary.
 """
-function logical_left_shift(
-    input1::Value, input2::Value; output::IR.Type, location=Location()
-)
-    results = IR.Type[output,]
-    operands = Value[input1, input2]
+function logical_left_shift(input1::Value, input2::Value; output::IR.Type, location=Location())
+    results = IR.Type[output, ]
+    operands = Value[input1, input2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.logical_left_shift",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.logical_left_shift", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -977,25 +738,19 @@ end
 
 Elementwise logical NOT of input.
 """
-function logical_not(
-    input1::Value; output=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function logical_not(input1::Value; output=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[input1,]
+    operands = Value[input1, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(output) && push!(results, output)
-
-    return IR.create_operation(
-        "tosa.logical_not",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.logical_not", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1006,21 +761,17 @@ Elementwise logical OR of input1 and input2. Axis of size 1 will be
 broadcast as necessary.
 """
 function logical_or(input1::Value, input2::Value; z::IR.Type, location=Location())
-    results = IR.Type[z,]
-    operands = Value[input1, input2]
+    results = IR.Type[z, ]
+    operands = Value[input1, input2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.logical_or",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.logical_or", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1030,24 +781,18 @@ end
 Elementwise logical right shift of input1 by the amount specified in input2.
 Axis of size 1 will be broadcast, as necessary.
 """
-function logical_right_shift(
-    input1::Value, input2::Value; output::IR.Type, location=Location()
-)
-    results = IR.Type[output,]
-    operands = Value[input1, input2]
+function logical_right_shift(input1::Value, input2::Value; output::IR.Type, location=Location())
+    results = IR.Type[output, ]
+    operands = Value[input1, input2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.logical_right_shift",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.logical_right_shift", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1058,21 +803,17 @@ Elementwise logical XOR of input1 and input2.  Axis of size 1 will be
 broadcast as necessary.
 """
 function logical_xor(input1::Value, input2::Value; z::IR.Type, location=Location())
-    results = IR.Type[z,]
-    operands = Value[input1, input2]
+    results = IR.Type[z, ]
+    operands = Value[input1, input2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.logical_xor",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.logical_xor", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1083,26 +824,19 @@ Performs a two dimensional matrix multiplication. This allows both inputs to
 be activations, rather than reserving weights as an attribute in the
 FULLY_CONNECTED operator.
 """
-function matmul(
-    a::Value, b::Value; c::IR.Type, quantization_info=nothing, location=Location()
-)
-    results = IR.Type[c,]
-    operands = Value[a, b]
+function matmul(a::Value, b::Value; c::IR.Type, quantization_info=nothing, location=Location())
+    results = IR.Type[c, ]
+    operands = Value[a, b, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(quantization_info) &&
-        push!(attributes, namedattribute("quantization_info", quantization_info))
-
-    return IR.create_operation(
-        "tosa.matmul",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(quantization_info) && push!(attributes, namedattribute("quantization_info", quantization_info))
+    
+    IR.create_operation(
+        "tosa.matmul", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1115,25 +849,17 @@ maximum value being placed in the
 output tensor.
 """
 function max_pool2d(input::Value; output::IR.Type, kernel, stride, pad, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input,]
+    results = IR.Type[output, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("kernel", kernel),
-        namedattribute("stride", stride),
-        namedattribute("pad", pad),
-    ]
-
-    return IR.create_operation(
-        "tosa.max_pool2d",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("kernel", kernel), namedattribute("stride", stride), namedattribute("pad", pad), ]
+    
+    IR.create_operation(
+        "tosa.max_pool2d", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1144,21 +870,17 @@ Elementwise max of input1 and input2. Axis of size 1 will be broadcast, as
 necessary.
 """
 function maximum(input1::Value, input2::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1, input2]
+    results = IR.Type[output, ]
+    operands = Value[input1, input2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.maximum",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.maximum", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1169,21 +891,17 @@ Elementwise minimum of input1 and input2. Axis of size 1
 will be broadcast, as necessary.
 """
 function minimum(input1::Value, input2::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1, input2]
+    results = IR.Type[output, ]
+    operands = Value[input1, input2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.minimum",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.minimum", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1194,21 +912,17 @@ Elementwise multiplication (Hadamard product) of input1 and input2.
 Axis of size 1 will be broadcast, as necessary.
 """
 function mul(input1::Value, input2::Value; output::IR.Type, shift, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1, input2]
+    results = IR.Type[output, ]
+    operands = Value[input1, input2, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("shift", shift),]
-
-    return IR.create_operation(
-        "tosa.mul",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("shift", shift), ]
+    
+    IR.create_operation(
+        "tosa.mul", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1217,26 +931,19 @@ end
 
 Elementwise negation operation
 """
-function negate(
-    input1::Value; output::IR.Type, quantization_info=nothing, location=Location()
-)
-    results = IR.Type[output,]
-    operands = Value[input1,]
+function negate(input1::Value; output::IR.Type, quantization_info=nothing, location=Location())
+    results = IR.Type[output, ]
+    operands = Value[input1, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(quantization_info) &&
-        push!(attributes, namedattribute("quantization_info", quantization_info))
-
-    return IR.create_operation(
-        "tosa.negate",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(quantization_info) && push!(attributes, namedattribute("quantization_info", quantization_info))
+    
+    IR.create_operation(
+        "tosa.negate", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1245,32 +952,20 @@ end
 
 Pads a tensor along borders of each dimension with pad_value.
 """
-function pad(
-    input1::Value,
-    padding::Value,
-    pad_const=nothing::Union{Nothing,Value};
-    output::IR.Type,
-    quantization_info=nothing,
-    location=Location(),
-)
-    results = IR.Type[output,]
-    operands = Value[input1, padding]
+function pad(input1::Value, padding::Value, pad_const=nothing::Union{Nothing, Value}; output::IR.Type, quantization_info=nothing, location=Location())
+    results = IR.Type[output, ]
+    operands = Value[input1, padding, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(pad_const) && push!(operands, pad_const)
-    !isnothing(quantization_info) &&
-        push!(attributes, namedattribute("quantization_info", quantization_info))
-
-    return IR.create_operation(
-        "tosa.pad",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(quantization_info) && push!(attributes, namedattribute("quantization_info", quantization_info))
+    
+    IR.create_operation(
+        "tosa.pad", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1281,21 +976,17 @@ Elementwise input1 raised to the power of input2.
 Axis of size 1 will be broadcast, as necessary.
 """
 function pow(input1::Value, input2::Value; z::IR.Type, location=Location())
-    results = IR.Type[z,]
-    operands = Value[input1, input2]
+    results = IR.Type[z, ]
+    operands = Value[input1, input2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.pow",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.pow", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1309,24 +1000,18 @@ tensor arguments. RFFT2D takes advantage of Hermitian symmetry to only
 calculate the first half of the final output axis. Imaginary values with
 locations (0,0), (0,W/2), (H/2,0) and (H/2,W/2) are zero.
 """
-function rfft2d(
-    input::Value; output_real::IR.Type, output_imag::IR.Type, location=Location()
-)
-    results = IR.Type[output_real, output_imag]
-    operands = Value[input,]
+function rfft2d(input::Value; output_real::IR.Type, output_imag::IR.Type, location=Location())
+    results = IR.Type[output_real, output_imag, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.rfft2d",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.rfft2d", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1337,21 +1022,17 @@ Elementwise reciprocal operation. For integer operation, a TABLE should be
 used with the appropriate ranges.
 """
 function reciprocal(input1::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1,]
+    results = IR.Type[output, ]
+    operands = Value[input1, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.reciprocal",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.reciprocal", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1361,21 +1042,17 @@ end
 Reduce a tensor along the given axis with a logical AND operation
 """
 function reduce_all(input::Value; output::IR.Type, axis, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input,]
+    results = IR.Type[output, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("axis", axis),]
-
-    return IR.create_operation(
-        "tosa.reduce_all",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("axis", axis), ]
+    
+    IR.create_operation(
+        "tosa.reduce_all", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1385,21 +1062,17 @@ end
 Reduce a tensor along the given axis with a logical OR operation
 """
 function reduce_any(input::Value; output::IR.Type, axis, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input,]
+    results = IR.Type[output, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("axis", axis),]
-
-    return IR.create_operation(
-        "tosa.reduce_any",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("axis", axis), ]
+    
+    IR.create_operation(
+        "tosa.reduce_any", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1409,21 +1082,17 @@ end
 Reduce a tensor along the given axis with a maximum operation
 """
 function reduce_max(input::Value; output::IR.Type, axis, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input,]
+    results = IR.Type[output, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("axis", axis),]
-
-    return IR.create_operation(
-        "tosa.reduce_max",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("axis", axis), ]
+    
+    IR.create_operation(
+        "tosa.reduce_max", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1433,21 +1102,17 @@ end
 Reduce a tensor along the given axis with a minimum operation
 """
 function reduce_min(input::Value; output::IR.Type, axis, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input,]
+    results = IR.Type[output, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("axis", axis),]
-
-    return IR.create_operation(
-        "tosa.reduce_min",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("axis", axis), ]
+    
+    IR.create_operation(
+        "tosa.reduce_min", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1457,21 +1122,17 @@ end
 Reduce a tensor along the given axis by computing the product of the axis.
 """
 function reduce_prod(input::Value; output::IR.Type, axis, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input,]
+    results = IR.Type[output, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("axis", axis),]
-
-    return IR.create_operation(
-        "tosa.reduce_prod",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("axis", axis), ]
+    
+    IR.create_operation(
+        "tosa.reduce_prod", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1481,21 +1142,17 @@ end
 Reduce a tensor along the given axis by computing the sum of the axis.
 """
 function reduce_sum(input::Value; output::IR.Type, axis, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input,]
+    results = IR.Type[output, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("axis", axis),]
-
-    return IR.create_operation(
-        "tosa.reduce_sum",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("axis", axis), ]
+    
+    IR.create_operation(
+        "tosa.reduce_sum", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1519,41 +1176,18 @@ signed 48 to 32         int48   int32
 unsigned 8 to signed 8  uint8   int8
 signed 8 to unsigned 8  int8    uint8
 """
-function rescale(
-    input::Value;
-    output::IR.Type,
-    input_zp,
-    output_zp,
-    multiplier,
-    shift,
-    scale32,
-    double_round,
-    per_channel,
-    location=Location(),
-)
-    results = IR.Type[output,]
-    operands = Value[input,]
+function rescale(input::Value; output::IR.Type, input_zp, output_zp, multiplier, shift, scale32, double_round, per_channel, location=Location())
+    results = IR.Type[output, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("input_zp", input_zp),
-        namedattribute("output_zp", output_zp),
-        namedattribute("multiplier", multiplier),
-        namedattribute("shift", shift),
-        namedattribute("scale32", scale32),
-        namedattribute("double_round", double_round),
-        namedattribute("per_channel", per_channel),
-    ]
-
-    return IR.create_operation(
-        "tosa.rescale",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("input_zp", input_zp), namedattribute("output_zp", output_zp), namedattribute("multiplier", multiplier), namedattribute("shift", shift), namedattribute("scale32", scale32), namedattribute("double_round", double_round), namedattribute("per_channel", per_channel), ]
+    
+    IR.create_operation(
+        "tosa.rescale", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1565,21 +1199,17 @@ specified by the shape argument. Reshape may operate on tensors of any rank.
 No data conversion happens during a reshape operation.
 """
 function reshape(input1::Value; output::IR.Type, new_shape, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1,]
+    results = IR.Type[output, ]
+    operands = Value[input1, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("new_shape", new_shape),]
-
-    return IR.create_operation(
-        "tosa.reshape",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("new_shape", new_shape), ]
+    
+    IR.create_operation(
+        "tosa.reshape", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1593,29 +1223,18 @@ output dimensions can be derived from the input dimensions by inverting the
 scale. And the [order_y, border_x] values adjust the output size to allow
 fractional sampling beyond integer input position (IH-1,IW-1).
 """
-function resize(
-    input::Value; output::IR.Type, scale, offset, border, mode, location=Location()
-)
-    results = IR.Type[output,]
-    operands = Value[input,]
+function resize(input::Value; output::IR.Type, scale, offset, border, mode, location=Location())
+    results = IR.Type[output, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("scale", scale),
-        namedattribute("offset", offset),
-        namedattribute("border", border),
-        namedattribute("mode", mode),
-    ]
-
-    return IR.create_operation(
-        "tosa.resize",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("scale", scale), namedattribute("offset", offset), namedattribute("border", border), namedattribute("mode", mode), ]
+    
+    IR.create_operation(
+        "tosa.resize", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1627,21 +1246,17 @@ reversed along the given axis. No data conversion happens during a reverse
 operation.
 """
 function reverse(input::Value; output::IR.Type, axis, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input,]
+    results = IR.Type[output, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("axis", axis),]
-
-    return IR.create_operation(
-        "tosa.reverse",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("axis", axis), ]
+    
+    IR.create_operation(
+        "tosa.reverse", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1652,21 +1267,17 @@ Elementwise reciprocal square root operation. For integer operation, a TABLE
 should be used with the appropriate ranges.
 """
 function rsqrt(input1::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1,]
+    results = IR.Type[output, ]
+    operands = Value[input1, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.rsqrt",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.rsqrt", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1676,24 +1287,18 @@ end
 The values_out tensor is set to the values_in tensor with data modified as follows:
 data from the input tensor is inserted at the positions specified by the indices tensor.
 """
-function scatter(
-    values_in::Value, indices::Value, input::Value; values_out::IR.Type, location=Location()
-)
-    results = IR.Type[values_out,]
-    operands = Value[values_in, indices, input]
+function scatter(values_in::Value, indices::Value, input::Value; values_out::IR.Type, location=Location())
+    results = IR.Type[values_out, ]
+    operands = Value[values_in, indices, input, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.scatter",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.scatter", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1702,24 +1307,18 @@ end
 
 Elementwise select of the output based on a condition.
 """
-function select(
-    pred::Value, on_true::Value, on_false::Value; output::IR.Type, location=Location()
-)
-    results = IR.Type[output,]
-    operands = Value[pred, on_true, on_false]
+function select(pred::Value, on_true::Value, on_false::Value; output::IR.Type, location=Location())
+    results = IR.Type[output, ]
+    operands = Value[pred, on_true, on_false, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.select",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.select", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1733,21 +1332,17 @@ with the following definition.  The sigmoid table has 513 entries each of
 in steps of 1/16.
 """
 function sigmoid(input::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input,]
+    results = IR.Type[output, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.sigmoid",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.sigmoid", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1759,23 +1354,17 @@ start coordinates, and extending for size elements in each direction.  No
 data conversion happens during a slice operation.
 """
 function slice(input::Value; output::IR.Type, start, size, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input,]
+    results = IR.Type[output, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("start", start), namedattribute("size", size)
-    ]
-
-    return IR.create_operation(
-        "tosa.slice",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("start", start), namedattribute("size", size), ]
+    
+    IR.create_operation(
+        "tosa.slice", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1786,21 +1375,17 @@ Elementwise subtraction of input1 and input2. Axis of size 1 will be
 broadcast as necessary.
 """
 function sub(input1::Value, input2::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1, input2]
+    results = IR.Type[output, ]
+    operands = Value[input1, input2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.sub",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.sub", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1823,21 +1408,17 @@ The TABLE operator is expected to be used as follows:
   RESCALE with a right shift of 15
 """
 function table(input::Value, table::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input, table]
+    results = IR.Type[output, ]
+    operands = Value[input, table, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.table",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.table", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1850,21 +1431,17 @@ with the following definition.  The tanh_table has 513 entries each of
 16-bit precision and covering the input range -8.0 to +8.0 in steps of 1/32.
 """
 function tanh(input::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input,]
+    results = IR.Type[output, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.tanh",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.tanh", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1874,21 +1451,17 @@ end
 Replicates input 0 multiplies times along each dimension.
 """
 function tile(input1::Value; output::IR.Type, multiples, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1,]
+    results = IR.Type[output, ]
+    operands = Value[input1, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("multiples", multiples),]
-
-    return IR.create_operation(
-        "tosa.tile",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("multiples", multiples), ]
+    
+    IR.create_operation(
+        "tosa.tile", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1898,38 +1471,19 @@ end
 Performs a 2D transposed convolution over the given tensor input, using the
 weights tensor.
 """
-function transpose_conv2d(
-    input::Value,
-    filter::Value,
-    bias::Value;
-    output::IR.Type,
-    out_pad,
-    stride,
-    out_shape,
-    quantization_info=nothing,
-    location=Location(),
-)
-    results = IR.Type[output,]
-    operands = Value[input, filter, bias]
+function transpose_conv2d(input::Value, filter::Value, bias::Value; output::IR.Type, out_pad, stride, out_shape, quantization_info=nothing, location=Location())
+    results = IR.Type[output, ]
+    operands = Value[input, filter, bias, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("out_pad", out_pad),
-        namedattribute("stride", stride),
-        namedattribute("out_shape", out_shape),
-    ]
-    !isnothing(quantization_info) &&
-        push!(attributes, namedattribute("quantization_info", quantization_info))
-
-    return IR.create_operation(
-        "tosa.transpose_conv2d",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("out_pad", out_pad), namedattribute("stride", stride), namedattribute("out_shape", out_shape), ]
+    !isnothing(quantization_info) && push!(attributes, namedattribute("quantization_info", quantization_info))
+    
+    IR.create_operation(
+        "tosa.transpose_conv2d", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1939,21 +1493,17 @@ end
 Permutes the dimensions based on perm.
 """
 function transpose(input1::Value, perms::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1, perms]
+    results = IR.Type[output, ]
+    operands = Value[input1, perms, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.transpose",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.transpose", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1965,28 +1515,18 @@ exits to another control point. This action is performed repeatedly after
 updating and re-evaluating the Boolean condition every iteration. This
 implements the semantic foreach or while iterative loop structure.
 """
-function while_loop(
-    inputs::Vector{Value};
-    output::Vector{IR.Type},
-    cond::Region,
-    body::Region,
-    location=Location(),
-)
-    results = IR.Type[output...,]
-    operands = Value[inputs...,]
-    owned_regions = Region[cond, body]
+function while_loop(inputs::Vector{Value}; output::Vector{IR.Type}, cond::Region, body::Region, location=Location())
+    results = IR.Type[output..., ]
+    operands = Value[inputs..., ]
+    owned_regions = Region[cond, body, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.while_loop",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.while_loop", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1999,20 +1539,16 @@ but produces no results of its own.
 """
 function yield(inputs::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[inputs...,]
+    operands = Value[inputs..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.yield",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.yield", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/16/Transform.jl
+++ b/src/Dialects/16/Transform.jl
@@ -1,8 +1,8 @@
 module transform
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `affine_simplify_bounded_affine_ops`
@@ -33,37 +33,24 @@ handles.
 TODO: Support affine.apply targets.
 TODO: Allow mixed PDL_Operation/int64_t for lower_bounds and upper_bounds.
 """
-function affine_simplify_bounded_affine_ops(
-    target::Value,
-    bounded_values::Vector{Value};
-    lower_bounds,
-    upper_bounds,
-    location=Location(),
-)
+function affine_simplify_bounded_affine_ops(target::Value, bounded_values::Vector{Value}; lower_bounds, upper_bounds, location=Location())
     results = IR.Type[]
-    operands = Value[target, bounded_values...]
+    operands = Value[target, bounded_values..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("lower_bounds", lower_bounds),
-        namedattribute("upper_bounds", upper_bounds),
-    ]
-
-    return IR.create_operation(
-        "transform.affine.simplify_bounded_affine_ops",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("lower_bounds", lower_bounds), namedattribute("upper_bounds", upper_bounds), ]
+    
+    IR.create_operation(
+        "transform.affine.simplify_bounded_affine_ops", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `bufferization_empty_tensor_to_alloc_tensor`
@@ -76,24 +63,18 @@ This operation consumes the `target` handle and produces the `transformed`
 handle. `target` is expected to be a `tensor.empty` operation. The transform
 always succeeds.
 """
-function bufferization_empty_tensor_to_alloc_tensor(
-    target::Value; transformed::IR.Type, location=Location()
-)
-    results = IR.Type[transformed,]
-    operands = Value[target,]
+function bufferization_empty_tensor_to_alloc_tensor(target::Value; transformed::IR.Type, location=Location())
+    results = IR.Type[transformed, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.bufferization.empty_tensor_to_alloc_tensor",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.bufferization.empty_tensor_to_alloc_tensor", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -118,61 +99,32 @@ Many ops implement `BufferizableOpInterface` via an external model. These
 external models must be registered when applying this transform op;
 otherwise, said ops would be considered non-bufferizable.
 """
-function bufferization_one_shot_bufferize(
-    target::Value;
-    function_boundary_type_conversion=nothing,
-    allow_return_allocs=nothing,
-    allow_unknown_ops=nothing,
-    bufferize_function_boundaries=nothing,
-    create_deallocs=nothing,
-    target_is_module=nothing,
-    test_analysis_only=nothing,
-    print_conflicts=nothing,
-    location=Location(),
-)
+function bufferization_one_shot_bufferize(target::Value; function_boundary_type_conversion=nothing, allow_return_allocs=nothing, allow_unknown_ops=nothing, bufferize_function_boundaries=nothing, create_deallocs=nothing, target_is_module=nothing, test_analysis_only=nothing, print_conflicts=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[target,]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(function_boundary_type_conversion) && push!(
-        attributes,
-        namedattribute(
-            "function_boundary_type_conversion", function_boundary_type_conversion
-        ),
-    )
-    !isnothing(allow_return_allocs) &&
-        push!(attributes, namedattribute("allow_return_allocs", allow_return_allocs))
-    !isnothing(allow_unknown_ops) &&
-        push!(attributes, namedattribute("allow_unknown_ops", allow_unknown_ops))
-    !isnothing(bufferize_function_boundaries) && push!(
-        attributes,
-        namedattribute("bufferize_function_boundaries", bufferize_function_boundaries),
-    )
-    !isnothing(create_deallocs) &&
-        push!(attributes, namedattribute("create_deallocs", create_deallocs))
-    !isnothing(target_is_module) &&
-        push!(attributes, namedattribute("target_is_module", target_is_module))
-    !isnothing(test_analysis_only) &&
-        push!(attributes, namedattribute("test_analysis_only", test_analysis_only))
-    !isnothing(print_conflicts) &&
-        push!(attributes, namedattribute("print_conflicts", print_conflicts))
-
-    return IR.create_operation(
-        "transform.bufferization.one_shot_bufferize",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(function_boundary_type_conversion) && push!(attributes, namedattribute("function_boundary_type_conversion", function_boundary_type_conversion))
+    !isnothing(allow_return_allocs) && push!(attributes, namedattribute("allow_return_allocs", allow_return_allocs))
+    !isnothing(allow_unknown_ops) && push!(attributes, namedattribute("allow_unknown_ops", allow_unknown_ops))
+    !isnothing(bufferize_function_boundaries) && push!(attributes, namedattribute("bufferize_function_boundaries", bufferize_function_boundaries))
+    !isnothing(create_deallocs) && push!(attributes, namedattribute("create_deallocs", create_deallocs))
+    !isnothing(target_is_module) && push!(attributes, namedattribute("target_is_module", target_is_module))
+    !isnothing(test_analysis_only) && push!(attributes, namedattribute("test_analysis_only", test_analysis_only))
+    !isnothing(print_conflicts) && push!(attributes, namedattribute("print_conflicts", print_conflicts))
+    
+    IR.create_operation(
+        "transform.bufferization.one_shot_bufferize", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `gpu_map_foreach_to_blocks`
@@ -212,31 +164,20 @@ The returned handle points to the same LaunchOp operand, consuming it and
 producing a new SSA value to satisfy chaining and linearity of the IR
 properties.
 """
-function gpu_map_foreach_to_blocks(
-    target::Value;
-    result::IR.Type,
-    gridDim=nothing,
-    generate_gpu_launch=nothing,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[target,]
+function gpu_map_foreach_to_blocks(target::Value; result::IR.Type, gridDim=nothing, generate_gpu_launch=nothing, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(gridDim) && push!(attributes, namedattribute("gridDim", gridDim))
-    !isnothing(generate_gpu_launch) &&
-        push!(attributes, namedattribute("generate_gpu_launch", generate_gpu_launch))
-
-    return IR.create_operation(
-        "transform.gpu.map_foreach_to_blocks",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(generate_gpu_launch) && push!(attributes, namedattribute("generate_gpu_launch", generate_gpu_launch))
+    
+    IR.create_operation(
+        "transform.gpu.map_foreach_to_blocks", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -319,37 +260,26 @@ gpu.launch blocks(%bx, %by, %bz) in (%x = %0, %y = %1, %z = %2)
 }
 ```
 """
-function gpu_map_nested_foreach_to_threads(
-    target::Value;
-    result::IR.Type,
-    blockDim=nothing,
-    syncAfterDistribute=nothing,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[target,]
+function gpu_map_nested_foreach_to_threads(target::Value; result::IR.Type, blockDim=nothing, syncAfterDistribute=nothing, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(blockDim) && push!(attributes, namedattribute("blockDim", blockDim))
-    !isnothing(syncAfterDistribute) &&
-        push!(attributes, namedattribute("syncAfterDistribute", syncAfterDistribute))
-
-    return IR.create_operation(
-        "transform.gpu.map_nested_foreach_to_threads",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(syncAfterDistribute) && push!(attributes, namedattribute("syncAfterDistribute", syncAfterDistribute))
+    
+    IR.create_operation(
+        "transform.gpu.map_nested_foreach_to_threads", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `structured_decompose`
@@ -367,21 +297,17 @@ The return handle points to only the subset of successfully produced
 computational operations, which can be empty.
 """
 function structured_decompose(target::Value; transformed::IR.Type, location=Location())
-    results = IR.Type[transformed,]
-    operands = Value[target,]
+    results = IR.Type[transformed, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.structured.decompose",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.structured.decompose", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -419,24 +345,18 @@ op are rejected by this operation.
 This operation reads and frees the producer handle.
 This operation reads the containing op handle.
 """
-function structured_fuse_into_containing_op(
-    producer_op::Value, containing_op::Value; fused_op::IR.Type, location=Location()
-)
-    results = IR.Type[fused_op,]
-    operands = Value[producer_op, containing_op]
+function structured_fuse_into_containing_op(producer_op::Value, containing_op::Value; fused_op::IR.Type, location=Location())
+    results = IR.Type[fused_op, ]
+    operands = Value[producer_op, containing_op, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.structured.fuse_into_containing_op",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.structured.fuse_into_containing_op", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -446,32 +366,20 @@ end
 Tiles the operations pointed to by the target handle and fuses their
 producers greedily using the options provided as attributes.
 """
-function structured_fuse(
-    target::Value;
-    transformed::IR.Type,
-    loops::Vector{IR.Type},
-    tile_sizes=nothing,
-    tile_interchange=nothing,
-    location=Location(),
-)
-    results = IR.Type[transformed, loops...]
-    operands = Value[target,]
+function structured_fuse(target::Value; transformed::IR.Type, loops::Vector{IR.Type}, tile_sizes=nothing, tile_interchange=nothing, location=Location())
+    results = IR.Type[transformed, loops..., ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(tile_sizes) && push!(attributes, namedattribute("tile_sizes", tile_sizes))
-    !isnothing(tile_interchange) &&
-        push!(attributes, namedattribute("tile_interchange", tile_interchange))
-
-    return IR.create_operation(
-        "transform.structured.fuse",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(tile_interchange) && push!(attributes, namedattribute("tile_interchange", tile_interchange))
+    
+    IR.create_operation(
+        "transform.structured.fuse", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -491,21 +399,17 @@ equivalent generic operations, which can be empty or contain the original
 ops if they were already in generic form.
 """
 function structured_generalize(target::Value; transformed::IR.Type, location=Location())
-    results = IR.Type[transformed,]
-    operands = Value[target,]
+    results = IR.Type[transformed, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.structured.generalize",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.structured.generalize", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -525,26 +429,19 @@ If any interchange fails, the transform definitely fails.
 The return handle points to only the subset of successfully produced
 interchanged operations, which can be empty.
 """
-function structured_interchange(
-    target::Value; transformed::IR.Type, iterator_interchange=nothing, location=Location()
-)
-    results = IR.Type[transformed,]
-    operands = Value[target,]
+function structured_interchange(target::Value; transformed::IR.Type, iterator_interchange=nothing, location=Location())
+    results = IR.Type[transformed, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(iterator_interchange) &&
-        push!(attributes, namedattribute("iterator_interchange", iterator_interchange))
-
-    return IR.create_operation(
-        "transform.structured.interchange",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(iterator_interchange) && push!(attributes, namedattribute("iterator_interchange", iterator_interchange))
+    
+    IR.create_operation(
+        "transform.structured.interchange", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -565,29 +462,19 @@ values) do not satify the constraints mentioned above. It produces a
 silenceable failure if at least one target op is not a Linalg op or fails to
 vectorize.
 """
-function structured_masked_vectorize(
-    target::Value,
-    vector_sizes::Vector{Value};
-    static_vector_sizes=nothing,
-    location=Location(),
-)
+function structured_masked_vectorize(target::Value, vector_sizes::Vector{Value}; static_vector_sizes=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[target, vector_sizes...]
+    operands = Value[target, vector_sizes..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(static_vector_sizes) &&
-        push!(attributes, namedattribute("static_vector_sizes", static_vector_sizes))
-
-    return IR.create_operation(
-        "transform.structured.masked_vectorize",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(static_vector_sizes) && push!(attributes, namedattribute("static_vector_sizes", static_vector_sizes))
+    
+    IR.create_operation(
+        "transform.structured.masked_vectorize", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -621,35 +508,22 @@ Otherwise it succeeds.
 This operation does not consume the target handle and produces new handles:
 it is a navigation op.
 """
-function structured_match(
-    target::Value;
-    results::IR.Type,
-    ops=nothing,
-    interface=nothing,
-    op_attrs=nothing,
-    filter_result_type=nothing,
-    location=Location(),
-)
-    results = IR.Type[results,]
-    operands = Value[target,]
+function structured_match(target::Value; results_::IR.Type, ops=nothing, interface=nothing, op_attrs=nothing, filter_result_type=nothing, location=Location())
+    results = IR.Type[results_, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(ops) && push!(attributes, namedattribute("ops", ops))
     !isnothing(interface) && push!(attributes, namedattribute("interface", interface))
     !isnothing(op_attrs) && push!(attributes, namedattribute("op_attrs", op_attrs))
-    !isnothing(filter_result_type) &&
-        push!(attributes, namedattribute("filter_result_type", filter_result_type))
-
-    return IR.create_operation(
-        "transform.structured.match",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(filter_result_type) && push!(attributes, namedattribute("filter_result_type", filter_result_type))
+    
+    IR.create_operation(
+        "transform.structured.match", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -709,34 +583,19 @@ structured.split %common after %splitr { dimension = 0 }
 // ...
 ```
 """
-function structured_multitile_sizes(
-    target::Value;
-    low_size::IR.Type,
-    high_size::IR.Type,
-    split_point::IR.Type,
-    dimension,
-    target_size,
-    divisor=nothing,
-    location=Location(),
-)
-    results = IR.Type[low_size, high_size, split_point]
-    operands = Value[target,]
+function structured_multitile_sizes(target::Value; low_size::IR.Type, high_size::IR.Type, split_point::IR.Type, dimension, target_size, divisor=nothing, location=Location())
+    results = IR.Type[low_size, high_size, split_point, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("dimension", dimension), namedattribute("target_size", target_size)
-    ]
+    attributes = NamedAttribute[namedattribute("dimension", dimension), namedattribute("target_size", target_size), ]
     !isnothing(divisor) && push!(attributes, namedattribute("divisor", divisor))
-
-    return IR.create_operation(
-        "transform.structured.multitile_sizes",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.structured.multitile_sizes", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -801,30 +660,19 @@ reason.
 
 The returned handle point to the packed LinalgOp.
 """
-function structured_pack(
-    target::Value,
-    packed_sizes::Vector{Value};
-    packed_op::IR.Type,
-    static_packed_sizes=nothing,
-    location=Location(),
-)
-    results = IR.Type[packed_op,]
-    operands = Value[target, packed_sizes...]
+function structured_pack(target::Value, packed_sizes::Vector{Value}; packed_op::IR.Type, static_packed_sizes=nothing, location=Location())
+    results = IR.Type[packed_op, ]
+    operands = Value[target, packed_sizes..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(static_packed_sizes) &&
-        push!(attributes, namedattribute("static_packed_sizes", static_packed_sizes))
-
-    return IR.create_operation(
-        "transform.structured.pack",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(static_packed_sizes) && push!(attributes, namedattribute("static_packed_sizes", static_packed_sizes))
+    
+    IR.create_operation(
+        "transform.structured.pack", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -866,33 +714,20 @@ the transformed `tensor.pack` and one to the transformed `tensor.unpack`.
 The last handle for `tensor.unpack` is empty if `target_pack_or_unpack_op` 
 was not itself a `tensor.unpack`.
 """
-function structured_pack_transpose(
-    target_pack_or_un_pack_op::Value,
-    target_linalg_op::Value;
-    packed_op::IR.Type,
-    pack_op::IR.Type,
-    un_pack_op::IR.Type,
-    outer_perm=nothing,
-    inner_perm=nothing,
-    location=Location(),
-)
-    results = IR.Type[packed_op, pack_op, un_pack_op]
-    operands = Value[target_pack_or_un_pack_op, target_linalg_op]
+function structured_pack_transpose(target_pack_or_un_pack_op::Value, target_linalg_op::Value; packed_op::IR.Type, pack_op::IR.Type, un_pack_op::IR.Type, outer_perm=nothing, inner_perm=nothing, location=Location())
+    results = IR.Type[packed_op, pack_op, un_pack_op, ]
+    operands = Value[target_pack_or_un_pack_op, target_linalg_op, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(outer_perm) && push!(attributes, namedattribute("outer_perm", outer_perm))
     !isnothing(inner_perm) && push!(attributes, namedattribute("inner_perm", inner_perm))
-
-    return IR.create_operation(
-        "transform.structured.pack_transpose",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.structured.pack_transpose", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -912,41 +747,23 @@ properly, the transform succeeds. Otherwise the transform silently fails.
 The return handle points to only the subset of successfully produced
 padded operations, which can be empty.
 """
-function structured_pad(
-    target::Value;
-    transformed::IR.Type,
-    padding_values=nothing,
-    padding_dimensions=nothing,
-    pack_paddings=nothing,
-    hoist_paddings=nothing,
-    transpose_paddings=nothing,
-    location=Location(),
-)
-    results = IR.Type[transformed,]
-    operands = Value[target,]
+function structured_pad(target::Value; transformed::IR.Type, padding_values=nothing, padding_dimensions=nothing, pack_paddings=nothing, hoist_paddings=nothing, transpose_paddings=nothing, location=Location())
+    results = IR.Type[transformed, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(padding_values) &&
-        push!(attributes, namedattribute("padding_values", padding_values))
-    !isnothing(padding_dimensions) &&
-        push!(attributes, namedattribute("padding_dimensions", padding_dimensions))
-    !isnothing(pack_paddings) &&
-        push!(attributes, namedattribute("pack_paddings", pack_paddings))
-    !isnothing(hoist_paddings) &&
-        push!(attributes, namedattribute("hoist_paddings", hoist_paddings))
-    !isnothing(transpose_paddings) &&
-        push!(attributes, namedattribute("transpose_paddings", transpose_paddings))
-
-    return IR.create_operation(
-        "transform.structured.pad",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(padding_values) && push!(attributes, namedattribute("padding_values", padding_values))
+    !isnothing(padding_dimensions) && push!(attributes, namedattribute("padding_dimensions", padding_dimensions))
+    !isnothing(pack_paddings) && push!(attributes, namedattribute("pack_paddings", pack_paddings))
+    !isnothing(hoist_paddings) && push!(attributes, namedattribute("hoist_paddings", hoist_paddings))
+    !isnothing(transpose_paddings) && push!(attributes, namedattribute("transpose_paddings", transpose_paddings))
+    
+    IR.create_operation(
+        "transform.structured.pad", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -969,41 +786,23 @@ properly, the transform succeeds.
 When successful, the return handle points to the \$target operation that
 was modified inplace.
 """
-function structured_promote(
-    target::Value;
-    transformed::IR.Type,
-    operands_to_promote=nothing,
-    use_full_tile_buffers=nothing,
-    use_full_tiles_by_default=nothing,
-    use_alloca=nothing,
-    alignment=nothing,
-    location=Location(),
-)
-    results = IR.Type[transformed,]
-    operands = Value[target,]
+function structured_promote(target::Value; transformed::IR.Type, operands_to_promote=nothing, use_full_tile_buffers=nothing, use_full_tiles_by_default=nothing, use_alloca=nothing, alignment=nothing, location=Location())
+    results = IR.Type[transformed, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(operands_to_promote) &&
-        push!(attributes, namedattribute("operands_to_promote", operands_to_promote))
-    !isnothing(use_full_tile_buffers) &&
-        push!(attributes, namedattribute("use_full_tile_buffers", use_full_tile_buffers))
-    !isnothing(use_full_tiles_by_default) && push!(
-        attributes,
-        namedattribute("use_full_tiles_by_default", use_full_tiles_by_default),
-    )
+    !isnothing(operands_to_promote) && push!(attributes, namedattribute("operands_to_promote", operands_to_promote))
+    !isnothing(use_full_tile_buffers) && push!(attributes, namedattribute("use_full_tile_buffers", use_full_tile_buffers))
+    !isnothing(use_full_tiles_by_default) && push!(attributes, namedattribute("use_full_tiles_by_default", use_full_tiles_by_default))
     !isnothing(use_alloca) && push!(attributes, namedattribute("use_alloca", use_alloca))
     !isnothing(alignment) && push!(attributes, namedattribute("alignment", alignment))
-
-    return IR.create_operation(
-        "transform.structured.promote",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.structured.promote", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1020,24 +819,18 @@ This op is for debugging/experiments only.
 
 This operation consumes the `target` handle.
 """
-function structured_replace(
-    target::Value; replacement::IR.Type, bodyRegion::Region, location=Location()
-)
-    results = IR.Type[replacement,]
-    operands = Value[target,]
-    owned_regions = Region[bodyRegion,]
+function structured_replace(target::Value; replacement::IR.Type, bodyRegion::Region, location=Location())
+    results = IR.Type[replacement, ]
+    operands = Value[target, ]
+    owned_regions = Region[bodyRegion, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.structured.replace",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.structured.replace", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1066,21 +859,17 @@ Loops can always be recovered by navigating from the tiled operations if
 needed.
 """
 function structured_scalarize(target::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[target,]
+    results = IR.Type[result, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.structured.scalarize",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.structured.scalarize", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1105,34 +894,19 @@ of the structured op after splitting, in the same order as the target
 operand, with the first handle corresponding to the part with lower
 iteration space indices.
 """
-function structured_split(
-    target::Value,
-    dynamic_split_point=nothing::Union{Nothing,Value};
-    first::IR.Type,
-    second::IR.Type,
-    dimension,
-    static_split_point,
-    location=Location(),
-)
-    results = IR.Type[first, second]
-    operands = Value[target,]
+function structured_split(target::Value, dynamic_split_point=nothing::Union{Nothing, Value}; first::IR.Type, second::IR.Type, dimension, static_split_point, location=Location())
+    results = IR.Type[first, second, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("dimension", dimension),
-        namedattribute("static_split_point", static_split_point),
-    ]
+    attributes = NamedAttribute[namedattribute("dimension", dimension), namedattribute("static_split_point", static_split_point), ]
     !isnothing(dynamic_split_point) && push!(operands, dynamic_split_point)
-
-    return IR.create_operation(
-        "transform.structured.split",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.structured.split", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1272,43 +1046,23 @@ Is transformed to:
  return %4 : tensor<16x32xf32>
 ```
 """
-function structured_split_reduction(
-    target::Value;
-    init_or_alloc_op::IR.Type,
-    fill_op::IR.Type,
-    split_linalg_op::IR.Type,
-    combining_linalg_op::IR.Type,
-    split_factor=nothing,
-    insert_split_dimension=nothing,
-    inner_parallel=nothing,
-    use_scaling_algorithm=nothing,
-    use_alloc=nothing,
-    location=Location(),
-)
-    results = IR.Type[init_or_alloc_op, fill_op, split_linalg_op, combining_linalg_op]
-    operands = Value[target,]
+function structured_split_reduction(target::Value; init_or_alloc_op::IR.Type, fill_op::IR.Type, split_linalg_op::IR.Type, combining_linalg_op::IR.Type, split_factor=nothing, insert_split_dimension=nothing, inner_parallel=nothing, use_scaling_algorithm=nothing, use_alloc=nothing, location=Location())
+    results = IR.Type[init_or_alloc_op, fill_op, split_linalg_op, combining_linalg_op, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(split_factor) &&
-        push!(attributes, namedattribute("split_factor", split_factor))
-    !isnothing(insert_split_dimension) &&
-        push!(attributes, namedattribute("insert_split_dimension", insert_split_dimension))
-    !isnothing(inner_parallel) &&
-        push!(attributes, namedattribute("inner_parallel", inner_parallel))
-    !isnothing(use_scaling_algorithm) &&
-        push!(attributes, namedattribute("use_scaling_algorithm", use_scaling_algorithm))
+    !isnothing(split_factor) && push!(attributes, namedattribute("split_factor", split_factor))
+    !isnothing(insert_split_dimension) && push!(attributes, namedattribute("insert_split_dimension", insert_split_dimension))
+    !isnothing(inner_parallel) && push!(attributes, namedattribute("inner_parallel", inner_parallel))
+    !isnothing(use_scaling_algorithm) && push!(attributes, namedattribute("use_scaling_algorithm", use_scaling_algorithm))
     !isnothing(use_alloc) && push!(attributes, namedattribute("use_alloc", use_alloc))
-
-    return IR.create_operation(
-        "transform.structured.split_reduction",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.structured.split_reduction", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1351,33 +1105,20 @@ that of the list associated with the `target` handle.
 If the internal implementation of tiling for any of the operations fails,
 produces a definite failure.
 """
-function structured_tile(
-    target::Value,
-    dynamic_sizes::Vector{Value};
-    tiled_linalg_op::IR.Type,
-    loops::Vector{IR.Type},
-    static_sizes=nothing,
-    interchange=nothing,
-    location=Location(),
-)
-    results = IR.Type[tiled_linalg_op, loops...]
-    operands = Value[target, dynamic_sizes...]
+function structured_tile(target::Value, dynamic_sizes::Vector{Value}; tiled_linalg_op::IR.Type, loops::Vector{IR.Type}, static_sizes=nothing, interchange=nothing, location=Location())
+    results = IR.Type[tiled_linalg_op, loops..., ]
+    operands = Value[target, dynamic_sizes..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(static_sizes) &&
-        push!(attributes, namedattribute("static_sizes", static_sizes))
+    !isnothing(static_sizes) && push!(attributes, namedattribute("static_sizes", static_sizes))
     !isnothing(interchange) && push!(attributes, namedattribute("interchange", interchange))
-
-    return IR.create_operation(
-        "transform.structured.tile",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.structured.tile", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1448,35 +1189,21 @@ is transformed into:
   } -> tensor<?xf32>
 ```
 """
-function structured_tile_reduction_using_foreach_thread(
-    target::Value;
-    foreach_thread_op::IR.Type,
-    fill_op::IR.Type,
-    split_linalg_op::IR.Type,
-    combining_linalg_op::IR.Type,
-    num_threads=nothing,
-    tile_sizes=nothing,
-    mapping=nothing,
-    location=Location(),
-)
-    results = IR.Type[foreach_thread_op, fill_op, split_linalg_op, combining_linalg_op]
-    operands = Value[target,]
+function structured_tile_reduction_using_foreach_thread(target::Value; foreach_thread_op::IR.Type, fill_op::IR.Type, split_linalg_op::IR.Type, combining_linalg_op::IR.Type, num_threads=nothing, tile_sizes=nothing, mapping=nothing, location=Location())
+    results = IR.Type[foreach_thread_op, fill_op, split_linalg_op, combining_linalg_op, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(num_threads) && push!(attributes, namedattribute("num_threads", num_threads))
     !isnothing(tile_sizes) && push!(attributes, namedattribute("tile_sizes", tile_sizes))
     !isnothing(mapping) && push!(attributes, namedattribute("mapping", mapping))
-
-    return IR.create_operation(
-        "transform.structured.tile_reduction_using_foreach_thread",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.structured.tile_reduction_using_foreach_thread", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1550,31 +1277,19 @@ is transformed into:
   } -> tensor<?xf32>
 ```
 """
-function structured_tile_reduction_using_scf(
-    target::Value;
-    for_op::IR.Type,
-    fill_op::IR.Type,
-    split_linalg_op::IR.Type,
-    combining_linalg_op::IR.Type,
-    tile_sizes=nothing,
-    location=Location(),
-)
-    results = IR.Type[for_op, fill_op, split_linalg_op, combining_linalg_op]
-    operands = Value[target,]
+function structured_tile_reduction_using_scf(target::Value; for_op::IR.Type, fill_op::IR.Type, split_linalg_op::IR.Type, combining_linalg_op::IR.Type, tile_sizes=nothing, location=Location())
+    results = IR.Type[for_op, fill_op, split_linalg_op, combining_linalg_op, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(tile_sizes) && push!(attributes, namedattribute("tile_sizes", tile_sizes))
-
-    return IR.create_operation(
-        "transform.structured.tile_reduction_using_scf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.structured.tile_reduction_using_scf", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1635,56 +1350,24 @@ These two returned handles point to:
 %3:2 = transform.structured.tile_to_foreach_thread_op %0 tile_sizes [0, %sz, 20]
 ```
 """
-function structured_tile_to_foreach_thread_op(
-    target::Value,
-    num_threads::Vector{Value},
-    tile_sizes::Vector{Value},
-    packed_num_threads=nothing::Union{Nothing,Value};
-    packed_tile_sizes=nothing::Union{Nothing,Value},
-    foreach_thread_op::IR.Type,
-    tiled_op::IR.Type,
-    static_num_threads=nothing,
-    static_tile_sizes=nothing,
-    mapping=nothing,
-    location=Location(),
-)
-    results = IR.Type[foreach_thread_op, tiled_op]
-    operands = Value[target, num_threads..., tile_sizes...]
+function structured_tile_to_foreach_thread_op(target::Value, num_threads::Vector{Value}, tile_sizes::Vector{Value}, packed_num_threads=nothing::Union{Nothing, Value}; packed_tile_sizes=nothing::Union{Nothing, Value}, foreach_thread_op::IR.Type, tiled_op::IR.Type, static_num_threads=nothing, static_tile_sizes=nothing, mapping=nothing, location=Location())
+    results = IR.Type[foreach_thread_op, tiled_op, ]
+    operands = Value[target, num_threads..., tile_sizes..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(packed_num_threads) && push!(operands, packed_num_threads)
     !isnothing(packed_tile_sizes) && push!(operands, packed_tile_sizes)
-    push!(
-        attributes,
-        operandsegmentsizes([
-            1,
-            length(num_threads),
-            length(tile_sizes),
-            if (packed_num_threads == nothing)
-                0
-            elseif 1(packed_tile_sizes == nothing)
-                0
-            else
-                1
-            end,
-        ]),
-    )
-    !isnothing(static_num_threads) &&
-        push!(attributes, namedattribute("static_num_threads", static_num_threads))
-    !isnothing(static_tile_sizes) &&
-        push!(attributes, namedattribute("static_tile_sizes", static_tile_sizes))
+    push!(attributes, operandsegmentsizes([1, length(num_threads), length(tile_sizes), isnothing(packed_num_threads) ? 0 : 1, isnothing(packed_tile_sizes) ? 0 : 1, ]))
+    !isnothing(static_num_threads) && push!(attributes, namedattribute("static_num_threads", static_num_threads))
+    !isnothing(static_tile_sizes) && push!(attributes, namedattribute("static_tile_sizes", static_tile_sizes))
     !isnothing(mapping) && push!(attributes, namedattribute("mapping", mapping))
-
-    return IR.create_operation(
-        "transform.structured.tile_to_foreach_thread_op",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.structured.tile_to_foreach_thread_op", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1727,33 +1410,20 @@ that of the list associated with the `target` handle.
 If the internal implementation of tiling for any of the operations fails,
 produces a definite failure.
 """
-function structured_tile_to_scf_for(
-    target::Value,
-    dynamic_sizes::Vector{Value};
-    tiled_linalg_op::IR.Type,
-    loops::Vector{IR.Type},
-    static_sizes=nothing,
-    interchange=nothing,
-    location=Location(),
-)
-    results = IR.Type[tiled_linalg_op, loops...]
-    operands = Value[target, dynamic_sizes...]
+function structured_tile_to_scf_for(target::Value, dynamic_sizes::Vector{Value}; tiled_linalg_op::IR.Type, loops::Vector{IR.Type}, static_sizes=nothing, interchange=nothing, location=Location())
+    results = IR.Type[tiled_linalg_op, loops..., ]
+    operands = Value[target, dynamic_sizes..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(static_sizes) &&
-        push!(attributes, namedattribute("static_sizes", static_sizes))
+    !isnothing(static_sizes) && push!(attributes, namedattribute("static_sizes", static_sizes))
     !isnothing(interchange) && push!(attributes, namedattribute("interchange", interchange))
-
-    return IR.create_operation(
-        "transform.structured.tile_to_scf_for",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.structured.tile_to_scf_for", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1794,54 +1464,28 @@ reason.
 The operation always returns the handle to the target op that is expected
 to be isolated from above.
 """
-function structured_vectorize(
-    target::Value;
-    transformed::IR.Type,
-    vectorize_padding=nothing,
-    vectorize_nd_extract=nothing,
-    disable_multi_reduction_to_contract_patterns=nothing,
-    disable_transfer_permutation_map_lowering_patterns=nothing,
-    location=Location(),
-)
-    results = IR.Type[transformed,]
-    operands = Value[target,]
+function structured_vectorize(target::Value; transformed::IR.Type, vectorize_padding=nothing, vectorize_nd_extract=nothing, disable_multi_reduction_to_contract_patterns=nothing, disable_transfer_permutation_map_lowering_patterns=nothing, location=Location())
+    results = IR.Type[transformed, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(vectorize_padding) &&
-        push!(attributes, namedattribute("vectorize_padding", vectorize_padding))
-    !isnothing(vectorize_nd_extract) &&
-        push!(attributes, namedattribute("vectorize_nd_extract", vectorize_nd_extract))
-    !isnothing(disable_multi_reduction_to_contract_patterns) && push!(
-        attributes,
-        namedattribute(
-            "disable_multi_reduction_to_contract_patterns",
-            disable_multi_reduction_to_contract_patterns,
-        ),
-    )
-    !isnothing(disable_transfer_permutation_map_lowering_patterns) && push!(
-        attributes,
-        namedattribute(
-            "disable_transfer_permutation_map_lowering_patterns",
-            disable_transfer_permutation_map_lowering_patterns,
-        ),
-    )
-
-    return IR.create_operation(
-        "transform.structured.vectorize",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(vectorize_padding) && push!(attributes, namedattribute("vectorize_padding", vectorize_padding))
+    !isnothing(vectorize_nd_extract) && push!(attributes, namedattribute("vectorize_nd_extract", vectorize_nd_extract))
+    !isnothing(disable_multi_reduction_to_contract_patterns) && push!(attributes, namedattribute("disable_multi_reduction_to_contract_patterns", disable_multi_reduction_to_contract_patterns))
+    !isnothing(disable_transfer_permutation_map_lowering_patterns) && push!(attributes, namedattribute("disable_transfer_permutation_map_lowering_patterns", disable_transfer_permutation_map_lowering_patterns))
+    
+    IR.create_operation(
+        "transform.structured.vectorize", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `memref_multibuffer`
@@ -1857,30 +1501,24 @@ multibuffered allocation.
 This operation returns the new allocation if multi-buffering
 succeeds, and failure otherwise.
 """
-function memref_multibuffer(
-    target::Value; transformed::IR.Type, factor, location=Location()
-)
-    results = IR.Type[transformed,]
-    operands = Value[target,]
+function memref_multibuffer(target::Value; transformed::IR.Type, factor, location=Location())
+    results = IR.Type[transformed, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("factor", factor),]
-
-    return IR.create_operation(
-        "transform.memref.multibuffer",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("factor", factor), ]
+    
+    IR.create_operation(
+        "transform.memref.multibuffer", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `loop_get_parent_for`
@@ -1892,26 +1530,20 @@ of operations associated with the handle contains parent operations in the
 same order as the list associated with the operand, except for operations
 that are parents to more than one input which are only present once.
 """
-function loop_get_parent_for(
-    target::Value; parent::IR.Type, num_loops=nothing, affine=nothing, location=Location()
-)
-    results = IR.Type[parent,]
-    operands = Value[target,]
+function loop_get_parent_for(target::Value; parent::IR.Type, num_loops=nothing, affine=nothing, location=Location())
+    results = IR.Type[parent, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(num_loops) && push!(attributes, namedattribute("num_loops", num_loops))
     !isnothing(affine) && push!(attributes, namedattribute("affine", affine))
-
-    return IR.create_operation(
-        "transform.loop.get_parent_for",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.loop.get_parent_for", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1927,21 +1559,17 @@ The return handle points to the coalesced loop if coalescing happens, or
 the given input loop if coalescing does not happen.
 """
 function loop_coalesce(target::Value; transformed::IR.Type, location=Location())
-    results = IR.Type[transformed,]
-    operands = Value[target,]
+    results = IR.Type[transformed, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.loop.coalesce",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.loop.coalesce", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1960,21 +1588,17 @@ module). Returns the handle to the list of outlined functions in the same
 order as the operand handle.
 """
 function loop_outline(target::Value; transformed::IR.Type, func_name, location=Location())
-    results = IR.Type[transformed,]
-    operands = Value[target,]
+    results = IR.Type[transformed, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("func_name", func_name),]
-
-    return IR.create_operation(
-        "transform.loop.outline",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("func_name", func_name), ]
+    
+    IR.create_operation(
+        "transform.loop.outline", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2002,31 +1626,19 @@ one.
 
 TODO: Return both the peeled loop and the remainder loop.
 """
-function loop_peel(
-    target::Value;
-    transformed::IR.Type,
-    fail_if_already_divisible=nothing,
-    location=Location(),
-)
-    results = IR.Type[transformed,]
-    operands = Value[target,]
+function loop_peel(target::Value; transformed::IR.Type, fail_if_already_divisible=nothing, location=Location())
+    results = IR.Type[transformed, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(fail_if_already_divisible) && push!(
-        attributes,
-        namedattribute("fail_if_already_divisible", fail_if_already_divisible),
-    )
-
-    return IR.create_operation(
-        "transform.loop.peel",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(fail_if_already_divisible) && push!(attributes, namedattribute("fail_if_already_divisible", fail_if_already_divisible))
+    
+    IR.create_operation(
+        "transform.loop.peel", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2053,32 +1665,20 @@ properly, the transform succeeds. Otherwise the transform silently fails.
 The return handle points to only the subset of successfully produced
 pipelined loops, which can be empty.
 """
-function loop_pipeline(
-    target::Value;
-    transformed::IR.Type,
-    iteration_interval=nothing,
-    read_latency=nothing,
-    location=Location(),
-)
-    results = IR.Type[transformed,]
-    operands = Value[target,]
+function loop_pipeline(target::Value; transformed::IR.Type, iteration_interval=nothing, read_latency=nothing, location=Location())
+    results = IR.Type[transformed, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(iteration_interval) &&
-        push!(attributes, namedattribute("iteration_interval", iteration_interval))
-    !isnothing(read_latency) &&
-        push!(attributes, namedattribute("read_latency", read_latency))
-
-    return IR.create_operation(
-        "transform.loop.pipeline",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(iteration_interval) && push!(attributes, namedattribute("iteration_interval", iteration_interval))
+    !isnothing(read_latency) && push!(attributes, namedattribute("read_latency", read_latency))
+    
+    IR.create_operation(
+        "transform.loop.pipeline", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2101,26 +1701,22 @@ removed after a full unrolling.
 """
 function loop_unroll(target::Value; factor, location=Location())
     results = IR.Type[]
-    operands = Value[target,]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("factor", factor),]
-
-    return IR.create_operation(
-        "transform.loop.unroll",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("factor", factor), ]
+    
+    IR.create_operation(
+        "transform.loop.unroll", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `alternatives`
@@ -2183,28 +1779,19 @@ Remark: this op allows one to implement a simple \"try\" construct as follows:
 }
 ```
 """
-function alternatives(
-    scope=nothing::Union{Nothing,Value};
-    results::Vector{IR.Type},
-    alternatives::Vector{Region},
-    location=Location(),
-)
-    results = IR.Type[results...,]
+function alternatives(scope=nothing::Union{Nothing, Value}; results_::Vector{IR.Type}, alternatives::Vector{Region}, location=Location())
+    results = IR.Type[results_..., ]
     operands = Value[]
-    owned_regions = Region[alternatives...,]
+    owned_regions = Region[alternatives..., ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(scope) && push!(operands, scope)
-
-    return IR.create_operation(
-        "transform.alternatives",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.alternatives", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2213,21 +1800,17 @@ end
 
 """
 function cast(input::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input,]
+    results = IR.Type[output, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.cast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.cast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2253,22 +1836,18 @@ This op generates as many handles as the terminating YieldOp has operands.
 For each result, the payload ops of the corresponding YieldOp operand are
 merged and mapped to the same resulting handle.
 """
-function foreach(target::Value; results::Vector{IR.Type}, body::Region, location=Location())
-    results = IR.Type[results...,]
-    operands = Value[target,]
-    owned_regions = Region[body,]
+function foreach(target::Value; results_::Vector{IR.Type}, body::Region, location=Location())
+    results = IR.Type[results_..., ]
+    operands = Value[target, ]
+    owned_regions = Region[body, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.foreach",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.foreach", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2291,21 +1870,17 @@ is applied, e.g., \"B\" may itself be a parent of \"A\". This may have an impact
 on the further transformation applied to the handle produced here.
 """
 function get_closest_isolated_parent(target::Value; parent::IR.Type, location=Location())
-    results = IR.Type[parent,]
-    operands = Value[target,]
+    results = IR.Type[parent, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.get_closest_isolated_parent",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.get_closest_isolated_parent", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2320,24 +1895,18 @@ definitely fails.
 The return handle points to the consuming operations operations, which can
 be empty.
 """
-function get_consumers_of_result(
-    target::Value; consumers::IR.Type, result_number, location=Location()
-)
-    results = IR.Type[consumers,]
-    operands = Value[target,]
+function get_consumers_of_result(target::Value; consumers::IR.Type, result_number, location=Location())
+    results = IR.Type[consumers, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("result_number", result_number),]
-
-    return IR.create_operation(
-        "transform.get_consumers_of_result",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("result_number", result_number), ]
+    
+    IR.create_operation(
+        "transform.get_consumers_of_result", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2351,24 +1920,18 @@ a block argument), the transform silently fails.
 The return handle points to only the subset of successfully produced
 computational operations, which can be empty.
 """
-function get_producer_of_operand(
-    target::Value; producer::IR.Type, operand_number, location=Location()
-)
-    results = IR.Type[producer,]
-    operands = Value[target,]
+function get_producer_of_operand(target::Value; producer::IR.Type, operand_number, location=Location())
+    results = IR.Type[producer, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("operand_number", operand_number),]
-
-    return IR.create_operation(
-        "transform.get_producer_of_operand",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("operand_number", operand_number), ]
+    
+    IR.create_operation(
+        "transform.get_producer_of_operand", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2384,29 +1947,20 @@ and so on. If `deduplicate` is set, do not add the given Payload IR
 operation more than once to the final list regardless of it coming from the
 same or different handles. Consumes the operands and produces a new handle.
 """
-function merge_handles(
-    handles::Vector{Value};
-    result=nothing::Union{Nothing,IR.Type},
-    deduplicate=nothing,
-    location=Location(),
-)
+function merge_handles(handles::Vector{Value}; result=nothing::Union{Nothing, IR.Type}, deduplicate=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[handles...,]
+    operands = Value[handles..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(deduplicate) && push!(attributes, namedattribute("deduplicate", deduplicate))
-
-    return IR.create_operation(
-        "transform.merge_handles",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.merge_handles", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -2429,21 +1983,17 @@ Payload IR ops actually matched the pattern and only fails if the pattern
 could not be looked up or compiled.
 """
 function pdl_match(root::Value; matched::IR.Type, pattern_name, location=Location())
-    results = IR.Type[matched,]
-    operands = Value[root,]
+    results = IR.Type[matched, ]
+    operands = Value[root, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("pattern_name", pattern_name),]
-
-    return IR.create_operation(
-        "transform.pdl_match",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("pattern_name", pattern_name), ]
+    
+    IR.create_operation(
+        "transform.pdl_match", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2456,7 +2006,7 @@ specified, the top-level op is dumped.
 
 This op is useful for printf-style debugging.
 """
-function print(target=nothing::Union{Nothing,Value}; name=nothing, location=Location())
+function print(target=nothing::Union{Nothing, Value}; name=nothing, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
@@ -2464,16 +2014,12 @@ function print(target=nothing::Union{Nothing,Value}; name=nothing, location=Loca
     attributes = NamedAttribute[]
     !isnothing(target) && push!(operands, target)
     !isnothing(name) && push!(attributes, namedattribute("name", name))
-
-    return IR.create_operation(
-        "transform.print",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.print", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2502,24 +2048,18 @@ MergeHandlesOp may be used to deduplicate the associated list of payload IR
 ops when necessary. Furthermore, a combination of ReplicateOp and
 MergeHandlesOp can be used to construct arbitrary lists with repetitions.
 """
-function replicate(
-    pattern::Value, handles::Vector{Value}; replicated::Vector{IR.Type}, location=Location()
-)
-    results = IR.Type[replicated...,]
-    operands = Value[pattern, handles...]
+function replicate(pattern::Value, handles::Vector{Value}; replicated::Vector{IR.Type}, location=Location())
+    results = IR.Type[replicated..., ]
+    operands = Value[pattern, handles..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.replicate",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.replicate", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2554,31 +2094,19 @@ The body of the sequence terminates with an implicit or explicit
 `transform.yield` op. The operands of the terminator are returned as the
 results of the sequence op.
 """
-function sequence(
-    root=nothing::Union{Nothing,Value};
-    results::Vector{IR.Type},
-    failure_propagation_mode,
-    body::Region,
-    location=Location(),
-)
-    results = IR.Type[results...,]
+function sequence(root=nothing::Union{Nothing, Value}; results_::Vector{IR.Type}, failure_propagation_mode, body::Region, location=Location())
+    results = IR.Type[results_..., ]
     operands = Value[]
-    owned_regions = Region[body,]
+    owned_regions = Region[body, ]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute(
-        "failure_propagation_mode", failure_propagation_mode
-    ),]
+    attributes = NamedAttribute[namedattribute("failure_propagation_mode", failure_propagation_mode), ]
     !isnothing(root) && push!(operands, root)
-
-    return IR.create_operation(
-        "transform.sequence",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.sequence", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2596,24 +2124,18 @@ This operation succeeds and returns `num_result_handles` if the statically
 specified `num_result_handles` corresponds to the dynamic number of
 operations contained in the source `handle`. Otherwise it silently fails.
 """
-function split_handles(
-    handle::Value; results::Vector{IR.Type}, num_result_handles, location=Location()
-)
-    results = IR.Type[results...,]
-    operands = Value[handle,]
+function split_handles(handle::Value; results_::Vector{IR.Type}, num_result_handles, location=Location())
+    results = IR.Type[results_..., ]
+    operands = Value[handle, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("num_result_handles", num_result_handles),]
-
-    return IR.create_operation(
-        "transform.split_handles",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("num_result_handles", num_result_handles), ]
+    
+    IR.create_operation(
+        "transform.split_handles", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2653,25 +2175,19 @@ available. This op is a possible top-level Transform IR op, the argument of
 its entry block corresponds to either the root op of the payload IR or the
 ops associated with its operand when provided.
 """
-function with_pdl_patterns(
-    root=nothing::Union{Nothing,Value}; body::Region, location=Location()
-)
+function with_pdl_patterns(root=nothing::Union{Nothing, Value}; body::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[body,]
+    owned_regions = Region[body, ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(root) && push!(operands, root)
-
-    return IR.create_operation(
-        "transform.with_pdl_patterns",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.with_pdl_patterns", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2682,28 +2198,24 @@ This terminator operation yields operation handles from regions of the
 transform IR ops back to the containing op. It is not itself associated with
 any transformation on the payload IR and is used for flow purposes only.
 """
-function yield(operands::Vector{Value}; location=Location())
+function yield(operands_::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[operands...,]
+    operands = Value[operands_..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.yield",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.yield", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `vector_lower_vectors`
@@ -2716,47 +2228,24 @@ At this time, the transform is all or nothing.
 This is usally a late step that is run after bufferization as part of the
 process of lowering to e.g. LLVM or NVVM.
 """
-function vector_lower_vectors(
-    target::Value;
-    results::IR.Type,
-    contraction_lowering=nothing,
-    multireduction_lowering=nothing,
-    split_transfers=nothing,
-    transpose_lowering=nothing,
-    transpose_avx2_lowering=nothing,
-    unroll_vector_transfers=nothing,
-    location=Location(),
-)
-    results = IR.Type[results,]
-    operands = Value[target,]
+function vector_lower_vectors(target::Value; results_::IR.Type, contraction_lowering=nothing, multireduction_lowering=nothing, split_transfers=nothing, transpose_lowering=nothing, transpose_avx2_lowering=nothing, unroll_vector_transfers=nothing, location=Location())
+    results = IR.Type[results_, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(contraction_lowering) &&
-        push!(attributes, namedattribute("contraction_lowering", contraction_lowering))
-    !isnothing(multireduction_lowering) && push!(
-        attributes, namedattribute("multireduction_lowering", multireduction_lowering)
-    )
-    !isnothing(split_transfers) &&
-        push!(attributes, namedattribute("split_transfers", split_transfers))
-    !isnothing(transpose_lowering) &&
-        push!(attributes, namedattribute("transpose_lowering", transpose_lowering))
-    !isnothing(transpose_avx2_lowering) && push!(
-        attributes, namedattribute("transpose_avx2_lowering", transpose_avx2_lowering)
-    )
-    !isnothing(unroll_vector_transfers) && push!(
-        attributes, namedattribute("unroll_vector_transfers", unroll_vector_transfers)
-    )
-
-    return IR.create_operation(
-        "transform.vector.lower_vectors",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(contraction_lowering) && push!(attributes, namedattribute("contraction_lowering", contraction_lowering))
+    !isnothing(multireduction_lowering) && push!(attributes, namedattribute("multireduction_lowering", multireduction_lowering))
+    !isnothing(split_transfers) && push!(attributes, namedattribute("split_transfers", split_transfers))
+    !isnothing(transpose_lowering) && push!(attributes, namedattribute("transpose_lowering", transpose_lowering))
+    !isnothing(transpose_avx2_lowering) && push!(attributes, namedattribute("transpose_avx2_lowering", transpose_avx2_lowering))
+    !isnothing(unroll_vector_transfers) && push!(attributes, namedattribute("unroll_vector_transfers", unroll_vector_transfers))
+    
+    IR.create_operation(
+        "transform.vector.lower_vectors", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/16/Vector.jl
+++ b/src/Dialects/16/Vector.jl
@@ -1,8 +1,8 @@
 module vector
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `vscale`
@@ -18,23 +18,19 @@ op can be used to calculate the step in vector-length agnostic (VLA) loops.
 Right now we only support one contiguous set of scalable dimensions, all of
 them grouped and scaled with the value returned by \'vscale\'.
 """
-function vscale(; res=nothing::Union{Nothing,IR.Type}, location=Location())
+function vscale(; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "vector.vscale",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.vscale", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -63,21 +59,17 @@ equal.
 ```
 """
 function bitcast(source::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[source,]
+    results = IR.Type[result, ]
+    operands = Value[source, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "vector.bitcast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.bitcast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -113,21 +105,17 @@ shaped vector with the same element type is always legal.
 ```
 """
 function broadcast(source::Value; vector::IR.Type, location=Location())
-    results = IR.Type[vector,]
-    operands = Value[source,]
+    results = IR.Type[vector, ]
+    operands = Value[source, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "vector.broadcast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.broadcast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -162,28 +150,18 @@ vector.compressstore %base[%i, %j], %mask, %value
   : memref<?x?xf32>, vector<16xi1>, vector<16xf32>
 ```
 """
-function compressstore(
-    base::Value,
-    indices::Vector{Value},
-    mask::Value,
-    valueToStore::Value;
-    location=Location(),
-)
+function compressstore(base::Value, indices::Vector{Value}, mask::Value, valueToStore::Value; location=Location())
     results = IR.Type[]
-    operands = Value[base, indices..., mask, valueToStore]
+    operands = Value[base, indices..., mask, valueToStore, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "vector.compressstore",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.compressstore", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -219,21 +197,17 @@ print %1
 ```
 """
 function constant_mask(; result_0::IR.Type, mask_dim_sizes, location=Location())
-    results = IR.Type[result_0,]
+    results = IR.Type[result_0, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("mask_dim_sizes", mask_dim_sizes),]
-
-    return IR.create_operation(
-        "vector.constant_mask",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("mask_dim_sizes", mask_dim_sizes), ]
+    
+    IR.create_operation(
+        "vector.constant_mask", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -355,36 +329,19 @@ int only. The default is \"add\".
   : vector<10xf32>, vector<10xf32> into f32
 ```
 """
-function contract(
-    lhs::Value,
-    rhs::Value,
-    acc::Value,
-    masks::Vector{Value};
-    result_0::IR.Type,
-    indexing_maps,
-    iterator_types,
-    kind=nothing,
-    location=Location(),
-)
-    results = IR.Type[result_0,]
-    operands = Value[lhs, rhs, acc, masks...]
+function contract(lhs::Value, rhs::Value, acc::Value, masks::Vector{Value}; result_0::IR.Type, indexing_maps, iterator_types, kind=nothing, location=Location())
+    results = IR.Type[result_0, ]
+    operands = Value[lhs, rhs, acc, masks..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("indexing_maps", indexing_maps),
-        namedattribute("iterator_types", iterator_types),
-    ]
+    attributes = NamedAttribute[namedattribute("indexing_maps", indexing_maps), namedattribute("iterator_types", iterator_types), ]
     !isnothing(kind) && push!(attributes, namedattribute("kind", kind))
-
-    return IR.create_operation(
-        "vector.contract",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.contract", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -418,22 +375,18 @@ print %1
         3 | 0    0    0
 ```
 """
-function create_mask(operands::Vector{Value}; result_0::IR.Type, location=Location())
-    results = IR.Type[result_0,]
-    operands = Value[operands...,]
+function create_mask(operands_::Vector{Value}; result_0::IR.Type, location=Location())
+    results = IR.Type[result_0, ]
+    operands = Value[operands_..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "vector.create_mask",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.create_mask", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -468,29 +421,18 @@ Examples:
    : memref<?x?xf32>, vector<16xi1>, vector<16xf32> into vector<16xf32>
 ```
 """
-function expandload(
-    base::Value,
-    indices::Vector{Value},
-    mask::Value,
-    pass_thru::Value;
-    result::IR.Type,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[base, indices..., mask, pass_thru]
+function expandload(base::Value, indices::Vector{Value}, mask::Value, pass_thru::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[base, indices..., mask, pass_thru, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "vector.expandload",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.expandload", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -516,29 +458,19 @@ https://llvm.org/docs/LangRef.html#extractelement-instruction
 %2 = vector.extractelement %z[]: vector<f32>
 ```
 """
-function extractelement(
-    vector::Value,
-    position=nothing::Union{Nothing,Value};
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[vector,]
+function extractelement(vector::Value, position=nothing::Union{Nothing, Value}; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[vector, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(position) && push!(operands, position)
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "vector.extractelement",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "vector.extractelement", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -555,25 +487,19 @@ the proper position. Degenerates to an element type in the 0-D case.
 %2 = vector.extract %0[3, 3, 3]: vector<4x8x16xf32>
 ```
 """
-function extract(
-    vector::Value; result_0=nothing::Union{Nothing,IR.Type}, position, location=Location()
-)
+function extract(vector::Value; result_0=nothing::Union{Nothing, IR.Type}, position, location=Location())
     results = IR.Type[]
-    operands = Value[vector,]
+    operands = Value[vector, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("position", position),]
+    attributes = NamedAttribute[namedattribute("position", position), ]
     !isnothing(result_0) && push!(results, result_0)
-
-    return IR.create_operation(
-        "vector.extract",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.extract", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -603,28 +529,18 @@ attribute. The returned subvector contains the elements starting at offset
   vector<4x8x16xf32> to vector<2x4x16xf32>
 ```
 """
-function extract_strided_slice(
-    vector::Value; result_0::IR.Type, offsets, sizes, strides, location=Location()
-)
-    results = IR.Type[result_0,]
-    operands = Value[vector,]
+function extract_strided_slice(vector::Value; result_0::IR.Type, offsets, sizes, strides, location=Location())
+    results = IR.Type[result_0, ]
+    operands = Value[vector, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("offsets", offsets),
-        namedattribute("sizes", sizes),
-        namedattribute("strides", strides),
-    ]
-
-    return IR.create_operation(
-        "vector.extract_strided_slice",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("offsets", offsets), namedattribute("sizes", sizes), namedattribute("strides", strides), ]
+    
+    IR.create_operation(
+        "vector.extract_strided_slice", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -645,29 +561,19 @@ to the `llvm.fma.*` intrinsic.
 %3 = vector.fma %0, %1, %2: vector<8x16xf32>
 ```
 """
-function fma(
-    lhs::Value,
-    rhs::Value,
-    acc::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function fma(lhs::Value, rhs::Value, acc::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs, acc]
+    operands = Value[lhs, rhs, acc, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "vector.fma",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.fma", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -697,23 +603,17 @@ http://llvm.org/docs/LangRef.html#llvm-matrix-transpose-intrinsic
 ```
 """
 function flat_transpose(matrix::Value; res::IR.Type, rows, columns, location=Location())
-    results = IR.Type[res,]
-    operands = Value[matrix,]
+    results = IR.Type[res, ]
+    operands = Value[matrix, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("rows", rows), namedattribute("columns", columns)
-    ]
-
-    return IR.create_operation(
-        "vector.flat_transpose",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("rows", rows), namedattribute("columns", columns), ]
+    
+    IR.create_operation(
+        "vector.flat_transpose", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -746,30 +646,18 @@ Examples:
    : memref<16x16xf32>, vector<16xi32>, vector<16xi1>, vector<16xf32> into vector<16xf32>
 ```
 """
-function gather(
-    base::Value,
-    indices::Vector{Value},
-    index_vec::Value,
-    mask::Value,
-    pass_thru::Value;
-    result::IR.Type,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[base, indices..., index_vec, mask, pass_thru]
+function gather(base::Value, indices::Vector{Value}, index_vec::Value, mask::Value, pass_thru::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[base, indices..., index_vec, mask, pass_thru, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "vector.gather",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.gather", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -794,30 +682,20 @@ https://llvm.org/docs/LangRef.html#insertelement-instruction
 %2 = vector.insertelement %f, %z[]: vector<f32>
 ```
 """
-function insertelement(
-    source::Value,
-    dest::Value,
-    position=nothing::Union{Nothing,Value};
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function insertelement(source::Value, dest::Value, position=nothing::Union{Nothing, Value}; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[source, dest]
+    operands = Value[source, dest, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(position) && push!(operands, position)
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "vector.insertelement",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.insertelement", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -835,29 +713,19 @@ position. Degenerates to a scalar source type when n = 0.
 %5 = vector.insert %3, %4[3, 3, 3] : f32 into vector<4x8x16xf32>
 ```
 """
-function insert(
-    source::Value,
-    dest::Value;
-    res=nothing::Union{Nothing,IR.Type},
-    position,
-    location=Location(),
-)
+function insert(source::Value, dest::Value; res=nothing::Union{Nothing, IR.Type}, position, location=Location())
     results = IR.Type[]
-    operands = Value[source, dest]
+    operands = Value[source, dest, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("position", position),]
+    attributes = NamedAttribute[namedattribute("position", position), ]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "vector.insert",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.insert", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -883,32 +751,19 @@ the proper location as specified by the offsets.
   vector<2x4xf32> into vector<16x4x8xf32>
 ```
 """
-function insert_strided_slice(
-    source::Value,
-    dest::Value;
-    res=nothing::Union{Nothing,IR.Type},
-    offsets,
-    strides,
-    location=Location(),
-)
+function insert_strided_slice(source::Value, dest::Value; res=nothing::Union{Nothing, IR.Type}, offsets, strides, location=Location())
     results = IR.Type[]
-    operands = Value[source, dest]
+    operands = Value[source, dest, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("offsets", offsets), namedattribute("strides", strides)
-    ]
+    attributes = NamedAttribute[namedattribute("offsets", offsets), namedattribute("strides", strides), ]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "vector.insert_strided_slice",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.insert_strided_slice", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -969,21 +824,17 @@ Example 6:  Explicit out-of-bound vector load.
 ```
 """
 function load(base::Value, indices::Vector{Value}; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[base, indices...]
+    results = IR.Type[result, ]
+    operands = Value[base, indices..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "vector.load",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.load", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1035,29 +886,19 @@ Examples:
   vector.mask %mask { vector.transfer_write %val, %t0[%idx] : vector<16xf32>, tensor<?xf32> } : vector<16xi1> -> tensor<?xf32>
 ```
 """
-function mask(
-    mask::Value,
-    passthru=nothing::Union{Nothing,Value};
-    results::Vector{IR.Type},
-    maskRegion::Region,
-    location=Location(),
-)
-    results = IR.Type[results...,]
-    operands = Value[mask,]
-    owned_regions = Region[maskRegion,]
+function mask(mask::Value, passthru=nothing::Union{Nothing, Value}; results_::Vector{IR.Type}, maskRegion::Region, location=Location())
+    results = IR.Type[results_..., ]
+    operands = Value[mask, ]
+    owned_regions = Region[maskRegion, ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(passthru) && push!(operands, passthru)
-
-    return IR.create_operation(
-        "vector.mask",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.mask", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1089,29 +930,18 @@ Examples:
    : memref<?x?xf32>, vector<16xi1>, vector<16xf32> into vector<16xf32>
 ```
 """
-function maskedload(
-    base::Value,
-    indices::Vector{Value},
-    mask::Value,
-    pass_thru::Value;
-    result::IR.Type,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[base, indices..., mask, pass_thru]
+function maskedload(base::Value, indices::Vector{Value}, mask::Value, pass_thru::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[base, indices..., mask, pass_thru, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "vector.maskedload",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.maskedload", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1143,28 +973,18 @@ vector.maskedstore %base[%i, %j], %mask, %value
   : memref<?x?xf32>, vector<16xi1>, vector<16xf32>
 ```
 """
-function maskedstore(
-    base::Value,
-    indices::Vector{Value},
-    mask::Value,
-    valueToStore::Value;
-    location=Location(),
-)
+function maskedstore(base::Value, indices::Vector{Value}, mask::Value, valueToStore::Value; location=Location())
     results = IR.Type[]
-    operands = Value[base, indices..., mask, valueToStore]
+    operands = Value[base, indices..., mask, valueToStore, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "vector.maskedstore",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.maskedstore", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1195,34 +1015,18 @@ http://llvm.org/docs/LangRef.html#llvm-matrix-multiply-intrinsic
   (vector<64xf64>, vector<48xf64>) -> vector<12xf64>
 ```
 """
-function matrix_multiply(
-    lhs::Value,
-    rhs::Value;
-    res::IR.Type,
-    lhs_rows,
-    lhs_columns,
-    rhs_columns,
-    location=Location(),
-)
-    results = IR.Type[res,]
-    operands = Value[lhs, rhs]
+function matrix_multiply(lhs::Value, rhs::Value; res::IR.Type, lhs_rows, lhs_columns, rhs_columns, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("lhs_rows", lhs_rows),
-        namedattribute("lhs_columns", lhs_columns),
-        namedattribute("rhs_columns", rhs_columns),
-    ]
-
-    return IR.create_operation(
-        "vector.matrix_multiply",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("lhs_rows", lhs_rows), namedattribute("lhs_columns", lhs_columns), namedattribute("rhs_columns", rhs_columns), ]
+    
+    IR.create_operation(
+        "vector.matrix_multiply", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1243,32 +1047,19 @@ Takes an initial accumulator operand.
   vector<4x16xf32> into f32
 ```
 """
-function multi_reduction(
-    source::Value,
-    acc::Value;
-    dest=nothing::Union{Nothing,IR.Type},
-    kind,
-    reduction_dims,
-    location=Location(),
-)
+function multi_reduction(source::Value, acc::Value; dest=nothing::Union{Nothing, IR.Type}, kind, reduction_dims, location=Location())
     results = IR.Type[]
-    operands = Value[source, acc]
+    operands = Value[source, acc, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("kind", kind), namedattribute("reduction_dims", reduction_dims)
-    ]
+    attributes = NamedAttribute[namedattribute("kind", kind), namedattribute("reduction_dims", reduction_dims), ]
     !isnothing(dest) && push!(results, dest)
-
-    return IR.create_operation(
-        "vector.multi_reduction",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.multi_reduction", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1322,30 +1113,19 @@ return %6: vector<10xf32>
 
 ```
 """
-function outerproduct(
-    lhs::Value,
-    rhs::Value,
-    acc::Vector{Value};
-    result_0::IR.Type,
-    kind=nothing,
-    location=Location(),
-)
-    results = IR.Type[result_0,]
-    operands = Value[lhs, rhs, acc...]
+function outerproduct(lhs::Value, rhs::Value, acc::Vector{Value}; result_0::IR.Type, kind=nothing, location=Location())
+    results = IR.Type[result_0, ]
+    operands = Value[lhs, rhs, acc..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(kind) && push!(attributes, namedattribute("kind", kind))
-
-    return IR.create_operation(
-        "vector.outerproduct",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.outerproduct", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1375,20 +1155,16 @@ newline).
 """
 function print(source::Value; location=Location())
     results = IR.Type[]
-    operands = Value[source,]
+    operands = Value[source, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "vector.print",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.print", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1414,29 +1190,19 @@ http://llvm.org/docs/LangRef.html#vector-reduction-intrinsics
 %4 = vector.reduction <mul>, %0, %1 : vector<16xf32> into f32
 ```
 """
-function reduction(
-    vector::Value,
-    acc=nothing::Union{Nothing,Value};
-    dest::IR.Type,
-    kind,
-    location=Location(),
-)
-    results = IR.Type[dest,]
-    operands = Value[vector,]
+function reduction(vector::Value, acc=nothing::Union{Nothing, Value}; dest::IR.Type, kind, location=Location())
+    results = IR.Type[dest, ]
+    operands = Value[vector, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("kind", kind),]
+    attributes = NamedAttribute[namedattribute("kind", kind), ]
     !isnothing(acc) && push!(operands, acc)
-
-    return IR.create_operation(
-        "vector.reduction",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.reduction", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1524,30 +1290,19 @@ Example
                     [n, o, p, q],
                     [r, -, -, -]]]
 """
-function reshape(
-    vector::Value,
-    input_shape::Vector{Value},
-    output_shape::Vector{Value};
-    result::IR.Type,
-    fixed_vector_sizes,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[vector, input_shape..., output_shape...]
+function reshape(vector::Value, input_shape::Vector{Value}, output_shape::Vector{Value}; result::IR.Type, fixed_vector_sizes, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[vector, input_shape..., output_shape..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("fixed_vector_sizes", fixed_vector_sizes),]
-    push!(attributes, operandsegmentsizes([1, length(input_shape), length(output_shape)]))
-
-    return IR.create_operation(
-        "vector.reshape",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("fixed_vector_sizes", fixed_vector_sizes), ]
+    push!(attributes, operandsegmentsizes([1, length(input_shape), length(output_shape), ]))
+    
+    IR.create_operation(
+        "vector.reshape", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1576,21 +1331,17 @@ Invalid example:
 ```
 """
 function scalable_extract(source::Value; res::IR.Type, pos, location=Location())
-    results = IR.Type[res,]
-    operands = Value[source,]
+    results = IR.Type[res, ]
+    operands = Value[source, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("pos", pos),]
-
-    return IR.create_operation(
-        "vector.scalable.extract",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("pos", pos), ]
+    
+    IR.create_operation(
+        "vector.scalable.extract", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1622,29 +1373,19 @@ Invalid example:
 %2 = vector.scalable.insert %0, %1[5] : vector<4xf32> into vector<[16]xf32>
 ```
 """
-function scalable_insert(
-    source::Value,
-    dest::Value;
-    res=nothing::Union{Nothing,IR.Type},
-    pos,
-    location=Location(),
-)
+function scalable_insert(source::Value, dest::Value; res=nothing::Union{Nothing, IR.Type}, pos, location=Location())
     results = IR.Type[]
-    operands = Value[source, dest]
+    operands = Value[source, dest, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("pos", pos),]
+    attributes = NamedAttribute[namedattribute("pos", pos), ]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "vector.scalable.insert",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.scalable.insert", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1665,37 +1406,20 @@ reduction in the scan.
   vector<4x8x16x32xf32>, vector<4x16x32xf32>
 ```
 """
-function scan(
-    source::Value,
-    initial_value::Value;
-    dest=nothing::Union{Nothing,IR.Type},
-    accumulated_value=nothing::Union{Nothing,IR.Type},
-    kind,
-    reduction_dim,
-    inclusive,
-    location=Location(),
-)
+function scan(source::Value, initial_value::Value; dest=nothing::Union{Nothing, IR.Type}, accumulated_value=nothing::Union{Nothing, IR.Type}, kind, reduction_dim, inclusive, location=Location())
     results = IR.Type[]
-    operands = Value[source, initial_value]
+    operands = Value[source, initial_value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("kind", kind),
-        namedattribute("reduction_dim", reduction_dim),
-        namedattribute("inclusive", inclusive),
-    ]
+    attributes = NamedAttribute[namedattribute("kind", kind), namedattribute("reduction_dim", reduction_dim), namedattribute("inclusive", inclusive), ]
     !isnothing(dest) && push!(results, dest)
     !isnothing(accumulated_value) && push!(results, accumulated_value)
-
-    return IR.create_operation(
-        "vector.scan",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.scan", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1732,29 +1456,18 @@ vector.scatter %base[%i, %j][%v], %mask, %value
     : memref<16x16xf32>, vector<16xi32>, vector<16xi1>, vector<16xf32>
 ```
 """
-function scatter(
-    base::Value,
-    indices::Vector{Value},
-    index_vec::Value,
-    mask::Value,
-    valueToStore::Value;
-    location=Location(),
-)
+function scatter(base::Value, indices::Vector{Value}, index_vec::Value, mask::Value, valueToStore::Value; location=Location())
     results = IR.Type[]
-    operands = Value[base, indices..., index_vec, mask, valueToStore]
+    operands = Value[base, indices..., index_vec, mask, valueToStore, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "vector.scatter",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.scatter", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1794,21 +1507,17 @@ is supported in that particular case, for now.
 ```
 """
 function shape_cast(source::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[source,]
+    results = IR.Type[result, ]
+    operands = Value[source, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "vector.shape_cast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.shape_cast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1847,25 +1556,19 @@ The legality rules are:
            : vector<f32>, vector<f32>           ; yields vector<2xf32>
 ```
 """
-function shuffle(
-    v1::Value, v2::Value; vector=nothing::Union{Nothing,IR.Type}, mask, location=Location()
-)
+function shuffle(v1::Value, v2::Value; vector=nothing::Union{Nothing, IR.Type}, mask, location=Location())
     results = IR.Type[]
-    operands = Value[v1, v2]
+    operands = Value[v1, v2, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("mask", mask),]
+    attributes = NamedAttribute[namedattribute("mask", mask), ]
     !isnothing(vector) && push!(results, vector)
-
-    return IR.create_operation(
-        "vector.shuffle",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.shuffle", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1883,21 +1586,17 @@ required to be of integer/index/float type.
 ```
 """
 function splat(input::Value; aggregate::IR.Type, location=Location())
-    results = IR.Type[aggregate,]
-    operands = Value[input,]
+    results = IR.Type[aggregate, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "vector.splat",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.splat", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1955,24 +1654,18 @@ Example 6:  Explicit out-of-bounds vector store.
 vector.store %valueToStore, %memref[%c0] : memref<7xf32>, vector<8xf32>
 ```
 """
-function store(
-    valueToStore::Value, base::Value, indices::Vector{Value}; location=Location()
-)
+function store(valueToStore::Value, base::Value, indices::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[valueToStore, base, indices...]
+    operands = Value[valueToStore, base, indices..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "vector.store",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.store", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2148,36 +1841,21 @@ for %i0 = 0 to %0 {
   tensor<f32>, vector<1xf32>
 ```
 """
-function transfer_read(
-    source::Value,
-    indices::Vector{Value},
-    padding::Value,
-    mask=nothing::Union{Nothing,Value};
-    vector::IR.Type,
-    permutation_map,
-    in_bounds=nothing,
-    location=Location(),
-)
-    results = IR.Type[vector,]
-    operands = Value[source, indices..., padding]
+function transfer_read(source::Value, indices::Vector{Value}, padding::Value, mask=nothing::Union{Nothing, Value}; vector::IR.Type, permutation_map, in_bounds=nothing, location=Location())
+    results = IR.Type[vector, ]
+    operands = Value[source, indices..., padding, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("permutation_map", permutation_map),]
+    attributes = NamedAttribute[namedattribute("permutation_map", permutation_map), ]
     !isnothing(mask) && push!(operands, mask)
-    push!(
-        attributes, operandsegmentsizes([1, length(indices), 1, (mask == nothing) ? 0 : 1])
-    )
+    push!(attributes, operandsegmentsizes([1, length(indices), 1, isnothing(mask) ? 0 : 1, ]))
     !isnothing(in_bounds) && push!(attributes, namedattribute("in_bounds", in_bounds))
-
-    return IR.create_operation(
-        "vector.transfer_read",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.transfer_read", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2280,37 +1958,22 @@ vector.transfer_write %4, %arg1[%c3, %c3]
   vector<1xf32>, tensor<f32>
 ```
 """
-function transfer_write(
-    vector::Value,
-    source::Value,
-    indices::Vector{Value},
-    mask=nothing::Union{Nothing,Value};
-    result=nothing::Union{Nothing,IR.Type},
-    permutation_map,
-    in_bounds=nothing,
-    location=Location(),
-)
+function transfer_write(vector::Value, source::Value, indices::Vector{Value}, mask=nothing::Union{Nothing, Value}; result=nothing::Union{Nothing, IR.Type}, permutation_map, in_bounds=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[vector, source, indices...]
+    operands = Value[vector, source, indices..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("permutation_map", permutation_map),]
+    attributes = NamedAttribute[namedattribute("permutation_map", permutation_map), ]
     !isnothing(mask) && push!(operands, mask)
-    push!(
-        attributes, operandsegmentsizes([1, 1, length(indices), (mask == nothing) ? 0 : 1])
-    )
+    push!(attributes, operandsegmentsizes([1, 1, length(indices), isnothing(mask) ? 0 : 1, ]))
     !isnothing(result) && push!(results, result)
     !isnothing(in_bounds) && push!(attributes, namedattribute("in_bounds", in_bounds))
-
-    return IR.create_operation(
-        "vector.transfer_write",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.transfer_write", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2341,21 +2004,17 @@ the transp array [i_1, .., i_n] must be a permutation of [0, .., n-1].
 ```
 """
 function transpose(vector::Value; result::IR.Type, transp, location=Location())
-    results = IR.Type[result,]
-    operands = Value[vector,]
+    results = IR.Type[result, ]
+    operands = Value[vector, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("transp", transp),]
-
-    return IR.create_operation(
-        "vector.transpose",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("transp", transp), ]
+    
+    IR.create_operation(
+        "vector.transpose", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2382,21 +2041,17 @@ operation ::= `vector.type_cast` ssa-use : memref-type to memref-type
 ```
 """
 function type_cast(memref::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[memref,]
+    results = IR.Type[result, ]
+    operands = Value[memref, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "vector.type_cast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.type_cast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2502,29 +2157,18 @@ some_synchronization_primitive
 // Execute in parallel on all threads/lanes.
 ```
 """
-function warp_execute_on_lane_0(
-    laneid::Value,
-    args::Vector{Value};
-    results::Vector{IR.Type},
-    warp_size,
-    warpRegion::Region,
-    location=Location(),
-)
-    results = IR.Type[results...,]
-    operands = Value[laneid, args...]
-    owned_regions = Region[warpRegion,]
+function warp_execute_on_lane_0(laneid::Value, args::Vector{Value}; results_::Vector{IR.Type}, warp_size, warpRegion::Region, location=Location())
+    results = IR.Type[results_..., ]
+    operands = Value[laneid, args..., ]
+    owned_regions = Region[warpRegion, ]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("warp_size", warp_size),]
-
-    return IR.create_operation(
-        "vector.warp_execute_on_lane_0",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("warp_size", warp_size), ]
+    
+    IR.create_operation(
+        "vector.warp_execute_on_lane_0", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2539,22 +2183,18 @@ parent operation\'s results.
 If the parent operation defines no value the vector.yield may be omitted
 when printing the region.
 """
-function yield(operands::Vector{Value}; location=Location())
+function yield(operands_::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[operands...,]
+    operands = Value[operands_..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "vector.yield",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.yield", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/16/X86Vector.jl
+++ b/src/Dialects/16/X86Vector.jl
@@ -1,32 +1,26 @@
 module x86vector
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `avx_intr_dp_ps_256`
 
 """
-function avx_intr_dp_ps_256(
-    a::Value, b::Value, c::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function avx_intr_dp_ps_256(a::Value, b::Value, c::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[a, b, c]
+    operands = Value[a, b, c, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "x86vector.avx.intr.dp.ps.256",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "x86vector.avx.intr.dp.ps.256", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -48,25 +42,19 @@ dot product of the two source vectors.
 %d = arith.addf %1, %2 : f32
 ```
 """
-function avx_intr_dot(
-    a::Value, b::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function avx_intr_dot(a::Value, b::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[a, b]
+    operands = Value[a, b, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "x86vector.avx.intr.dot",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "x86vector.avx.intr.dot", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -74,25 +62,19 @@ end
 `avx512_intr_mask_compress`
 
 """
-function avx512_intr_mask_compress(
-    a::Value, src::Value, k::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function avx512_intr_mask_compress(a::Value, src::Value, k::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[a, src, k]
+    operands = Value[a, src, k, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "x86vector.avx512.intr.mask.compress",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "x86vector.avx512.intr.mask.compress", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -111,33 +93,21 @@ Contiguously store the active integer/floating-point elements in `a` (those
 with their respective bit set in writemask `k`) to `dst`, and pass through the
 remaining elements from `src`.
 """
-function avx512_mask_compress(
-    k::Value,
-    a::Value,
-    src=nothing::Union{Nothing,Value};
-    dst=nothing::Union{Nothing,IR.Type},
-    constant_src=nothing,
-    location=Location(),
-)
+function avx512_mask_compress(k::Value, a::Value, src=nothing::Union{Nothing, Value}; dst=nothing::Union{Nothing, IR.Type}, constant_src=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[k, a]
+    operands = Value[k, a, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(src) && push!(operands, src)
     !isnothing(dst) && push!(results, dst)
-    !isnothing(constant_src) &&
-        push!(attributes, namedattribute("constant_src", constant_src))
-
-    return IR.create_operation(
-        "x86vector.avx512.mask.compress",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(constant_src) && push!(attributes, namedattribute("constant_src", constant_src))
+    
+    IR.create_operation(
+        "x86vector.avx512.mask.compress", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -155,31 +125,19 @@ Round packed floating-point elements in `a` to the number of fraction bits
 specified by `imm`, and store the results in `dst` using writemask `k`
 (elements are copied from src when the corresponding mask bit is not set).
 """
-function avx512_mask_rndscale(
-    src::Value,
-    k::Value,
-    a::Value,
-    imm::Value,
-    rounding::Value;
-    dst=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function avx512_mask_rndscale(src::Value, k::Value, a::Value, imm::Value, rounding::Value; dst=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[src, k, a, imm, rounding]
+    operands = Value[src, k, a, imm, rounding, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(dst) && push!(results, dst)
-
-    return IR.create_operation(
-        "x86vector.avx512.mask.rndscale",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "x86vector.avx512.mask.rndscale", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -187,31 +145,19 @@ end
 `avx512_intr_mask_rndscale_pd_512`
 
 """
-function avx512_intr_mask_rndscale_pd_512(
-    src::Value,
-    k::Value,
-    a::Value,
-    imm::Value,
-    rounding::Value;
-    res=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function avx512_intr_mask_rndscale_pd_512(src::Value, k::Value, a::Value, imm::Value, rounding::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[src, k, a, imm, rounding]
+    operands = Value[src, k, a, imm, rounding, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "x86vector.avx512.intr.mask.rndscale.pd.512",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "x86vector.avx512.intr.mask.rndscale.pd.512", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -219,31 +165,19 @@ end
 `avx512_intr_mask_rndscale_ps_512`
 
 """
-function avx512_intr_mask_rndscale_ps_512(
-    src::Value,
-    k::Value,
-    a::Value,
-    imm::Value,
-    rounding::Value;
-    res=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function avx512_intr_mask_rndscale_ps_512(src::Value, k::Value, a::Value, imm::Value, rounding::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[src, k, a, imm, rounding]
+    operands = Value[src, k, a, imm, rounding, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "x86vector.avx512.intr.mask.rndscale.ps.512",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "x86vector.avx512.intr.mask.rndscale.ps.512", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -261,31 +195,19 @@ Scale the packed floating-point elements in `a` using values from `b`, and
 store the results in `dst` using writemask `k` (elements are copied from src
 when the corresponding mask bit is not set).
 """
-function avx512_mask_scalef(
-    src::Value,
-    a::Value,
-    b::Value,
-    k::Value,
-    rounding::Value;
-    dst=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function avx512_mask_scalef(src::Value, a::Value, b::Value, k::Value, rounding::Value; dst=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[src, a, b, k, rounding]
+    operands = Value[src, a, b, k, rounding, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(dst) && push!(results, dst)
-
-    return IR.create_operation(
-        "x86vector.avx512.mask.scalef",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "x86vector.avx512.mask.scalef", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -293,31 +215,19 @@ end
 `avx512_intr_mask_scalef_pd_512`
 
 """
-function avx512_intr_mask_scalef_pd_512(
-    src::Value,
-    a::Value,
-    b::Value,
-    k::Value,
-    rounding::Value;
-    res=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function avx512_intr_mask_scalef_pd_512(src::Value, a::Value, b::Value, k::Value, rounding::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[src, a, b, k, rounding]
+    operands = Value[src, a, b, k, rounding, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "x86vector.avx512.intr.mask.scalef.pd.512",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "x86vector.avx512.intr.mask.scalef.pd.512", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -325,31 +235,19 @@ end
 `avx512_intr_mask_scalef_ps_512`
 
 """
-function avx512_intr_mask_scalef_ps_512(
-    src::Value,
-    a::Value,
-    b::Value,
-    k::Value,
-    rounding::Value;
-    res=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function avx512_intr_mask_scalef_ps_512(src::Value, a::Value, b::Value, k::Value, rounding::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[src, a, b, k, rounding]
+    operands = Value[src, a, b, k, rounding, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "x86vector.avx512.intr.mask.scalef.ps.512",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "x86vector.avx512.intr.mask.scalef.ps.512", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -357,25 +255,19 @@ end
 `avx_intr_rsqrt_ps_256`
 
 """
-function avx_intr_rsqrt_ps_256(
-    a::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function avx_intr_rsqrt_ps_256(a::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[a,]
+    operands = Value[a, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "x86vector.avx.intr.rsqrt.ps.256",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "x86vector.avx.intr.rsqrt.ps.256", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -383,23 +275,19 @@ end
 `avx_rsqrt`
 
 """
-function avx_rsqrt(a::Value; b=nothing::Union{Nothing,IR.Type}, location=Location())
+function avx_rsqrt(a::Value; b=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[a,]
+    operands = Value[a, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(b) && push!(results, b)
-
-    return IR.create_operation(
-        "x86vector.avx.rsqrt",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "x86vector.avx.rsqrt", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -407,24 +295,18 @@ end
 `avx512_intr_vp2intersect_d_512`
 
 """
-function avx512_intr_vp2intersect_d_512(
-    a::Value, b::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[a, b]
+function avx512_intr_vp2intersect_d_512(a::Value, b::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[a, b, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "x86vector.avx512.intr.vp2intersect.d.512",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "x86vector.avx512.intr.vp2intersect.d.512", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -444,30 +326,18 @@ specified by `k1` and `k2`. A match in corresponding elements of `a` and
 `b` is indicated by a set bit in the corresponding bit of the mask
 registers.
 """
-function avx512_vp2intersect(
-    a::Value,
-    b::Value;
-    k1=nothing::Union{Nothing,IR.Type},
-    k2=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[a, b]
+function avx512_vp2intersect(a::Value, b::Value; k1::IR.Type, k2::IR.Type, location=Location())
+    results = IR.Type[k1, k2, ]
+    operands = Value[a, b, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(k1) && push!(results, k1)
-    !isnothing(k2) && push!(results, k2)
-
-    return IR.create_operation(
-        "x86vector.avx512.vp2intersect",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "x86vector.avx512.vp2intersect", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -475,24 +345,18 @@ end
 `avx512_intr_vp2intersect_q_512`
 
 """
-function avx512_intr_vp2intersect_q_512(
-    a::Value, b::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[a, b]
+function avx512_intr_vp2intersect_q_512(a::Value, b::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[a, b, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "x86vector.avx512.intr.vp2intersect.q.512",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "x86vector.avx512.intr.vp2intersect.q.512", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 


### PR DESCRIPTION
for example `openacc.enter_data`:
```julia
function enter_data(ifCond=nothing::Union{Nothing, Value}; asyncOperand=nothing::Union{Nothing, Value}, waitDevnum=nothing::Union{Nothing, Value}, waitOperands::Vector{Value}, copyinOperands::Vector{Value}, createOperands::Vector{Value}, createZeroOperands::Vector{Value}, attachOperands::Vector{Value}, async=nothing, wait=nothing, location=Location())
    results = IR.Type[]
    operands = Value[waitOperands..., copyinOperands..., createOperands..., createZeroOperands..., attachOperands..., ]
    owned_regions = Region[]
    successors = Block[]
    attributes = NamedAttribute[]
    !isnothing(ifCond) && push!(operands, ifCond)
    !isnothing(asyncOperand) && push!(operands, asyncOperand)
    !isnothing(waitDevnum) && push!(operands, waitDevnum)
    push!(attributes, operandsegmentsizes([isnothing(ifCond) ? 0 : 1, isnothing(asyncOperand) ? 0 : 1, isnothing(waitDevnum) ? 0 : 1, length(waitOperands), length(copyinOperands), length(createOperands), length(createZeroOperands), length(attachOperands), ]))
    !isnothing(async) && push!(attributes, namedattribute("async", async))
    !isnothing(wait) && push!(attributes, namedattribute("wait", wait))
    
    IR.create_operation(
        "acc.enter_data", location;
        operands, owned_regions, successors, attributes,
        results=results,
        result_inference=false
    )
end
```
There's a trailing comma in the list now but that should be no problem.