### PR TITLE
Fix mark_donate, and print Type and Attribute as plain text

### DIFF
--- a/src/IR/Attribute.jl
+++ b/src/IR/Attribute.jl
@@ -899,11 +899,23 @@ function Base.getindex(attr::Attribute)
     end
 end
 
-function Base.show(io::IO, attribute::Attribute)
-    print(io, "Attribute(#= ")
+"""
+    print(io, attribute)
+
+Print `attribute` in MLIR's textual form, e.g. `#aie<bd_dim_layout_array[]>`.
+Unlike [`show`](@ref), this emits just the attribute, which is what you want when
+interpolating it into MLIR source text.
+"""
+function Base.print(io::IO, attribute::Attribute)
     c_print_callback = @cfunction(API.print_callback, Cvoid, (API.MlirStringRef, Any))
     ref = Ref(io)
     API.mlirAttributePrint(attribute, c_print_callback, ref)
+    return nothing
+end
+
+function Base.show(io::IO, attribute::Attribute)
+    print(io, "Attribute(#= ")
+    print(io, attribute)
     return print(io, " =#)")
 end
 

--- a/src/IR/Type.jl
+++ b/src/IR/Type.jl
@@ -755,10 +755,22 @@ function julia_type(type::Type)
     end
 end
 
-function Base.show(io::IO, type::Type)
-    print(io, "Type(#= ")
+"""
+    print(io, type)
+
+Print `type` in MLIR's textual form, e.g. `memref<1024xi32>`. Unlike [`show`](@ref),
+this emits just the type, which is what you want when interpolating it into MLIR
+source text.
+"""
+function Base.print(io::IO, type::Type)
     c_print_callback = @cfunction(API.print_callback, Cvoid, (API.MlirStringRef, Any))
     ref = Ref(io)
     API.mlirTypePrint(type, c_print_callback, ref)
+    return nothing
+end
+
+function Base.show(io::IO, type::Type)
+    print(io, "Type(#= ")
+    print(io, type)
     return print(io, " =#)")
 end

--- a/src/IR/debug.jl
+++ b/src/IR/debug.jl
@@ -103,7 +103,13 @@ function mark_dispose(f, obj)
 end
 
 # we could potentially track ownership here
-mark_donate(new_owner, obj) = mark_dispose(obj)
+#
+# Both forms return `obj`, so that they can wrap an argument in place, as in
+# `mlirBlockAppendOwnedOperation(block, mark_donate(op))`. The one-argument form
+# donates to an owner that the caller does not name (e.g. `move_after!`, where the
+# new owner is whichever block the other operation belongs to).
+mark_donate(obj) = (mark_dispose(obj); obj)
+mark_donate(new_owner, obj) = mark_donate(obj)
 
 # MLIR.API types
 for AT in [


### PR DESCRIPTION
push!(::Block, ::Operation) and push!(::Region, ::Block), along with
move_before!/move_after!, call a one-argument mark_donate(obj) that was never
defined: only the two-argument form existed, and it returned nothing rather than
the object those callers hand straight to the C API. Add the one-argument method
and return obj from both, so appending an operation to a block works.

Type and Attribute only had a show, which wraps the text as `Type(#= ... =#)`,
leaving no way to obtain the plain MLIR form -- the one to interpolate into
source text, e.g. building `!aie.objectfifo<memref<1024xi32>>` around a memref
type. Add print for both and define show in terms of it.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
